### PR TITLE
[US4-C-α #51] 관리자 로그인 + 라우팅 가드 + 대시보드 스캐폴드 (T084/T087/T088/T090)

### DIFF
--- a/lib/core/routes/app_router.dart
+++ b/lib/core/routes/app_router.dart
@@ -1,47 +1,82 @@
 import 'package:go_router/go_router.dart';
+
+import '../../features/admin_catalog/presentation/bloc/admin_auth_bloc.dart';
+import '../../features/admin_catalog/presentation/bloc/admin_auth_state.dart';
+import '../../features/admin_catalog/presentation/screens/admin_dashboard_screen.dart';
+import '../../features/admin_catalog/presentation/screens/admin_login_screen.dart';
 import '../../features/books/presentation/screens/book_list_screen.dart';
-import '../../screens/mobile/book_detail/book_detail_screen.dart';
-import '../../screens/mobile/auth/login_screen.dart';
-import '../../screens/mobile/loan/my_loans_screen.dart';
 import '../../models/book.dart';
+import '../../screens/mobile/auth/login_screen.dart';
+import '../../screens/mobile/book_detail/book_detail_screen.dart';
+import '../../screens/mobile/loan/my_loans_screen.dart';
+import 'go_router_refresh_stream.dart';
 
-/// Application router configuration using go_router
 class AppRouter {
-  static final GoRouter router = GoRouter(
-    initialLocation: '/',
-    debugLogDiagnostics: true,
-    routes: [
-      GoRoute(
-        path: '/',
-        builder: (context, state) => const BookListScreen(),
-      ),
-      
-      // Book detail screen
-      GoRoute(
-        path: '/books/:id',
-        builder: (context, state) {
-          final book = state.extra as Book?;
+  /// Build a [GoRouter] wired up with admin authentication guards.
+  ///
+  /// The router's `redirect` callback inspects [adminAuthBloc] state to
+  /// gate `/admin/*` routes. The router refreshes whenever the bloc emits.
+  static GoRouter create(AdminAuthBloc adminAuthBloc) {
+    return GoRouter(
+      initialLocation: '/',
+      debugLogDiagnostics: true,
+      refreshListenable: GoRouterRefreshStream(adminAuthBloc.stream),
+      redirect: (context, state) {
+        final loc = state.matchedLocation;
+        final isAdminRoute = loc.startsWith('/admin');
+        if (!isAdminRoute) return null;
 
-          if (book != null) {
-            return BookDetailScreen(book: book);
-          }
+        final authState = adminAuthBloc.state;
+        final isAuthenticated = authState is AdminAuthenticated;
+        final isOnLogin = loc == '/admin/login';
 
-          // If no book provided, fall back to list
-          return const BookListScreen();
-        },
-      ),
-      
-      // Login screen
-      GoRoute(
-        path: '/login',
-        builder: (context, state) => const LoginScreen(),
-      ),
-      
-      // My loans screen
-      GoRoute(
-        path: '/my-loans',
-        builder: (context, state) => const MyLoansScreen(),
-      ),
-    ],
-  );
+        if (!isAuthenticated && !isOnLogin) return '/admin/login';
+        if (isAuthenticated && isOnLogin) return '/admin';
+        return null;
+      },
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (context, state) => const BookListScreen(),
+        ),
+
+        // Book detail screen
+        GoRoute(
+          path: '/books/:id',
+          builder: (context, state) {
+            final book = state.extra as Book?;
+            if (book != null) {
+              return BookDetailScreen(book: book);
+            }
+            return const BookListScreen();
+          },
+        ),
+
+        // Student login
+        GoRoute(
+          path: '/login',
+          builder: (context, state) => const LoginScreen(),
+        ),
+
+        GoRoute(
+          path: '/my-loans',
+          builder: (context, state) => const MyLoansScreen(),
+        ),
+
+        // Admin
+        GoRoute(
+          path: '/admin/login',
+          builder: (context, state) => const AdminLoginScreen(),
+        ),
+        GoRoute(
+          path: '/admin',
+          builder: (context, state) => const AdminDashboardScreen(),
+        ),
+        GoRoute(
+          path: '/admin/catalog',
+          builder: (context, state) => const AdminCatalogPlaceholderScreen(),
+        ),
+      ],
+    );
+  }
 }

--- a/lib/core/routes/go_router_refresh_stream.dart
+++ b/lib/core/routes/go_router_refresh_stream.dart
@@ -1,0 +1,21 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+/// Adapter that turns a [Stream] into a [ChangeNotifier] so it can be passed
+/// to `GoRouter`'s `refreshListenable`. Notifies listeners on every emission,
+/// triggering re-evaluation of the router's `redirect` callback.
+class GoRouterRefreshStream extends ChangeNotifier {
+  GoRouterRefreshStream(Stream<dynamic> stream) {
+    notifyListeners();
+    _subscription = stream.asBroadcastStream().listen((_) => notifyListeners());
+  }
+
+  late final StreamSubscription<dynamic> _subscription;
+
+  @override
+  void dispose() {
+    _subscription.cancel();
+    super.dispose();
+  }
+}

--- a/lib/features/admin_catalog/presentation/screens/admin_dashboard_screen.dart
+++ b/lib/features/admin_catalog/presentation/screens/admin_dashboard_screen.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+
+import '../bloc/admin_auth_bloc.dart';
+import '../bloc/admin_auth_state.dart';
+import '../widgets/admin_sidebar.dart';
+
+class AdminDashboardScreen extends StatelessWidget {
+  const AdminDashboardScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('관리자 대시보드')),
+      drawer: const AdminSidebar(currentRoute: '/admin'),
+      body: BlocBuilder<AdminAuthBloc, AdminAuthState>(
+        builder: (context, state) {
+          if (state is! AdminAuthenticated) {
+            return const SizedBox.shrink();
+          }
+          return Center(
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 720),
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Text(
+                      '환영합니다, ${state.admin.fullName}님',
+                      style: Theme.of(context).textTheme.headlineSmall,
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      '역할: ${state.admin.isSuperAdmin ? "최고 관리자" : "관리자"}',
+                      style: Theme.of(context).textTheme.bodyMedium,
+                    ),
+                    const SizedBox(height: 24),
+                    Card(
+                      child: ListTile(
+                        leading: const Icon(Icons.book),
+                        title: const Text('도서 관리'),
+                        subtitle: const Text('도서 추가, 편집, 삭제'),
+                        trailing: const Icon(Icons.chevron_right),
+                        onTap: () => context.go('/admin/catalog'),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+/// Placeholder for catalog screen — replaced in US4-C-β.
+class AdminCatalogPlaceholderScreen extends StatelessWidget {
+  const AdminCatalogPlaceholderScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('도서 관리')),
+      drawer: const AdminSidebar(currentRoute: '/admin/catalog'),
+      body: const Center(
+        child: Padding(
+          padding: EdgeInsets.all(24),
+          child: Text(
+            '도서 관리 화면은 곧 제공됩니다 (US4-C-β).',
+            textAlign: TextAlign.center,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/admin_catalog/presentation/screens/admin_login_screen.dart
+++ b/lib/features/admin_catalog/presentation/screens/admin_login_screen.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../bloc/admin_auth_bloc.dart';
+import '../bloc/admin_auth_event.dart';
+import '../bloc/admin_auth_state.dart';
+
+class AdminLoginScreen extends StatefulWidget {
+  const AdminLoginScreen({super.key});
+
+  @override
+  State<AdminLoginScreen> createState() => _AdminLoginScreenState();
+}
+
+class _AdminLoginScreenState extends State<AdminLoginScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _usernameController = TextEditingController();
+  final _passwordController = TextEditingController();
+  bool _obscurePassword = true;
+
+  @override
+  void dispose() {
+    _usernameController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    if (!_formKey.currentState!.validate()) return;
+    context.read<AdminAuthBloc>().add(
+          AdminAuthRequested(
+            username: _usernameController.text.trim(),
+            password: _passwordController.text,
+          ),
+        );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 420),
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Card(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: BlocConsumer<AdminAuthBloc, AdminAuthState>(
+                  listener: (context, state) {
+                    if (state is AdminAuthFailed) {
+                      ScaffoldMessenger.of(context)
+                        ..hideCurrentSnackBar()
+                        ..showSnackBar(SnackBar(content: Text(state.message)));
+                    }
+                  },
+                  builder: (context, state) {
+                    final isLoading = state is AdminAuthLoading;
+                    return Form(
+                      key: _formKey,
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          Text(
+                            '관리자 로그인',
+                            textAlign: TextAlign.center,
+                            style: Theme.of(context).textTheme.headlineSmall,
+                          ),
+                          const SizedBox(height: 24),
+                          TextFormField(
+                            controller: _usernameController,
+                            enabled: !isLoading,
+                            decoration: const InputDecoration(
+                              labelText: '사용자명',
+                              border: OutlineInputBorder(),
+                              prefixIcon: Icon(Icons.person_outline),
+                            ),
+                            textInputAction: TextInputAction.next,
+                            validator: (v) => (v == null || v.trim().isEmpty)
+                                ? '사용자명을 입력하세요'
+                                : null,
+                          ),
+                          const SizedBox(height: 16),
+                          TextFormField(
+                            controller: _passwordController,
+                            enabled: !isLoading,
+                            obscureText: _obscurePassword,
+                            decoration: InputDecoration(
+                              labelText: '비밀번호',
+                              border: const OutlineInputBorder(),
+                              prefixIcon: const Icon(Icons.lock_outline),
+                              suffixIcon: IconButton(
+                                tooltip: _obscurePassword ? '표시' : '숨기기',
+                                icon: Icon(
+                                  _obscurePassword
+                                      ? Icons.visibility
+                                      : Icons.visibility_off,
+                                ),
+                                onPressed: () => setState(
+                                    () => _obscurePassword = !_obscurePassword),
+                              ),
+                            ),
+                            onFieldSubmitted: (_) => _submit(),
+                            validator: (v) => (v == null || v.isEmpty)
+                                ? '비밀번호를 입력하세요'
+                                : null,
+                          ),
+                          const SizedBox(height: 24),
+                          FilledButton(
+                            onPressed: isLoading ? null : _submit,
+                            style: FilledButton.styleFrom(
+                              minimumSize: const Size.fromHeight(48),
+                            ),
+                            child: isLoading
+                                ? const SizedBox(
+                                    width: 22,
+                                    height: 22,
+                                    child: CircularProgressIndicator(
+                                      strokeWidth: 2.5,
+                                    ),
+                                  )
+                                : const Text('로그인'),
+                          ),
+                        ],
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/admin_catalog/presentation/widgets/admin_sidebar.dart
+++ b/lib/features/admin_catalog/presentation/widgets/admin_sidebar.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+
+import '../bloc/admin_auth_bloc.dart';
+import '../bloc/admin_auth_event.dart';
+import '../bloc/admin_auth_state.dart';
+
+/// Side navigation for admin screens. Lists primary destinations and a
+/// logout action. Catalog item is enabled but currently routes to a
+/// placeholder until US4-C-β lands.
+class AdminSidebar extends StatelessWidget {
+  const AdminSidebar({super.key, required this.currentRoute});
+
+  final String currentRoute;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<AdminAuthBloc, AdminAuthState>(
+      buildWhen: (prev, next) =>
+          prev is AdminAuthenticated || next is AdminAuthenticated,
+      builder: (context, state) {
+        final admin = state is AdminAuthenticated ? state.admin : null;
+        return NavigationDrawer(
+          selectedIndex: _selectedIndex,
+          onDestinationSelected: (i) => _onSelect(context, i),
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(28, 16, 28, 8),
+              child: Text(
+                admin?.fullName ?? '관리자',
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+            ),
+            if (admin != null)
+              Padding(
+                padding: const EdgeInsets.fromLTRB(28, 0, 28, 16),
+                child: Text(
+                  admin.email,
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+              ),
+            const Divider(),
+            const NavigationDrawerDestination(
+              icon: Icon(Icons.dashboard_outlined),
+              selectedIcon: Icon(Icons.dashboard),
+              label: Text('대시보드'),
+            ),
+            const NavigationDrawerDestination(
+              icon: Icon(Icons.book_outlined),
+              selectedIcon: Icon(Icons.book),
+              label: Text('도서 관리'),
+            ),
+            const Padding(
+              padding: EdgeInsets.fromLTRB(28, 16, 28, 8),
+              child: Divider(),
+            ),
+            ListTile(
+              leading: const Icon(Icons.logout),
+              title: const Text('로그아웃'),
+              onTap: () => context
+                  .read<AdminAuthBloc>()
+                  .add(const AdminAuthLogoutRequested()),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  int get _selectedIndex {
+    if (currentRoute.startsWith('/admin/catalog')) return 1;
+    return 0;
+  }
+
+  void _onSelect(BuildContext context, int index) {
+    Navigator.of(context).maybePop(); // close drawer if open
+    switch (index) {
+      case 0:
+        context.go('/admin');
+        break;
+      case 1:
+        context.go('/admin/catalog');
+        break;
+    }
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,30 +1,63 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+
+import 'app/config.dart';
 import 'core/routes/app_router.dart';
+import 'features/admin_catalog/data/repositories/admin_auth_repository_impl.dart';
+import 'features/admin_catalog/presentation/bloc/admin_auth_bloc.dart';
+import 'features/admin_catalog/presentation/bloc/admin_auth_event.dart';
 
 void main() {
   runApp(const Library42App());
 }
 
-class Library42App extends StatelessWidget {
+class Library42App extends StatefulWidget {
   const Library42App({super.key});
 
   @override
+  State<Library42App> createState() => _Library42AppState();
+}
+
+class _Library42AppState extends State<Library42App> {
+  late final AdminAuthBloc _adminAuthBloc;
+  late final GoRouter _router;
+
+  @override
+  void initState() {
+    super.initState();
+    _adminAuthBloc = AdminAuthBloc(
+      repository: AdminAuthRepositoryImpl(baseUrl: AppConfig.apiBaseUrl),
+    )..add(const AdminAuthSessionRestored());
+    _router = AppRouter.create(_adminAuthBloc);
+  }
+
+  @override
+  void dispose() {
+    _adminAuthBloc.close();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return MaterialApp.router(
-      title: '42 Library Management',
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
-        useMaterial3: true,
-      ),
-      darkTheme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(
-          seedColor: Colors.blue,
-          brightness: Brightness.dark,
+    return BlocProvider<AdminAuthBloc>.value(
+      value: _adminAuthBloc,
+      child: MaterialApp.router(
+        title: '42 Library Management',
+        theme: ThemeData(
+          colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+          useMaterial3: true,
         ),
-        useMaterial3: true,
+        darkTheme: ThemeData(
+          colorScheme: ColorScheme.fromSeed(
+            seedColor: Colors.blue,
+            brightness: Brightness.dark,
+          ),
+          useMaterial3: true,
+        ),
+        routerConfig: _router,
+        debugShowCheckedModeBanner: false,
       ),
-      routerConfig: AppRouter.router,
-      debugShowCheckedModeBanner: false,
     );
   }
 }

--- a/specs/001-library-management/tasks.md
+++ b/specs/001-library-management/tasks.md
@@ -180,16 +180,16 @@
 
 **UI Components - Web Dashboard**
 
-- [ ] T084 [P] [US4] Create AdminSidebar navigation widget in lib/widgets/admin/admin_sidebar.dart
+- [X] T084 [P] [US4] Create AdminSidebar navigation widget in lib/features/admin_catalog/presentation/widgets/admin_sidebar.dart
 - [ ] T085 [P] [US4] Create BookFormWidget for add/edit in lib/widgets/admin/book_form.dart
 - [ ] T086 [P] [US4] Create DeleteConfirmationDialog in lib/widgets/admin/delete_confirmation_dialog.dart
 
 **Screens - Web Dashboard**
 
-- [ ] T087 [US4] Create AdminLoginScreen in lib/screens/web/login/admin_login_screen.dart
-- [ ] T088 [US4] Create AdminDashboardScreen in lib/screens/web/dashboard/dashboard_screen.dart
+- [X] T087 [US4] Create AdminLoginScreen in lib/features/admin_catalog/presentation/screens/admin_login_screen.dart
+- [X] T088 [US4] Create AdminDashboardScreen in lib/features/admin_catalog/presentation/screens/admin_dashboard_screen.dart
 - [ ] T089 [US4] Create CatalogManagementScreen in lib/screens/web/catalog/catalog_screen.dart
-- [ ] T090 [US4] Add admin routes to navigation in lib/app/routes.dart
+- [X] T090 [US4] Add admin routes to navigation in lib/core/routes/app_router.dart (with auth guard via refreshListenable + redirect)
 - [ ] T091 [US4] Implement book add/edit form with validation in CatalogManagementScreen
 - [ ] T092 [US4] Implement book deletion with warning dialog for active loans
 

--- a/test/features/admin_catalog/presentation/screens/admin_login_screen_test.dart
+++ b/test/features/admin_catalog/presentation/screens/admin_login_screen_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lib_42_flutter/features/admin_catalog/domain/repositories/admin_auth_repository.dart';
+import 'package:lib_42_flutter/features/admin_catalog/presentation/bloc/admin_auth_bloc.dart';
+import 'package:lib_42_flutter/features/admin_catalog/presentation/screens/admin_login_screen.dart';
+
+import '../../../../support/fake_admin_auth_repository.dart';
+
+Future<AdminAuthBloc> _pump(
+  WidgetTester tester,
+  FakeAdminAuthRepository repository,
+) async {
+  final bloc = AdminAuthBloc(repository: repository);
+  addTearDown(bloc.close);
+  await tester.pumpWidget(
+    MaterialApp(
+      home: BlocProvider<AdminAuthBloc>.value(
+        value: bloc,
+        child: const AdminLoginScreen(),
+      ),
+    ),
+  );
+  return bloc;
+}
+
+void main() {
+  group('AdminLoginScreen', () {
+    testWidgets('renders title and disabled login until inputs filled',
+        (tester) async {
+      await _pump(tester, FakeAdminAuthRepository());
+
+      expect(find.text('관리자 로그인'), findsOneWidget);
+      expect(find.byType(TextFormField), findsNWidgets(2));
+      expect(find.widgetWithText(FilledButton, '로그인'), findsOneWidget);
+    });
+
+    testWidgets('shows validation errors when submitted with empty fields',
+        (tester) async {
+      await _pump(tester, FakeAdminAuthRepository());
+
+      await tester.tap(find.widgetWithText(FilledButton, '로그인'));
+      await tester.pump();
+
+      expect(find.text('사용자명을 입력하세요'), findsOneWidget);
+      expect(find.text('비밀번호를 입력하세요'), findsOneWidget);
+    });
+
+    testWidgets('dispatches login on valid input', (tester) async {
+      final repository = FakeAdminAuthRepository()
+        ..loginResult = AdminAuthResult(token: 't', admin: makeAdmin());
+      await _pump(tester, repository);
+
+      await tester.enterText(find.byType(TextFormField).first, 'admin');
+      await tester.enterText(find.byType(TextFormField).last, 'admin123');
+      await tester.tap(find.widgetWithText(FilledButton, '로그인'));
+      await tester.pump();
+      // Allow async login to settle
+      await tester.pump(const Duration(milliseconds: 10));
+
+      expect(repository.loginCalls, 1);
+    });
+
+    testWidgets('shows snackbar with error on AdminAuthFailed',
+        (tester) async {
+      final repository = FakeAdminAuthRepository()
+        ..loginError = const AdminAuthException(
+          AdminAuthFailure.invalidCredentials,
+          '잘못된 자격증명',
+        );
+      await _pump(tester, repository);
+
+      await tester.enterText(find.byType(TextFormField).first, 'admin');
+      await tester.enterText(find.byType(TextFormField).last, 'wrong');
+      await tester.tap(find.widgetWithText(FilledButton, '로그인'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 10));
+
+      expect(find.text('잘못된 자격증명'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
Closes #51

## 요약

MVP 게이트 2 서브 게이트 3-α. 관리자 로그인 → 빈 대시보드 진입까지 동작. 카탈로그 관리 본체는 β.

## 변경 (+533 / -57)

### 신규 화면 / 위젯
- \`presentation/screens/admin_login_screen.dart\` (T087) — 폼 + 검증 + 로딩 표시 + 실패 SnackBar
- \`presentation/screens/admin_dashboard_screen.dart\` (T088) — 환영 + 관리자 정보 + 카탈로그 링크 (β placeholder 포함)
- \`presentation/widgets/admin_sidebar.dart\` (T084) — NavigationDrawer로 네비/로그아웃

### 라우팅 인프라 변경
- \`core/routes/go_router_refresh_stream.dart\` — Stream → ChangeNotifier 어댑터
- \`core/routes/app_router.dart\` — \`AppRouter.router\` 정적 → \`AppRouter.create(adminAuthBloc)\` 빌더 전환. \`refreshListenable\` + \`redirect\` 로 \`/admin/*\` 가드
- \`main.dart\` — StatelessWidget → StatefulWidget. AdminAuthBloc 생명주기 관리, 시작 시 \`AdminAuthSessionRestored\`, BlocProvider.value로 하위 트리 제공

### 가드 동작
- 미인증으로 \`/admin/*\` 접근 → \`/admin/login\` 리다이렉트
- 인증된 상태로 \`/admin/login\` 접근 → \`/admin\` 리다이렉트
- 학생 라우트(\`/\`, \`/books/:id\`, \`/login\`, \`/my-loans\`) 무변경

### 테스트
- \`test/features/admin_catalog/presentation/screens/admin_login_screen_test.dart\` — 4건 (렌더, 검증, 디스패치, 실패 SnackBar)

### tasks.md 갱신
T084/T087/T088/T090 [X] + features/ 경로 반영

## 수동 검증 시나리오

1. \`make up\` → \`http://localhost:8080/#/admin/login\` 접근
2. 잘못된 자격증명 입력 → 에러 SnackBar
3. \`admin\` / \`admin123\` 입력 → \`/admin\` 대시보드 진입
4. 새로고침 → 세션 유지 (SessionRestored)
5. 사이드바 → 로그아웃 → \`/admin/login\` 복귀
6. 비로그인 상태로 \`/admin\` 직접 URL 입력 → \`/admin/login\` 자동 리다이렉트
7. \`/admin/catalog\` 접근 → β placeholder 화면

## 헌법 준수

- [x] II/III/IV/XIII
- [ ] XVI. 로컬 검증 — Flutter CI

## Test Plan

- [ ] CI green
- [ ] 학생 도서 목록 (\`/\`) 무변화 — BookListScreen 정상 동작
- [ ] 7개 수동 검증 시나리오 통과