### PR TITLE
[Spec #37] T060 debouncing 수치 500ms로 갱신 (spec-code 드리프트 제거)

### DIFF
--- a/specs/001-library-management/tasks.md
+++ b/specs/001-library-management/tasks.md
@@ -127,7 +127,7 @@
 **Performance & Polish**
 
 - [X] T059 [US1] Implement lazy loading with ListView.builder in HomeScreen
-- [X] T060 [US1] Add search debouncing (300ms) to SearchBar widget *(implemented at 500ms default — see Resync notes)*
+- [X] T060 [US1] Add search debouncing (500ms) to SearchBar widget
 - [X] T061 [US1] Implement offline caching for book catalog in BookRepository
 - [X] T062 [US1] Add loading states and error handling to HomeScreen
 - [ ] T063 [US1] Add pagination for book list (20 books per page)


### PR DESCRIPTION
Closes #37

## 요약

PR #28 재정비에서 발견한 spec-code 드리프트 최종 정리. \`tasks.md\`의 T060 \`(300ms)\` → \`(500ms)\`로 갱신하고 #28에서 남긴 임시 각주 제거.

## 변경

\`specs/001-library-management/tasks.md\` 1줄 (-1 +1):

\`\`\`
- [X] T060 [US1] Add search debouncing (300ms) to SearchBar widget *(implemented at 500ms default — see Resync notes)*
+ [X] T060 [US1] Add search debouncing (500ms) to SearchBar widget
\`\`\`

## 사유: 코드가 아닌 spec을 바꾼다

- 500ms가 실 사용자 타이핑 리듬에 더 자연스럽고 과도한 API 호출 방지
- 코드 \`lib/widgets/book_search_bar.dart:19\`는 이미 500ms 기본값으로 머지됨
- 관련 위젯 테스트 T037도 500ms 기준으로 동작 중
- 300ms로 되돌리면 코드+테스트+UX 검증 재실시 필요 — 비용 대비 효익 낮음

## 헌법 준수

- [x] II. Branch Strategy
- [x] III. Issue-Driven Commits
- [x] IV. 한글 문서화
- [x] XIII. 명확한 PR 제목
- [ ] XVI. 로컬 검증 — markdown 한 줄 수정. 코드 영향 없음

## Test Plan

- [ ] CI green
- [ ] tasks.md T060 항목 한 줄 리뷰