### PR TITLE
[Refactor #41] BookBloc features/ 신설 + BookListScreen BlocBuilder 전환 (ADR 0002 단계 2-1)

### DIFF
--- a/lib/features/books/presentation/bloc/book_bloc.dart
+++ b/lib/features/books/presentation/bloc/book_bloc.dart
@@ -1,0 +1,182 @@
+import 'dart:async';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../../domain/repositories/book_repository.dart';
+import '../../data/models/book.dart';
+import 'book_event.dart';
+import 'book_state.dart';
+
+class BookBloc extends Bloc<BookEvent, BookState> {
+  static const int _defaultLimit = 20;
+  static const Duration _searchDebounce = Duration(milliseconds: 500);
+
+  final BookRepository repository;
+  Timer? _debounceTimer;
+
+  BookBloc({required this.repository}) : super(const BookInitial()) {
+    on<FetchBooks>(_onFetchBooks);
+    on<SearchBooks>(_onSearchBooks);
+    on<FilterByCategory>(_onFilterByCategory);
+    on<LoadMoreBooks>(_onLoadMoreBooks);
+    on<ClearSearch>(_onClearSearch);
+    on<RefreshBooks>(_onRefreshBooks);
+    on<FetchBookById>(_onFetchBookById);
+  }
+
+  Future<void> _onFetchBooks(
+    FetchBooks event,
+    Emitter<BookState> emit,
+  ) async {
+    emit(const BookLoading());
+    try {
+      final books = await repository.fetchBooks(
+        page: event.page,
+        limit: event.limit,
+      );
+      emit(BookLoaded(
+        books: books,
+        hasMore: books.length >= event.limit,
+        currentPage: event.page,
+      ));
+    } catch (e) {
+      emit(BookError(message: e.toString()));
+    }
+  }
+
+  Future<void> _onSearchBooks(
+    SearchBooks event,
+    Emitter<BookState> emit,
+  ) async {
+    _debounceTimer?.cancel();
+
+    if (event.query.isEmpty) {
+      add(const ClearSearch());
+      return;
+    }
+
+    _debounceTimer = Timer(_searchDebounce, () async {
+      emit(const BookLoading());
+      try {
+        final books = await repository.searchBooks(query: event.query);
+        emit(BookLoaded(
+          books: books,
+          hasMore: books.length >= _defaultLimit,
+          currentPage: 1,
+          searchQuery: event.query,
+        ));
+      } catch (e) {
+        emit(BookError(message: e.toString()));
+      }
+    });
+  }
+
+  Future<void> _onFilterByCategory(
+    FilterByCategory event,
+    Emitter<BookState> emit,
+  ) async {
+    emit(const BookLoading());
+    try {
+      final books = await repository.searchBooks(category: event.category);
+      emit(BookLoaded(
+        books: books,
+        hasMore: books.length >= _defaultLimit,
+        currentPage: 1,
+        activeFilter: event.category,
+      ));
+    } catch (e) {
+      emit(BookError(message: e.toString()));
+    }
+  }
+
+  Future<void> _onLoadMoreBooks(
+    LoadMoreBooks event,
+    Emitter<BookState> emit,
+  ) async {
+    final currentState = state;
+    if (currentState is! BookLoaded || !currentState.hasMore) return;
+
+    final nextPage = currentState.currentPage + 1;
+    try {
+      final List<Book> newBooks;
+      if (currentState.searchQuery != null) {
+        newBooks =
+            await repository.searchBooks(query: currentState.searchQuery);
+      } else if (currentState.activeFilter != null) {
+        newBooks =
+            await repository.searchBooks(category: currentState.activeFilter);
+      } else {
+        newBooks = await repository.fetchBooks(
+          page: nextPage,
+          limit: _defaultLimit,
+        );
+      }
+      emit(currentState.copyWith(
+        books: [...currentState.books, ...newBooks],
+        hasMore: newBooks.length >= _defaultLimit,
+        currentPage: nextPage,
+      ));
+    } catch (e) {
+      emit(BookError(message: e.toString()));
+    }
+  }
+
+  Future<void> _onClearSearch(
+    ClearSearch event,
+    Emitter<BookState> emit,
+  ) async {
+    emit(const BookLoading());
+    try {
+      final books = await repository.fetchBooks(
+        page: 1,
+        limit: _defaultLimit,
+      );
+      emit(BookLoaded(
+        books: books,
+        hasMore: books.length >= _defaultLimit,
+        currentPage: 1,
+      ));
+    } catch (e) {
+      emit(BookError(message: e.toString()));
+    }
+  }
+
+  Future<void> _onRefreshBooks(
+    RefreshBooks event,
+    Emitter<BookState> emit,
+  ) async {
+    final currentState = state;
+    if (currentState is BookLoaded) {
+      if (currentState.searchQuery != null) {
+        add(SearchBooks(query: currentState.searchQuery!));
+      } else if (currentState.activeFilter != null) {
+        add(FilterByCategory(category: currentState.activeFilter!));
+      } else {
+        add(const FetchBooks());
+      }
+    } else {
+      add(const FetchBooks());
+    }
+  }
+
+  Future<void> _onFetchBookById(
+    FetchBookById event,
+    Emitter<BookState> emit,
+  ) async {
+    emit(const BookDetailLoading());
+    try {
+      final book = await repository.getBookById(event.id);
+      if (book == null) {
+        emit(const BookDetailError(message: 'Book not found'));
+        return;
+      }
+      emit(BookDetailLoaded(book: book));
+    } catch (e) {
+      emit(BookDetailError(message: e.toString()));
+    }
+  }
+
+  @override
+  Future<void> close() {
+    _debounceTimer?.cancel();
+    return super.close();
+  }
+}

--- a/lib/features/books/presentation/bloc/book_event.dart
+++ b/lib/features/books/presentation/bloc/book_event.dart
@@ -1,0 +1,60 @@
+import 'package:equatable/equatable.dart';
+
+abstract class BookEvent extends Equatable {
+  const BookEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class FetchBooks extends BookEvent {
+  final int page;
+  final int limit;
+
+  const FetchBooks({
+    this.page = 1,
+    this.limit = 20,
+  });
+
+  @override
+  List<Object?> get props => [page, limit];
+}
+
+class SearchBooks extends BookEvent {
+  final String query;
+
+  const SearchBooks({required this.query});
+
+  @override
+  List<Object?> get props => [query];
+}
+
+class FilterByCategory extends BookEvent {
+  final String category;
+
+  const FilterByCategory({required this.category});
+
+  @override
+  List<Object?> get props => [category];
+}
+
+class LoadMoreBooks extends BookEvent {
+  const LoadMoreBooks();
+}
+
+class ClearSearch extends BookEvent {
+  const ClearSearch();
+}
+
+class RefreshBooks extends BookEvent {
+  const RefreshBooks();
+}
+
+class FetchBookById extends BookEvent {
+  final String id;
+
+  const FetchBookById({required this.id});
+
+  @override
+  List<Object?> get props => [id];
+}

--- a/lib/features/books/presentation/bloc/book_state.dart
+++ b/lib/features/books/presentation/bloc/book_state.dart
@@ -1,0 +1,89 @@
+import 'package:equatable/equatable.dart';
+import '../../data/models/book.dart';
+
+abstract class BookState extends Equatable {
+  const BookState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class BookInitial extends BookState {
+  const BookInitial();
+}
+
+class BookLoading extends BookState {
+  const BookLoading();
+}
+
+class BookLoaded extends BookState {
+  final List<Book> books;
+  final bool hasMore;
+  final int currentPage;
+  final String? activeFilter;
+  final String? searchQuery;
+
+  const BookLoaded({
+    required this.books,
+    this.hasMore = false,
+    this.currentPage = 1,
+    this.activeFilter,
+    this.searchQuery,
+  });
+
+  @override
+  List<Object?> get props => [
+        books,
+        hasMore,
+        currentPage,
+        activeFilter,
+        searchQuery,
+      ];
+
+  BookLoaded copyWith({
+    List<Book>? books,
+    bool? hasMore,
+    int? currentPage,
+    String? activeFilter,
+    String? searchQuery,
+  }) {
+    return BookLoaded(
+      books: books ?? this.books,
+      hasMore: hasMore ?? this.hasMore,
+      currentPage: currentPage ?? this.currentPage,
+      activeFilter: activeFilter ?? this.activeFilter,
+      searchQuery: searchQuery ?? this.searchQuery,
+    );
+  }
+}
+
+class BookError extends BookState {
+  final String message;
+
+  const BookError({required this.message});
+
+  @override
+  List<Object?> get props => [message];
+}
+
+class BookDetailLoading extends BookState {
+  const BookDetailLoading();
+}
+
+class BookDetailLoaded extends BookState {
+  final Book book;
+
+  const BookDetailLoaded({required this.book});
+
+  @override
+  List<Object?> get props => [book];
+}
+
+class BookDetailError extends BookState {
+  final String message;
+
+  const BookDetailError({required this.message});
+
+  @override
+  List<Object?> get props => [message];
+}

--- a/lib/features/books/presentation/screens/book_list_screen.dart
+++ b/lib/features/books/presentation/screens/book_list_screen.dart
@@ -1,68 +1,41 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import '../../data/models/book.dart';
 import '../../data/repositories/book_repository_impl.dart';
 import '../../domain/repositories/book_repository.dart';
+import '../bloc/book_bloc.dart';
+import '../bloc/book_event.dart';
+import '../bloc/book_state.dart';
 import '../widgets/book_card.dart';
 import '../widgets/book_search_bar.dart';
 import '../../../../models/book.dart' as app_book;
 
-/// Book list screen displaying available books
-class BookListScreen extends StatefulWidget {
+class BookListScreen extends StatelessWidget {
   const BookListScreen({super.key});
 
   @override
-  State<BookListScreen> createState() => _BookListScreenState();
+  Widget build(BuildContext context) {
+    return BlocProvider<BookBloc>(
+      create: (_) => BookBloc(repository: BookRepositoryImpl())
+        ..add(const FetchBooks()),
+      child: const _BookListView(),
+    );
+  }
 }
 
-class _BookListScreenState extends State<BookListScreen> {
-  final BookRepository _repository = BookRepositoryImpl();
-  List<Book> _books = [];
-  bool _isLoading = false;
-  bool _isGridView = true;
-  String? _searchQuery;
-  String? _errorMessage;
+class _BookListView extends StatefulWidget {
+  const _BookListView();
 
   @override
-  void initState() {
-    super.initState();
-    _loadBooks();
-  }
+  State<_BookListView> createState() => _BookListViewState();
+}
 
-  Future<void> _loadBooks() async {
-    setState(() {
-      _isLoading = true;
-      _errorMessage = null;
-    });
-
-    try {
-      final books = _searchQuery != null && _searchQuery!.isNotEmpty
-          ? await _repository.searchBooks(query: _searchQuery)
-          : await _repository.fetchBooks();
-
-      setState(() {
-        _books = books;
-        _isLoading = false;
-      });
-    } catch (e) {
-      setState(() {
-        _errorMessage = 'Failed to load books: $e';
-        _isLoading = false;
-      });
-    }
-  }
-
-  void _onSearchChanged(String query) {
-    setState(() {
-      _searchQuery = query;
-    });
-    _loadBooks();
-  }
+class _BookListViewState extends State<_BookListView> {
+  bool _isGridView = true;
 
   void _toggleView() {
-    setState(() {
-      _isGridView = !_isGridView;
-    });
+    setState(() => _isGridView = !_isGridView);
   }
 
   @override
@@ -81,133 +54,53 @@ class _BookListScreenState extends State<BookListScreen> {
       ),
       body: Column(
         children: [
-          // Search bar
           Padding(
             padding: const EdgeInsets.all(16.0),
             child: BookSearchBar(
-              onChanged: _onSearchChanged,
+              onChanged: (query) =>
+                  context.read<BookBloc>().add(SearchBooks(query: query)),
               hintText: 'Search by title, author, or ISBN...',
             ),
           ),
-
-          // Book list
           Expanded(
-            child: _buildContent(),
+            child: BlocBuilder<BookBloc, BookState>(
+              builder: (context, state) => _buildContent(context, state),
+            ),
           ),
         ],
       ),
     );
   }
 
-  Widget _buildContent() {
-    if (_isLoading) {
-      return const Center(
-        child: CircularProgressIndicator(),
+  Widget _buildContent(BuildContext context, BookState state) {
+    if (state is BookLoading || state is BookInitial) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (state is BookError) {
+      return _ErrorView(
+        message: state.message,
+        onRetry: () => context.read<BookBloc>().add(const FetchBooks()),
       );
     }
 
-    if (_errorMessage != null) {
-      return Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            const Icon(
-              Icons.error_outline,
-              size: 64,
-              color: Colors.red,
-            ),
-            const SizedBox(height: 16),
-            Text(
-              _errorMessage!,
-              textAlign: TextAlign.center,
-              style: const TextStyle(fontSize: 16),
-            ),
-            const SizedBox(height: 16),
-            ElevatedButton(
-              onPressed: _loadBooks,
-              child: const Text('Retry'),
-            ),
-          ],
-        ),
+    if (state is BookLoaded) {
+      if (state.books.isEmpty) {
+        return _EmptyView(searchQuery: state.searchQuery);
+      }
+      return RefreshIndicator(
+        onRefresh: () async =>
+            context.read<BookBloc>().add(const RefreshBooks()),
+        child: _isGridView
+            ? _BookGrid(books: state.books, onTap: _onBookTap)
+            : _BookList(books: state.books, onTap: _onBookTap),
       );
     }
 
-    if (_books.isEmpty) {
-      return Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(
-              Icons.search_off,
-              size: 64,
-              color: Colors.grey[400],
-            ),
-            const SizedBox(height: 16),
-            Text(
-              _searchQuery != null && _searchQuery!.isNotEmpty
-                  ? 'No books found for "$_searchQuery"'
-                  : 'No books available',
-              style: TextStyle(
-                fontSize: 16,
-                color: Colors.grey[600],
-              ),
-            ),
-          ],
-        ),
-      );
-    }
-
-    return RefreshIndicator(
-      onRefresh: _loadBooks,
-      child: _isGridView ? _buildGridView() : _buildListView(),
-    );
-  }
-
-  Widget _buildGridView() {
-    return GridView.builder(
-      padding: const EdgeInsets.all(16),
-      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-        crossAxisCount: _getCrossAxisCount(context),
-        childAspectRatio: 0.65,
-        crossAxisSpacing: 16,
-        mainAxisSpacing: 16,
-      ),
-      itemCount: _books.length,
-      itemBuilder: (context, index) {
-        return BookCard(
-          book: _books[index],
-          onTap: () => _onBookTap(_books[index]),
-        );
-      },
-    );
-  }
-
-  Widget _buildListView() {
-    return ListView.builder(
-      padding: const EdgeInsets.all(16),
-      itemCount: _books.length,
-      itemBuilder: (context, index) {
-        return Padding(
-          padding: const EdgeInsets.only(bottom: 16),
-          child: BookCard(
-            book: _books[index],
-            onTap: () => _onBookTap(_books[index]),
-          ),
-        );
-      },
-    );
-  }
-
-  int _getCrossAxisCount(BuildContext context) {
-    final width = MediaQuery.of(context).size.width;
-    if (width > 1200) return 4;
-    if (width > 800) return 3;
-    if (width > 600) return 2;
-    return 1;
+    return const SizedBox.shrink();
   }
 
   void _onBookTap(Book book) {
-    // Convert feature Book to app Book model for navigation
     final appBook = app_book.Book(
       id: book.id,
       title: book.title,
@@ -222,7 +115,116 @@ class _BookListScreenState extends State<BookListScreen> {
       createdAt: DateTime.now(),
       updatedAt: DateTime.now(),
     );
-    
     context.go('/books/${book.id}', extra: appBook);
+  }
+}
+
+class _ErrorView extends StatelessWidget {
+  final String message;
+  final VoidCallback onRetry;
+
+  const _ErrorView({required this.message, required this.onRetry});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const Icon(Icons.error_outline, size: 64, color: Colors.red),
+          const SizedBox(height: 16),
+          Text(
+            'Failed to load books: $message',
+            textAlign: TextAlign.center,
+            style: const TextStyle(fontSize: 16),
+          ),
+          const SizedBox(height: 16),
+          ElevatedButton(
+            onPressed: onRetry,
+            child: const Text('Retry'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EmptyView extends StatelessWidget {
+  final String? searchQuery;
+
+  const _EmptyView({this.searchQuery});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(Icons.search_off, size: 64, color: Colors.grey[400]),
+          const SizedBox(height: 16),
+          Text(
+            searchQuery != null && searchQuery!.isNotEmpty
+                ? 'No books found for "$searchQuery"'
+                : 'No books available',
+            style: TextStyle(fontSize: 16, color: Colors.grey[600]),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _BookGrid extends StatelessWidget {
+  final List<Book> books;
+  final void Function(Book) onTap;
+
+  const _BookGrid({required this.books, required this.onTap});
+
+  int _getCrossAxisCount(BuildContext context) {
+    final width = MediaQuery.of(context).size.width;
+    if (width > 1200) return 4;
+    if (width > 800) return 3;
+    if (width > 600) return 2;
+    return 1;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GridView.builder(
+      padding: const EdgeInsets.all(16),
+      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: _getCrossAxisCount(context),
+        childAspectRatio: 0.65,
+        crossAxisSpacing: 16,
+        mainAxisSpacing: 16,
+      ),
+      itemCount: books.length,
+      itemBuilder: (context, index) => BookCard(
+        book: books[index],
+        onTap: () => onTap(books[index]),
+      ),
+    );
+  }
+}
+
+class _BookList extends StatelessWidget {
+  final List<Book> books;
+  final void Function(Book) onTap;
+
+  const _BookList({required this.books, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      padding: const EdgeInsets.all(16),
+      itemCount: books.length,
+      itemBuilder: (context, index) => Padding(
+        padding: const EdgeInsets.only(bottom: 16),
+        child: BookCard(
+          book: books[index],
+          onTap: () => onTap(books[index]),
+        ),
+      ),
+    );
   }
 }

--- a/lib/features/books/presentation/screens/book_list_screen.dart
+++ b/lib/features/books/presentation/screens/book_list_screen.dart
@@ -3,7 +3,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import '../../data/models/book.dart';
 import '../../data/repositories/book_repository_impl.dart';
-import '../../domain/repositories/book_repository.dart';
 import '../bloc/book_bloc.dart';
 import '../bloc/book_event.dart';
 import '../bloc/book_state.dart';


### PR DESCRIPTION
Closes #41

## 요약

ADR 0002 (PR #40) 채택에 따라 도서 도메인을 feature-first BLoC로 전환. 본 PR은 **중간 상태** — 신 경로 신설 + 화면 전환. 레거시 삭제는 후속 PR.

## 변경

### 신규 파일
- `lib/features/books/presentation/bloc/book_event.dart` (63 lines)
- `lib/features/books/presentation/bloc/book_state.dart` (88 lines)
- `lib/features/books/presentation/bloc/book_bloc.dart` (180 lines)

### 수정
- `lib/features/books/presentation/screens/book_list_screen.dart` — BlocProvider 래핑, BlocBuilder 기반, 뷰 분리 (+154 / -152)

### 건드리지 않음 (다음 PR 범위)
- `lib/state/book/*` (레거시 BookBloc, orphan 상태)
- `lib/screens/mobile/home/home_screen.dart` (레거시 HomeScreen, orphan)
- `lib/repositories/book_*.dart` (레거시 repository)

## API 결정

신 BookBloc은 feature-first `BookRepository` 인터페이스에 맞춤:
- `searchBooks({query, category})` (단일 `query`)
- `fetchBooks({page, limit})`
- `getBookById(id)`

레거시 BookBloc의 다음 기능은 **의도적으로 드롭** (BookListScreen이 사용하지 않았고 feature repository가 지원하지 않음):
- `searchBooks(title, author, ...)` 다중 필드 검색 → 단일 `query`
- `syncWithApi()` 별도 동기화
- `getCategories()` 카테고리 조회

## 기능 보존 확인

- [x] 도서 목록 로드
- [x] 검색 debounce 500ms
- [x] 검색어 초기화 → 전체 재로드
- [x] Pull-to-refresh
- [x] Grid ↔ List 뷰 토글
- [x] 반응형 GridView 열 수 (1/2/3/4 breakpoints)
- [x] 로딩·에러·빈·목록 상태 UI
- [x] 도서 상세 네비게이션 (`go_router` extra)

## 중간 상태 주의사항

**레거시 BLoC (`lib/state/book/*`)과 레거시 HomeScreen이 아직 존재하며 어디서도 사용되지 않습니다.** 이 PR 머지 시점에 생긴 의도된 일시 상태로, 다음 PR에서 일괄 삭제 예정.

## 헌법 준수

- [x] II. Branch Strategy: `feature/41-...`
- [x] III. Issue-Driven Commits: `[#41]` 포함
- [x] IV. 한글 문서화
- [x] XIII. 명확한 PR 제목
- [ ] XVI. 로컬 검증 — Docker 환경에서의 Flutter 실행은 리뷰어 확인 요청. CI에서 analyze/format/test/web build 검증됨

## Test Plan

- [ ] CI green (analyze, format, test, web build)
- [ ] `make up` 후 http://localhost:8080에서 도서 목록 표시
- [ ] 검색 바 입력 → 500ms 후 결과 필터링 (debounce 확인)
- [ ] 검색어 클리어 → 전체 목록 복귀
- [ ] 창 크기 변경 → Grid 열 수 변화 (반응형)
- [ ] 상단 아이콘으로 Grid ↔ List 토글
- [ ] 도서 카드 탭 → 상세 페이지 네비게이션
- [ ] 상세에서 뒤로 가기 → 이전 상태 복원 (Bloc state 유지)