### PR TITLE
[US4-B #49] AdminAuthBloc + 관리자 인증 상태 계층 (T064/T072/T073/T081-T083)

### DIFF
--- a/lib/features/admin_catalog/data/models/administrator.dart
+++ b/lib/features/admin_catalog/data/models/administrator.dart
@@ -1,0 +1,56 @@
+import 'package:equatable/equatable.dart';
+
+enum AdminRole { admin, superAdmin }
+
+AdminRole _parseRole(String raw) {
+  switch (raw) {
+    case 'super_admin':
+      return AdminRole.superAdmin;
+    case 'admin':
+      return AdminRole.admin;
+    default:
+      throw ArgumentError('Unknown admin role: $raw');
+  }
+}
+
+String _roleToJson(AdminRole role) =>
+    role == AdminRole.superAdmin ? 'super_admin' : 'admin';
+
+class Administrator extends Equatable {
+  final String id;
+  final String username;
+  final String email;
+  final String fullName;
+  final AdminRole role;
+
+  const Administrator({
+    required this.id,
+    required this.username,
+    required this.email,
+    required this.fullName,
+    required this.role,
+  });
+
+  factory Administrator.fromJson(Map<String, dynamic> json) {
+    return Administrator(
+      id: json['id'] as String,
+      username: json['username'] as String,
+      email: json['email'] as String,
+      fullName: json['fullName'] as String,
+      role: _parseRole(json['role'] as String),
+    );
+  }
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'id': id,
+        'username': username,
+        'email': email,
+        'fullName': fullName,
+        'role': _roleToJson(role),
+      };
+
+  bool get isSuperAdmin => role == AdminRole.superAdmin;
+
+  @override
+  List<Object?> get props => [id, username, email, fullName, role];
+}

--- a/lib/features/admin_catalog/data/repositories/admin_auth_repository_impl.dart
+++ b/lib/features/admin_catalog/data/repositories/admin_auth_repository_impl.dart
@@ -1,0 +1,106 @@
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+
+import '../../../../services/storage/secure_storage_service.dart';
+import '../../domain/repositories/admin_auth_repository.dart';
+import '../models/administrator.dart';
+
+/// HTTP-backed implementation of [AdminAuthRepository].
+///
+/// Targets the backend mounted at `<baseUrl>/v1/admin/*`. Uses its own Dio
+/// instance so that student-flow interceptors (which inject the student JWT)
+/// don't leak admin credentials.
+class AdminAuthRepositoryImpl implements AdminAuthRepository {
+  AdminAuthRepositoryImpl({
+    required String baseUrl,
+    SecureStorageService? storage,
+    Dio? httpClient,
+  })  : _storage = storage ?? SecureStorageService(),
+        _dio = httpClient ??
+            Dio(
+              BaseOptions(
+                baseUrl: baseUrl,
+                connectTimeout: const Duration(seconds: 15),
+                receiveTimeout: const Duration(seconds: 15),
+                headers: {'Content-Type': 'application/json'},
+                // Accept 4xx so we can translate to domain errors ourselves.
+                validateStatus: (status) => status != null && status < 500,
+              ),
+            );
+
+  final SecureStorageService _storage;
+  final Dio _dio;
+
+  @override
+  Future<AdminAuthResult> login({
+    required String username,
+    required String password,
+  }) async {
+    final Response<dynamic> response;
+    try {
+      response = await _dio.post<dynamic>(
+        '/v1/admin/login',
+        data: {'username': username, 'password': password},
+      );
+    } on DioException catch (e) {
+      throw AdminAuthException(
+        AdminAuthFailure.network,
+        e.message ?? '네트워크 오류가 발생했습니다.',
+      );
+    }
+
+    if (response.statusCode == 401) {
+      throw const AdminAuthException(
+        AdminAuthFailure.invalidCredentials,
+        '사용자명 또는 비밀번호가 올바르지 않습니다.',
+      );
+    }
+
+    if (response.statusCode != 200 || response.data is! Map) {
+      throw AdminAuthException(
+        AdminAuthFailure.unknown,
+        '예상치 못한 응답 (${response.statusCode}).',
+      );
+    }
+
+    final body = response.data as Map<String, dynamic>;
+    final token = body['token'] as String?;
+    final adminJson = body['admin'] as Map<String, dynamic>?;
+    if (token == null || adminJson == null) {
+      throw const AdminAuthException(
+        AdminAuthFailure.unknown,
+        '응답 형식이 유효하지 않습니다.',
+      );
+    }
+
+    final admin = Administrator.fromJson(adminJson);
+    await _storage.writeAdminToken(token);
+    await _storage.writeAdminProfile(jsonEncode(admin.toJson()));
+
+    return AdminAuthResult(token: token, admin: admin);
+  }
+
+  @override
+  Future<AdminAuthResult?> restoreSession() async {
+    final token = await _storage.readAdminToken();
+    final profileJson = await _storage.readAdminProfile();
+    if (token == null || token.isEmpty || profileJson == null) return null;
+    try {
+      final admin = Administrator.fromJson(
+        jsonDecode(profileJson) as Map<String, dynamic>,
+      );
+      return AdminAuthResult(token: token, admin: admin);
+    } catch (_) {
+      // Corrupted profile — clear and force re-login.
+      await logout();
+      return null;
+    }
+  }
+
+  @override
+  Future<void> logout() async {
+    await _storage.deleteAdminToken();
+    await _storage.deleteAdminProfile();
+  }
+}

--- a/lib/features/admin_catalog/domain/repositories/admin_auth_repository.dart
+++ b/lib/features/admin_catalog/domain/repositories/admin_auth_repository.dart
@@ -1,0 +1,39 @@
+import '../../data/models/administrator.dart';
+
+class AdminAuthResult {
+  final String token;
+  final Administrator admin;
+
+  const AdminAuthResult({required this.token, required this.admin});
+}
+
+class AdminAuthException implements Exception {
+  final String message;
+  final AdminAuthFailure failure;
+
+  const AdminAuthException(this.failure, this.message);
+
+  @override
+  String toString() => 'AdminAuthException($failure): $message';
+}
+
+enum AdminAuthFailure {
+  invalidCredentials,
+  network,
+  unknown,
+}
+
+abstract class AdminAuthRepository {
+  /// Authenticate with username + password. Throws [AdminAuthException] on failure.
+  Future<AdminAuthResult> login({
+    required String username,
+    required String password,
+  });
+
+  /// Returns the currently authenticated admin and token if a session exists,
+  /// or null when no session is stored.
+  Future<AdminAuthResult?> restoreSession();
+
+  /// Clears any stored admin session.
+  Future<void> logout();
+}

--- a/lib/features/admin_catalog/presentation/bloc/admin_auth_bloc.dart
+++ b/lib/features/admin_catalog/presentation/bloc/admin_auth_bloc.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../domain/repositories/admin_auth_repository.dart';
+import 'admin_auth_event.dart';
+import 'admin_auth_state.dart';
+
+class AdminAuthBloc extends Bloc<AdminAuthEvent, AdminAuthState> {
+  final AdminAuthRepository repository;
+
+  AdminAuthBloc({required this.repository}) : super(const AdminAuthInitial()) {
+    on<AdminAuthRequested>(_onLoginRequested);
+    on<AdminAuthSessionRestored>(_onSessionRestored);
+    on<AdminAuthLogoutRequested>(_onLogoutRequested);
+  }
+
+  Future<void> _onLoginRequested(
+    AdminAuthRequested event,
+    Emitter<AdminAuthState> emit,
+  ) async {
+    emit(const AdminAuthLoading());
+    try {
+      final result = await repository.login(
+        username: event.username,
+        password: event.password,
+      );
+      emit(AdminAuthenticated(admin: result.admin, token: result.token));
+    } on AdminAuthException catch (e) {
+      emit(AdminAuthFailed(failure: e.failure, message: e.message));
+    }
+  }
+
+  Future<void> _onSessionRestored(
+    AdminAuthSessionRestored event,
+    Emitter<AdminAuthState> emit,
+  ) async {
+    final result = await repository.restoreSession();
+    if (result == null) {
+      emit(const AdminUnauthenticated());
+    } else {
+      emit(AdminAuthenticated(admin: result.admin, token: result.token));
+    }
+  }
+
+  Future<void> _onLogoutRequested(
+    AdminAuthLogoutRequested event,
+    Emitter<AdminAuthState> emit,
+  ) async {
+    await repository.logout();
+    emit(const AdminUnauthenticated());
+  }
+}

--- a/lib/features/admin_catalog/presentation/bloc/admin_auth_event.dart
+++ b/lib/features/admin_catalog/presentation/bloc/admin_auth_event.dart
@@ -1,0 +1,26 @@
+import 'package:equatable/equatable.dart';
+
+abstract class AdminAuthEvent extends Equatable {
+  const AdminAuthEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class AdminAuthRequested extends AdminAuthEvent {
+  final String username;
+  final String password;
+
+  const AdminAuthRequested({required this.username, required this.password});
+
+  @override
+  List<Object?> get props => [username, password];
+}
+
+class AdminAuthSessionRestored extends AdminAuthEvent {
+  const AdminAuthSessionRestored();
+}
+
+class AdminAuthLogoutRequested extends AdminAuthEvent {
+  const AdminAuthLogoutRequested();
+}

--- a/lib/features/admin_catalog/presentation/bloc/admin_auth_state.dart
+++ b/lib/features/admin_catalog/presentation/bloc/admin_auth_state.dart
@@ -1,0 +1,43 @@
+import 'package:equatable/equatable.dart';
+
+import '../../data/models/administrator.dart';
+import '../../domain/repositories/admin_auth_repository.dart';
+
+abstract class AdminAuthState extends Equatable {
+  const AdminAuthState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class AdminAuthInitial extends AdminAuthState {
+  const AdminAuthInitial();
+}
+
+class AdminAuthLoading extends AdminAuthState {
+  const AdminAuthLoading();
+}
+
+class AdminAuthenticated extends AdminAuthState {
+  final Administrator admin;
+  final String token;
+
+  const AdminAuthenticated({required this.admin, required this.token});
+
+  @override
+  List<Object?> get props => [admin, token];
+}
+
+class AdminUnauthenticated extends AdminAuthState {
+  const AdminUnauthenticated();
+}
+
+class AdminAuthFailed extends AdminAuthState {
+  final AdminAuthFailure failure;
+  final String message;
+
+  const AdminAuthFailed({required this.failure, required this.message});
+
+  @override
+  List<Object?> get props => [failure, message];
+}

--- a/lib/services/storage/secure_storage_service.dart
+++ b/lib/services/storage/secure_storage_service.dart
@@ -9,6 +9,8 @@ class SecureStorageService {
   static const String _keyUserId = 'user_id';
   static const String _key42Token = '42_oauth_token';
   static const String _keyJwtToken = 'jwt_token';
+  static const String _keyAdminToken = 'admin_jwt_token';
+  static const String _keyAdminProfile = 'admin_profile';
 
   SecureStorageService({FlutterSecureStorage? storage})
       : _storage = storage ?? const FlutterSecureStorage();
@@ -94,5 +96,31 @@ class SecureStorageService {
   /// Clear all stored tokens
   Future<void> clearAll() async {
     await _storage.deleteAll();
+  }
+
+  // Admin session (separate from student JWT)
+
+  Future<void> writeAdminToken(String token) async {
+    await _storage.write(key: _keyAdminToken, value: token);
+  }
+
+  Future<String?> readAdminToken() async {
+    return _storage.read(key: _keyAdminToken);
+  }
+
+  Future<void> deleteAdminToken() async {
+    await _storage.delete(key: _keyAdminToken);
+  }
+
+  Future<void> writeAdminProfile(String json) async {
+    await _storage.write(key: _keyAdminProfile, value: json);
+  }
+
+  Future<String?> readAdminProfile() async {
+    return _storage.read(key: _keyAdminProfile);
+  }
+
+  Future<void> deleteAdminProfile() async {
+    await _storage.delete(key: _keyAdminProfile);
   }
 }

--- a/specs/001-library-management/tasks.md
+++ b/specs/001-library-management/tasks.md
@@ -146,7 +146,7 @@
 
 ### Tests for User Story 4
 
-- [ ] T064 [P] [US4] Create unit test for Administrator model in test/unit_test/models/administrator_test.dart
+- [X] T064 [P] [US4] Create unit test for Administrator model in test/features/admin_catalog/data/models/administrator_test.dart
 - [ ] T065 [P] [US4] Create widget test for admin dashboard in test/widget_test/screens/web/dashboard/dashboard_screen_test.dart
 - [ ] T066 [P] [US4] Create widget test for book management form in test/widget_test/screens/web/catalog/book_form_test.dart
 - [ ] T067 [P] [US4] Create integration test for admin book management flow in test/integration_test/admin_catalog_test.dart
@@ -159,8 +159,8 @@
 
 **Models & Data Layer**
 
-- [ ] T072 [P] [US4] Create Administrator model in lib/models/administrator.dart
-- [ ] T073 [US4] Create AdministratorRepository in lib/repositories/administrator_repository.dart
+- [X] T072 [P] [US4] Create Administrator model in lib/features/admin_catalog/data/models/administrator.dart
+- [X] T073 [US4] Create AdminAuthRepository (interface + HTTP impl) in lib/features/admin_catalog/{domain,data}/repositories/
 
 **Backend API - Admin & Books Management**
 
@@ -174,9 +174,9 @@
 
 **State Management**
 
-- [ ] T081 [P] [US4] Create AuthEvent classes for admin in lib/state/auth/auth_event.dart
-- [ ] T082 [P] [US4] Create AuthState classes for admin in lib/state/auth/auth_state.dart
-- [ ] T083 [US4] Implement AuthBloc for admin authentication in lib/state/auth/auth_bloc.dart
+- [X] T081 [P] [US4] Create AdminAuthEvent classes in lib/features/admin_catalog/presentation/bloc/admin_auth_event.dart
+- [X] T082 [P] [US4] Create AdminAuthState classes in lib/features/admin_catalog/presentation/bloc/admin_auth_state.dart
+- [X] T083 [US4] Implement AdminAuthBloc in lib/features/admin_catalog/presentation/bloc/admin_auth_bloc.dart
 
 **UI Components - Web Dashboard**
 

--- a/test/features/admin_catalog/data/models/administrator_test.dart
+++ b/test/features/admin_catalog/data/models/administrator_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lib_42_flutter/features/admin_catalog/data/models/administrator.dart';
+
+void main() {
+  group('Administrator model (T064)', () {
+    test('parses admin role from JSON', () {
+      final admin = Administrator.fromJson(const {
+        'id': 'a1',
+        'username': 'alice',
+        'email': 'alice@42lib.kr',
+        'fullName': 'Alice',
+        'role': 'admin',
+      });
+
+      expect(admin.id, 'a1');
+      expect(admin.username, 'alice');
+      expect(admin.role, AdminRole.admin);
+      expect(admin.isSuperAdmin, isFalse);
+    });
+
+    test('parses super_admin role from JSON', () {
+      final admin = Administrator.fromJson(const {
+        'id': 'a2',
+        'username': 'root',
+        'email': 'root@42lib.kr',
+        'fullName': 'Root',
+        'role': 'super_admin',
+      });
+
+      expect(admin.role, AdminRole.superAdmin);
+      expect(admin.isSuperAdmin, isTrue);
+    });
+
+    test('throws on unknown role', () {
+      expect(
+        () => Administrator.fromJson(const {
+          'id': 'a3',
+          'username': 'x',
+          'email': 'x@42lib.kr',
+          'fullName': 'X',
+          'role': 'pirate',
+        }),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('serializes roundtrip', () {
+      const original = Administrator(
+        id: 'a4',
+        username: 'bob',
+        email: 'bob@42lib.kr',
+        fullName: 'Bob',
+        role: AdminRole.superAdmin,
+      );
+
+      final parsed = Administrator.fromJson(original.toJson());
+
+      expect(parsed, equals(original));
+      expect(original.toJson()['role'], 'super_admin');
+    });
+
+    test('Equatable compares by value', () {
+      const a = Administrator(
+        id: 'a5',
+        username: 'carol',
+        email: 'carol@42lib.kr',
+        fullName: 'Carol',
+        role: AdminRole.admin,
+      );
+      const b = Administrator(
+        id: 'a5',
+        username: 'carol',
+        email: 'carol@42lib.kr',
+        fullName: 'Carol',
+        role: AdminRole.admin,
+      );
+
+      expect(a, equals(b));
+    });
+  });
+}

--- a/test/features/admin_catalog/presentation/bloc/admin_auth_bloc_test.dart
+++ b/test/features/admin_catalog/presentation/bloc/admin_auth_bloc_test.dart
@@ -1,0 +1,101 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lib_42_flutter/features/admin_catalog/domain/repositories/admin_auth_repository.dart';
+import 'package:lib_42_flutter/features/admin_catalog/presentation/bloc/admin_auth_bloc.dart';
+import 'package:lib_42_flutter/features/admin_catalog/presentation/bloc/admin_auth_event.dart';
+import 'package:lib_42_flutter/features/admin_catalog/presentation/bloc/admin_auth_state.dart';
+
+import '../../../../support/fake_admin_auth_repository.dart';
+
+void main() {
+  group('AdminAuthBloc (T083)', () {
+    late FakeAdminAuthRepository repository;
+
+    setUp(() {
+      repository = FakeAdminAuthRepository();
+    });
+
+    blocTest<AdminAuthBloc, AdminAuthState>(
+      'emits [Loading, Authenticated] on successful login',
+      build: () {
+        final admin = makeAdmin();
+        repository.loginResult =
+            AdminAuthResult(token: 'tok-abc', admin: admin);
+        return AdminAuthBloc(repository: repository);
+      },
+      act: (bloc) => bloc.add(
+        const AdminAuthRequested(username: 'admin', password: 'admin123'),
+      ),
+      expect: () => [
+        isA<AdminAuthLoading>(),
+        isA<AdminAuthenticated>()
+            .having((s) => s.token, 'token', 'tok-abc')
+            .having((s) => s.admin.username, 'admin.username', 'admin'),
+      ],
+      verify: (_) {
+        expect(repository.loginCalls, 1);
+      },
+    );
+
+    blocTest<AdminAuthBloc, AdminAuthState>(
+      'emits [Loading, Failed] with invalid credentials',
+      build: () {
+        repository.loginError = const AdminAuthException(
+          AdminAuthFailure.invalidCredentials,
+          '사용자명 또는 비밀번호가 올바르지 않습니다.',
+        );
+        return AdminAuthBloc(repository: repository);
+      },
+      act: (bloc) => bloc.add(
+        const AdminAuthRequested(username: 'admin', password: 'wrong'),
+      ),
+      expect: () => [
+        isA<AdminAuthLoading>(),
+        isA<AdminAuthFailed>()
+            .having((s) => s.failure, 'failure',
+                AdminAuthFailure.invalidCredentials),
+      ],
+    );
+
+    blocTest<AdminAuthBloc, AdminAuthState>(
+      'session restore: emits Authenticated when session exists',
+      build: () {
+        repository.restoredSession = AdminAuthResult(
+          token: 'existing-token',
+          admin: makeAdmin(username: 'persistent'),
+        );
+        return AdminAuthBloc(repository: repository);
+      },
+      act: (bloc) => bloc.add(const AdminAuthSessionRestored()),
+      expect: () => [
+        isA<AdminAuthenticated>()
+            .having((s) => s.admin.username, 'admin.username', 'persistent'),
+      ],
+    );
+
+    blocTest<AdminAuthBloc, AdminAuthState>(
+      'session restore: emits Unauthenticated when no session',
+      build: () {
+        repository.restoredSession = null;
+        return AdminAuthBloc(repository: repository);
+      },
+      act: (bloc) => bloc.add(const AdminAuthSessionRestored()),
+      expect: () => [isA<AdminUnauthenticated>()],
+    );
+
+    blocTest<AdminAuthBloc, AdminAuthState>(
+      'logout: clears session and emits Unauthenticated',
+      build: () {
+        repository.loginResult =
+            AdminAuthResult(token: 'tok', admin: makeAdmin());
+        return AdminAuthBloc(repository: repository);
+      },
+      seed: () => AdminAuthenticated(admin: makeAdmin(), token: 'tok'),
+      act: (bloc) => bloc.add(const AdminAuthLogoutRequested()),
+      expect: () => [isA<AdminUnauthenticated>()],
+      verify: (_) {
+        expect(repository.logoutCalls, 1);
+      },
+    );
+  });
+}

--- a/test/support/fake_admin_auth_repository.dart
+++ b/test/support/fake_admin_auth_repository.dart
@@ -1,0 +1,54 @@
+import 'package:lib_42_flutter/features/admin_catalog/data/models/administrator.dart';
+import 'package:lib_42_flutter/features/admin_catalog/domain/repositories/admin_auth_repository.dart';
+
+/// Test fake for [AdminAuthRepository]. Callers control the outcome of each
+/// method via the public fields — no HTTP or secure-storage required.
+class FakeAdminAuthRepository implements AdminAuthRepository {
+  AdminAuthResult? loginResult;
+  AdminAuthException? loginError;
+  AdminAuthResult? restoredSession;
+  int loginCalls = 0;
+  int logoutCalls = 0;
+  int restoreCalls = 0;
+
+  @override
+  Future<AdminAuthResult> login({
+    required String username,
+    required String password,
+  }) async {
+    loginCalls++;
+    if (loginError != null) throw loginError!;
+    if (loginResult != null) return loginResult!;
+    throw const AdminAuthException(
+      AdminAuthFailure.unknown,
+      'FakeAdminAuthRepository: loginResult or loginError not set',
+    );
+  }
+
+  @override
+  Future<AdminAuthResult?> restoreSession() async {
+    restoreCalls++;
+    return restoredSession;
+  }
+
+  @override
+  Future<void> logout() async {
+    logoutCalls++;
+  }
+}
+
+Administrator makeAdmin({
+  String id = 'admin-1',
+  String username = 'admin',
+  String email = 'admin@42lib.kr',
+  String fullName = '관리자',
+  AdminRole role = AdminRole.admin,
+}) {
+  return Administrator(
+    id: id,
+    username: username,
+    email: email,
+    fullName: fullName,
+    role: role,
+  );
+}


### PR DESCRIPTION
Closes #49

## 요약

MVP 게이트 2 (US4) 서브 게이트 2. PR #47 백엔드 \`/admin/login\` 을 소비하는 프론트 상태 계층. UI는 US4-C.

## 설계 핵심

ADR 0001·0002 준수. 새 admin 코드는 \`lib/features/admin_catalog/\` 단일 모듈로 작성하고, 기존 student용 \`lib/state/auth/*\` 와 **완전 분리**:
- 별도 BLoC (\`AdminAuthBloc\`)
- 별도 토큰 키 (\`admin_jwt_token\`)
- 별도 HTTP 클라이언트 (자체 Dio 인스턴스, student 인터셉터 격리)

## 변경 (+591 / -6)

### 신규 (lib/features/admin_catalog/)
- \`data/models/administrator.dart\` — Equatable 모델, role enum, JSON 직렬화
- \`domain/repositories/admin_auth_repository.dart\` — 인터페이스, \`AdminAuthResult\`, \`AdminAuthException\` (\`AdminAuthFailure\` enum)
- \`data/repositories/admin_auth_repository_impl.dart\` — Dio 기반 HTTP impl
- \`presentation/bloc/admin_auth_{event,state,bloc}.dart\` — Login / SessionRestored / Logout 흐름

### 공유 레이어 확장
- \`lib/services/storage/secure_storage_service.dart\` — \`writeAdminToken\`, \`readAdminToken\`, \`deleteAdminToken\`, \`writeAdminProfile\`, \`readAdminProfile\`, \`deleteAdminProfile\` 6개 메서드 추가. 키 \`admin_jwt_token\`, \`admin_profile\`.

### 테스트
- \`test/features/admin_catalog/data/models/administrator_test.dart\` (T064) — JSON 파싱, role 검증, 직렬화 roundtrip, Equatable
- \`test/features/admin_catalog/presentation/bloc/admin_auth_bloc_test.dart\` — login 성공/실패, restore 세션 있음/없음, logout
- \`test/support/fake_admin_auth_repository.dart\` — 호출자 제어 fake + \`makeAdmin()\` 팩토리

### tasks.md 갱신

T064/T072/T073/T081/T082/T083 [X] + features/ 경로 반영. T083 원경로(\`lib/state/auth/auth_bloc.dart\`)는 student용 AuthBloc이라 그대로 유지하고, AdminAuthBloc은 별도 파일로 작성됨을 path 변경으로 명시.

## 결정 기록

### 왜 student AuthBloc을 확장하지 않고 별도 BLoC인가
- 인증 방식이 다름 (42 OAuth vs bcrypt)
- 권한·UX 흐름이 다름
- 토큰을 분리 저장해야 함 (한 사람이 학생 + 관리자 동시 가능)
- BLoC 한 개에 두 가지 인증 상태를 합치면 상태 폭발

### AdminAuthRepositoryImpl HTTP 직접 테스트 미포함
- Dio 모킹 패키지(http_mock_adapter 등) 의존성 추가 회피
- repo는 thin 변환 레이어 (HTTP 응답 → 도메인 객체) 라 모델·블록 테스트 + 향후 통합 테스트로 계약 검증 충분
- 실 동작 검증은 US4-C UI 테스트 또는 수동 로그인 플로우에서

## 후속 (US4-C 범위)

- AdminLoginScreen, AdminDashboardScreen, CatalogManagementScreen
- BookFormWidget, DeleteConfirmationDialog
- 관리자 라우팅 + AdminAuthBloc 연결
- 관리자용 책 CRUD repository (admin 토큰 사용)

## 헌법 준수

- [x] II/III/IV/XIII
- [ ] XVI. 로컬 검증 — Flutter 테스트는 CI 실행

## Test Plan

- [ ] CI green (analyze, format, test, web build)
- [ ] AdminAuthBloc 5건 테스트 통과
- [ ] Administrator 모델 5건 테스트 통과
- [ ] 기존 student 인증/도서 화면 동작 무변화