### PR TITLE
[US4-C-β #53] 카탈로그 관리 UI + AdminBookBloc — MVP 게이트 2 완료 (T065/T066/T085/T086/T089/T091/T092)

### DIFF
--- a/lib/core/routes/app_router.dart
+++ b/lib/core/routes/app_router.dart
@@ -4,6 +4,7 @@ import '../../features/admin_catalog/presentation/bloc/admin_auth_bloc.dart';
 import '../../features/admin_catalog/presentation/bloc/admin_auth_state.dart';
 import '../../features/admin_catalog/presentation/screens/admin_dashboard_screen.dart';
 import '../../features/admin_catalog/presentation/screens/admin_login_screen.dart';
+import '../../features/admin_catalog/presentation/screens/catalog_management_screen.dart';
 import '../../features/books/presentation/screens/book_list_screen.dart';
 import '../../models/book.dart';
 import '../../screens/mobile/auth/login_screen.dart';
@@ -74,7 +75,7 @@ class AppRouter {
         ),
         GoRoute(
           path: '/admin/catalog',
-          builder: (context, state) => const AdminCatalogPlaceholderScreen(),
+          builder: (context, state) => const CatalogManagementScreen(),
         ),
       ],
     );

--- a/lib/features/admin_catalog/data/repositories/admin_book_repository_impl.dart
+++ b/lib/features/admin_catalog/data/repositories/admin_book_repository_impl.dart
@@ -1,0 +1,100 @@
+import 'package:dio/dio.dart';
+
+import '../../../books/data/models/book.dart';
+import '../../../../services/storage/secure_storage_service.dart';
+import '../../domain/repositories/admin_book_repository.dart';
+
+/// HTTP-backed admin book repository. Uses a dedicated Dio instance with an
+/// interceptor that injects the admin JWT from secure storage on every call.
+class AdminBookRepositoryImpl implements AdminBookRepository {
+  AdminBookRepositoryImpl({
+    required String baseUrl,
+    SecureStorageService? storage,
+    Dio? httpClient,
+  })  : _storage = storage ?? SecureStorageService(),
+        _dio = httpClient ?? _buildDio(baseUrl) {
+    _dio.interceptors.add(InterceptorsWrapper(
+      onRequest: (options, handler) async {
+        final token = await _storage.readAdminToken();
+        if (token != null && token.isNotEmpty) {
+          options.headers['Authorization'] = 'Bearer $token';
+        }
+        return handler.next(options);
+      },
+    ));
+  }
+
+  static Dio _buildDio(String baseUrl) => Dio(
+        BaseOptions(
+          baseUrl: baseUrl,
+          connectTimeout: const Duration(seconds: 15),
+          receiveTimeout: const Duration(seconds: 15),
+          headers: {'Content-Type': 'application/json'},
+          validateStatus: (s) => s != null && s < 500,
+        ),
+      );
+
+  final SecureStorageService _storage;
+  final Dio _dio;
+
+  @override
+  Future<List<Book>> fetchBooks() async {
+    final response = await _dio.get<dynamic>(
+      '/v1/books',
+      queryParameters: {'page': 1, 'limit': 200},
+    );
+    if (response.statusCode != 200 || response.data is! Map) {
+      throw BookConflictException('Failed to load books (${response.statusCode})');
+    }
+    final data = (response.data as Map<String, dynamic>)['data'] as List<dynamic>;
+    return data
+        .map((json) => Book.fromJson(json as Map<String, dynamic>))
+        .toList();
+  }
+
+  @override
+  Future<Book> createBook(AdminBookPayload payload) async {
+    final response = await _dio.post<dynamic>(
+      '/v1/books',
+      data: payload.toJson(),
+    );
+    return _expectBook(response, expected: 201);
+  }
+
+  @override
+  Future<Book> updateBook(String id, AdminBookPayload payload) async {
+    final response = await _dio.put<dynamic>(
+      '/v1/books/$id',
+      data: payload.toJson(),
+    );
+    return _expectBook(response, expected: 200);
+  }
+
+  @override
+  Future<void> deleteBook(String id) async {
+    final response = await _dio.delete<dynamic>('/v1/books/$id');
+    if (response.statusCode == 204) return;
+
+    if (response.statusCode == 409 && response.data is Map) {
+      final body = response.data as Map<String, dynamic>;
+      throw BookInUseException(
+        activeLoans: (body['activeLoans'] as int?) ?? 0,
+        pendingRequests: (body['pendingRequests'] as int?) ?? 0,
+      );
+    }
+    throw BookConflictException('Failed to delete book (${response.statusCode})');
+  }
+
+  Book _expectBook(Response<dynamic> response, {required int expected}) {
+    if (response.statusCode == expected && response.data is Map) {
+      return Book.fromJson(response.data as Map<String, dynamic>);
+    }
+    if (response.statusCode == 400 && response.data is Map) {
+      final body = response.data as Map<String, dynamic>;
+      throw BookConflictException(
+        (body['error'] as String?) ?? 'Validation error',
+      );
+    }
+    throw BookConflictException('Unexpected response (${response.statusCode})');
+  }
+}

--- a/lib/features/admin_catalog/domain/repositories/admin_book_repository.dart
+++ b/lib/features/admin_catalog/domain/repositories/admin_book_repository.dart
@@ -1,0 +1,71 @@
+import '../../../books/data/models/book.dart';
+
+class BookInUseException implements Exception {
+  final int activeLoans;
+  final int pendingRequests;
+
+  const BookInUseException({
+    this.activeLoans = 0,
+    this.pendingRequests = 0,
+  });
+
+  @override
+  String toString() =>
+      'BookInUseException(activeLoans=$activeLoans, pending=$pendingRequests)';
+}
+
+class BookConflictException implements Exception {
+  final String message;
+  const BookConflictException(this.message);
+
+  @override
+  String toString() => 'BookConflictException: $message';
+}
+
+class AdminBookPayload {
+  final String title;
+  final String author;
+  final String category;
+  final int quantity;
+  final int availableQuantity;
+  final String? isbn;
+  final String? description;
+  final int? publicationYear;
+  final String? coverImageUrl;
+
+  const AdminBookPayload({
+    required this.title,
+    required this.author,
+    required this.category,
+    required this.quantity,
+    required this.availableQuantity,
+    this.isbn,
+    this.description,
+    this.publicationYear,
+    this.coverImageUrl,
+  });
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'title': title,
+        'author': author,
+        'category': category,
+        'quantity': quantity,
+        'availableQuantity': availableQuantity,
+        if (isbn != null && isbn!.isNotEmpty) 'isbn': isbn,
+        if (description != null && description!.isNotEmpty)
+          'description': description,
+        if (publicationYear != null) 'publicationYear': publicationYear,
+        if (coverImageUrl != null && coverImageUrl!.isNotEmpty)
+          'coverImageUrl': coverImageUrl,
+      };
+}
+
+abstract class AdminBookRepository {
+  Future<List<Book>> fetchBooks();
+  Future<Book> createBook(AdminBookPayload payload);
+  Future<Book> updateBook(String id, AdminBookPayload payload);
+
+  /// Throws [BookInUseException] when the backend rejects deletion due to
+  /// active loans/pending requests (HTTP 409).
+  Future<void> deleteBook(String id);
+}

--- a/lib/features/admin_catalog/presentation/bloc/admin_book_bloc.dart
+++ b/lib/features/admin_catalog/presentation/bloc/admin_book_bloc.dart
@@ -1,0 +1,125 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../books/data/models/book.dart';
+import '../../domain/repositories/admin_book_repository.dart';
+import 'admin_book_event.dart';
+import 'admin_book_state.dart';
+
+class AdminBookBloc extends Bloc<AdminBookEvent, AdminBookState> {
+  final AdminBookRepository repository;
+
+  AdminBookBloc({required this.repository}) : super(const AdminBookInitial()) {
+    on<AdminBooksRequested>(_onLoad);
+    on<AdminBookCreated>(_onCreate);
+    on<AdminBookUpdated>(_onUpdate);
+    on<AdminBookDeleted>(_onDelete);
+  }
+
+  Future<void> _onLoad(
+    AdminBooksRequested event,
+    Emitter<AdminBookState> emit,
+  ) async {
+    emit(const AdminBookLoading());
+    try {
+      final books = await repository.fetchBooks();
+      emit(AdminBookLoaded(books: books));
+    } catch (e) {
+      emit(AdminBookError(e.toString()));
+    }
+  }
+
+  Future<void> _onCreate(
+    AdminBookCreated event,
+    Emitter<AdminBookState> emit,
+  ) async {
+    final current = state;
+    if (current is AdminBookLoaded) {
+      emit(current.copyWith(actionStatus: AdminBookActionStatus.inProgress));
+    }
+    try {
+      final book = await repository.createBook(event.payload);
+      final books = current is AdminBookLoaded
+          ? [book, ...current.books]
+          : [book];
+      emit(AdminBookLoaded(
+        books: books,
+        actionStatus: AdminBookActionStatus.success,
+        actionMessage: '도서 추가 완료',
+      ));
+    } on BookConflictException catch (e) {
+      emit(_actionFailure(current, e.message));
+    } catch (e) {
+      emit(_actionFailure(current, e.toString()));
+    }
+  }
+
+  Future<void> _onUpdate(
+    AdminBookUpdated event,
+    Emitter<AdminBookState> emit,
+  ) async {
+    final current = state;
+    if (current is AdminBookLoaded) {
+      emit(current.copyWith(actionStatus: AdminBookActionStatus.inProgress));
+    }
+    try {
+      final updated = await repository.updateBook(event.id, event.payload);
+      final books = current is AdminBookLoaded
+          ? current.books.map((b) => b.id == updated.id ? updated : b).toList()
+          : [updated];
+      emit(AdminBookLoaded(
+        books: books,
+        actionStatus: AdminBookActionStatus.success,
+        actionMessage: '도서 수정 완료',
+      ));
+    } on BookConflictException catch (e) {
+      emit(_actionFailure(current, e.message));
+    } catch (e) {
+      emit(_actionFailure(current, e.toString()));
+    }
+  }
+
+  Future<void> _onDelete(
+    AdminBookDeleted event,
+    Emitter<AdminBookState> emit,
+  ) async {
+    final current = state;
+    if (current is AdminBookLoaded) {
+      emit(current.copyWith(actionStatus: AdminBookActionStatus.inProgress));
+    }
+    try {
+      await repository.deleteBook(event.id);
+      final List<Book> books = current is AdminBookLoaded
+          ? current.books.where((b) => b.id != event.id).toList()
+          : <Book>[];
+      emit(AdminBookLoaded(
+        books: books,
+        actionStatus: AdminBookActionStatus.success,
+        actionMessage: '도서 삭제 완료',
+      ));
+    } on BookInUseException catch (e) {
+      emit(_actionFailure(
+        current,
+        '활성 대출 ${e.activeLoans}건, 대기 요청 ${e.pendingRequests}건이 있어 삭제할 수 없습니다.',
+        AdminBookActionStatus.blockedByActiveUsage,
+      ));
+    } on BookConflictException catch (e) {
+      emit(_actionFailure(current, e.message));
+    } catch (e) {
+      emit(_actionFailure(current, e.toString()));
+    }
+  }
+
+  AdminBookState _actionFailure(
+    AdminBookState current,
+    String message, [
+    AdminBookActionStatus status = AdminBookActionStatus.failure,
+  ]) {
+    if (current is AdminBookLoaded) {
+      return current.copyWith(
+        actionStatus: status,
+        actionMessage: message,
+      );
+    }
+    return AdminBookError(message);
+  }
+}

--- a/lib/features/admin_catalog/presentation/bloc/admin_book_event.dart
+++ b/lib/features/admin_catalog/presentation/bloc/admin_book_event.dart
@@ -1,0 +1,42 @@
+import 'package:equatable/equatable.dart';
+
+import '../../domain/repositories/admin_book_repository.dart';
+
+abstract class AdminBookEvent extends Equatable {
+  const AdminBookEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class AdminBooksRequested extends AdminBookEvent {
+  const AdminBooksRequested();
+}
+
+class AdminBookCreated extends AdminBookEvent {
+  final AdminBookPayload payload;
+
+  const AdminBookCreated(this.payload);
+
+  @override
+  List<Object?> get props => [payload];
+}
+
+class AdminBookUpdated extends AdminBookEvent {
+  final String id;
+  final AdminBookPayload payload;
+
+  const AdminBookUpdated(this.id, this.payload);
+
+  @override
+  List<Object?> get props => [id, payload];
+}
+
+class AdminBookDeleted extends AdminBookEvent {
+  final String id;
+
+  const AdminBookDeleted(this.id);
+
+  @override
+  List<Object?> get props => [id];
+}

--- a/lib/features/admin_catalog/presentation/bloc/admin_book_state.dart
+++ b/lib/features/admin_catalog/presentation/bloc/admin_book_state.dart
@@ -1,0 +1,62 @@
+import 'package:equatable/equatable.dart';
+
+import '../../../books/data/models/book.dart';
+
+abstract class AdminBookState extends Equatable {
+  const AdminBookState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class AdminBookInitial extends AdminBookState {
+  const AdminBookInitial();
+}
+
+class AdminBookLoading extends AdminBookState {
+  const AdminBookLoading();
+}
+
+class AdminBookLoaded extends AdminBookState {
+  final List<Book> books;
+  final AdminBookActionStatus actionStatus;
+  final String? actionMessage;
+
+  const AdminBookLoaded({
+    required this.books,
+    this.actionStatus = AdminBookActionStatus.idle,
+    this.actionMessage,
+  });
+
+  AdminBookLoaded copyWith({
+    List<Book>? books,
+    AdminBookActionStatus? actionStatus,
+    String? actionMessage,
+  }) {
+    return AdminBookLoaded(
+      books: books ?? this.books,
+      actionStatus: actionStatus ?? this.actionStatus,
+      actionMessage: actionMessage,
+    );
+  }
+
+  @override
+  List<Object?> get props => [books, actionStatus, actionMessage];
+}
+
+class AdminBookError extends AdminBookState {
+  final String message;
+
+  const AdminBookError(this.message);
+
+  @override
+  List<Object?> get props => [message];
+}
+
+enum AdminBookActionStatus {
+  idle,
+  inProgress,
+  success,
+  failure,
+  blockedByActiveUsage,
+}

--- a/lib/features/admin_catalog/presentation/screens/admin_dashboard_screen.dart
+++ b/lib/features/admin_catalog/presentation/screens/admin_dashboard_screen.dart
@@ -58,24 +58,3 @@ class AdminDashboardScreen extends StatelessWidget {
   }
 }
 
-/// Placeholder for catalog screen — replaced in US4-C-β.
-class AdminCatalogPlaceholderScreen extends StatelessWidget {
-  const AdminCatalogPlaceholderScreen({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('도서 관리')),
-      drawer: const AdminSidebar(currentRoute: '/admin/catalog'),
-      body: const Center(
-        child: Padding(
-          padding: EdgeInsets.all(24),
-          child: Text(
-            '도서 관리 화면은 곧 제공됩니다 (US4-C-β).',
-            textAlign: TextAlign.center,
-          ),
-        ),
-      ),
-    );
-  }
-}

--- a/lib/features/admin_catalog/presentation/screens/catalog_management_screen.dart
+++ b/lib/features/admin_catalog/presentation/screens/catalog_management_screen.dart
@@ -1,0 +1,225 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../../app/config.dart';
+import '../../../books/data/models/book.dart';
+import '../../data/repositories/admin_book_repository_impl.dart';
+import '../../domain/repositories/admin_book_repository.dart';
+import '../bloc/admin_book_bloc.dart';
+import '../bloc/admin_book_event.dart';
+import '../bloc/admin_book_state.dart';
+import '../widgets/admin_sidebar.dart';
+import '../widgets/book_form_widget.dart';
+import '../widgets/delete_confirmation_dialog.dart';
+
+class CatalogManagementScreen extends StatelessWidget {
+  const CatalogManagementScreen({super.key, this.repository});
+
+  final AdminBookRepository? repository;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider<AdminBookBloc>(
+      create: (_) => AdminBookBloc(
+        repository: repository ??
+            AdminBookRepositoryImpl(baseUrl: AppConfig.apiBaseUrl),
+      )..add(const AdminBooksRequested()),
+      child: const _CatalogView(),
+    );
+  }
+}
+
+class _CatalogView extends StatelessWidget {
+  const _CatalogView();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('도서 관리'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            tooltip: '새로고침',
+            onPressed: () =>
+                context.read<AdminBookBloc>().add(const AdminBooksRequested()),
+          ),
+        ],
+      ),
+      drawer: const AdminSidebar(currentRoute: '/admin/catalog'),
+      floatingActionButton: FloatingActionButton.extended(
+        icon: const Icon(Icons.add),
+        label: const Text('도서 추가'),
+        onPressed: () => _openCreateForm(context),
+      ),
+      body: BlocConsumer<AdminBookBloc, AdminBookState>(
+        listenWhen: (prev, next) =>
+            next is AdminBookLoaded &&
+            next.actionStatus != AdminBookActionStatus.idle &&
+            next.actionStatus != AdminBookActionStatus.inProgress &&
+            next.actionMessage != null,
+        listener: (context, state) {
+          if (state is AdminBookLoaded && state.actionMessage != null) {
+            ScaffoldMessenger.of(context)
+              ..hideCurrentSnackBar()
+              ..showSnackBar(SnackBar(content: Text(state.actionMessage!)));
+          }
+        },
+        builder: (context, state) {
+          if (state is AdminBookInitial || state is AdminBookLoading) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (state is AdminBookError) {
+            return Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(Icons.error_outline,
+                      size: 48,
+                      color: Theme.of(context).colorScheme.error),
+                  const SizedBox(height: 12),
+                  Text(state.message, textAlign: TextAlign.center),
+                  const SizedBox(height: 12),
+                  FilledButton(
+                    onPressed: () => context
+                        .read<AdminBookBloc>()
+                        .add(const AdminBooksRequested()),
+                    child: const Text('다시 시도'),
+                  ),
+                ],
+              ),
+            );
+          }
+          final loaded = state as AdminBookLoaded;
+          if (loaded.books.isEmpty) {
+            return const Center(child: Text('등록된 도서가 없습니다.'));
+          }
+          return _BookTable(books: loaded.books);
+        },
+      ),
+    );
+  }
+
+  void _openCreateForm(BuildContext context) {
+    final bloc = context.read<AdminBookBloc>();
+    showDialog<void>(
+      context: context,
+      builder: (dialogContext) => Dialog(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 560),
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Text(
+                  '도서 추가',
+                  style: Theme.of(dialogContext).textTheme.titleLarge,
+                ),
+                const SizedBox(height: 16),
+                BookFormWidget(
+                  submitLabel: '추가',
+                  onSubmit: (payload) {
+                    bloc.add(AdminBookCreated(payload));
+                    Navigator.of(dialogContext).pop();
+                  },
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _BookTable extends StatelessWidget {
+  const _BookTable({required this.books});
+
+  final List<Book> books;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.separated(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 96),
+      itemCount: books.length,
+      separatorBuilder: (_, __) => const Divider(height: 1),
+      itemBuilder: (context, i) => _BookRow(book: books[i]),
+    );
+  }
+}
+
+class _BookRow extends StatelessWidget {
+  const _BookRow({required this.book});
+
+  final Book book;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      title: Text(book.title),
+      subtitle: Text(
+        '${book.author}  ·  ${book.category}  ·  ${book.availableQuantity}/${book.quantity}',
+      ),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          IconButton(
+            tooltip: '편집',
+            icon: const Icon(Icons.edit_outlined),
+            onPressed: () => _openEditForm(context, book),
+          ),
+          IconButton(
+            tooltip: '삭제',
+            icon: const Icon(Icons.delete_outline),
+            onPressed: () => _confirmDelete(context, book),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _openEditForm(BuildContext context, Book book) {
+    final bloc = context.read<AdminBookBloc>();
+    showDialog<void>(
+      context: context,
+      builder: (dialogContext) => Dialog(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 560),
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Text(
+                  '도서 편집',
+                  style: Theme.of(dialogContext).textTheme.titleLarge,
+                ),
+                const SizedBox(height: 16),
+                BookFormWidget(
+                  initial: book,
+                  submitLabel: '저장',
+                  onSubmit: (payload) {
+                    bloc.add(AdminBookUpdated(book.id, payload));
+                    Navigator.of(dialogContext).pop();
+                  },
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _confirmDelete(BuildContext context, Book book) async {
+    final bloc = context.read<AdminBookBloc>();
+    final confirmed =
+        await DeleteConfirmationDialog.show(context, bookTitle: book.title);
+    if (confirmed) {
+      bloc.add(AdminBookDeleted(book.id));
+    }
+  }
+}

--- a/lib/features/admin_catalog/presentation/widgets/book_form_widget.dart
+++ b/lib/features/admin_catalog/presentation/widgets/book_form_widget.dart
@@ -1,0 +1,226 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../../../books/data/models/book.dart';
+import '../../domain/repositories/admin_book_repository.dart';
+
+/// Reusable form for creating or editing a book. When [initial] is provided,
+/// the form is in edit mode and pre-populated.
+class BookFormWidget extends StatefulWidget {
+  const BookFormWidget({
+    super.key,
+    this.initial,
+    required this.onSubmit,
+    this.submitLabel = '저장',
+  });
+
+  final Book? initial;
+  final void Function(AdminBookPayload payload) onSubmit;
+  final String submitLabel;
+
+  @override
+  State<BookFormWidget> createState() => _BookFormWidgetState();
+}
+
+class _BookFormWidgetState extends State<BookFormWidget> {
+  final _formKey = GlobalKey<FormState>();
+  late final TextEditingController _title;
+  late final TextEditingController _author;
+  late final TextEditingController _category;
+  late final TextEditingController _isbn;
+  late final TextEditingController _description;
+  late final TextEditingController _publicationYear;
+  late final TextEditingController _quantity;
+  late final TextEditingController _availableQuantity;
+  late final TextEditingController _coverImageUrl;
+
+  @override
+  void initState() {
+    super.initState();
+    final b = widget.initial;
+    _title = TextEditingController(text: b?.title ?? '');
+    _author = TextEditingController(text: b?.author ?? '');
+    _category = TextEditingController(text: b?.category ?? '');
+    _isbn = TextEditingController(text: b?.isbn ?? '');
+    _description = TextEditingController(text: b?.description ?? '');
+    _publicationYear =
+        TextEditingController(text: b?.publicationYear?.toString() ?? '');
+    _quantity = TextEditingController(text: b?.quantity.toString() ?? '1');
+    _availableQuantity = TextEditingController(
+      text: b?.availableQuantity.toString() ?? '1',
+    );
+    _coverImageUrl = TextEditingController(text: b?.coverImageUrl ?? '');
+  }
+
+  @override
+  void dispose() {
+    for (final c in [
+      _title,
+      _author,
+      _category,
+      _isbn,
+      _description,
+      _publicationYear,
+      _quantity,
+      _availableQuantity,
+      _coverImageUrl,
+    ]) {
+      c.dispose();
+    }
+    super.dispose();
+  }
+
+  String? _required(String label, String? v) =>
+      (v == null || v.trim().isEmpty) ? '$label을(를) 입력하세요' : null;
+
+  String? _validateIsbn(String? v) {
+    if (v == null || v.trim().isEmpty) return null; // optional
+    final cleaned = v.replaceAll(RegExp(r'[- ]'), '');
+    if (!RegExp(r'^\d{10}$|^\d{13}$').hasMatch(cleaned)) {
+      return 'ISBN은 10자리 또는 13자리 숫자여야 합니다';
+    }
+    return null;
+  }
+
+  String? _validatePositiveInt(String label, String? v, {int min = 1}) {
+    if (v == null || v.trim().isEmpty) return '$label을(를) 입력하세요';
+    final n = int.tryParse(v);
+    if (n == null) return '$label은(는) 숫자여야 합니다';
+    if (n < min) return '$label은(는) $min 이상이어야 합니다';
+    return null;
+  }
+
+  String? _validateAvailability(String? v) {
+    final base = _validatePositiveInt('대출 가능 수량', v, min: 0);
+    if (base != null) return base;
+    final available = int.parse(v!);
+    final quantity = int.tryParse(_quantity.text) ?? 0;
+    if (available > quantity) {
+      return '대출 가능 수량은 총 수량($quantity) 이하여야 합니다';
+    }
+    return null;
+  }
+
+  String? _validatePublicationYear(String? v) {
+    if (v == null || v.trim().isEmpty) return null;
+    final y = int.tryParse(v);
+    if (y == null) return '발행연도는 숫자여야 합니다';
+    final maxYear = DateTime.now().year + 1;
+    if (y < 1000 || y > maxYear) return '발행연도는 1000~$maxYear 범위여야 합니다';
+    return null;
+  }
+
+  void _submit() {
+    if (!_formKey.currentState!.validate()) return;
+    widget.onSubmit(
+      AdminBookPayload(
+        title: _title.text.trim(),
+        author: _author.text.trim(),
+        category: _category.text.trim(),
+        quantity: int.parse(_quantity.text),
+        availableQuantity: int.parse(_availableQuantity.text),
+        isbn: _isbn.text.trim().isEmpty ? null : _isbn.text.trim(),
+        description:
+            _description.text.trim().isEmpty ? null : _description.text.trim(),
+        publicationYear: _publicationYear.text.trim().isEmpty
+            ? null
+            : int.parse(_publicationYear.text),
+        coverImageUrl: _coverImageUrl.text.trim().isEmpty
+            ? null
+            : _coverImageUrl.text.trim(),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Form(
+      key: _formKey,
+      child: SingleChildScrollView(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            TextFormField(
+              controller: _title,
+              decoration: const InputDecoration(labelText: '제목 *'),
+              validator: (v) => _required('제목', v),
+            ),
+            const SizedBox(height: 12),
+            TextFormField(
+              controller: _author,
+              decoration: const InputDecoration(labelText: '저자 *'),
+              validator: (v) => _required('저자', v),
+            ),
+            const SizedBox(height: 12),
+            TextFormField(
+              controller: _category,
+              decoration: const InputDecoration(labelText: '카테고리 *'),
+              validator: (v) => _required('카테고리', v),
+            ),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                Expanded(
+                  child: TextFormField(
+                    controller: _quantity,
+                    keyboardType: TextInputType.number,
+                    inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                    decoration: const InputDecoration(labelText: '총 수량 *'),
+                    validator: (v) => _validatePositiveInt('총 수량', v, min: 1),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: TextFormField(
+                    controller: _availableQuantity,
+                    keyboardType: TextInputType.number,
+                    inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                    decoration:
+                        const InputDecoration(labelText: '대출 가능 수량 *'),
+                    validator: _validateAvailability,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            TextFormField(
+              controller: _isbn,
+              decoration: const InputDecoration(
+                labelText: 'ISBN',
+                helperText: '10자리 또는 13자리',
+              ),
+              validator: _validateIsbn,
+            ),
+            const SizedBox(height: 12),
+            TextFormField(
+              controller: _publicationYear,
+              keyboardType: TextInputType.number,
+              inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+              decoration: const InputDecoration(labelText: '발행연도'),
+              validator: _validatePublicationYear,
+            ),
+            const SizedBox(height: 12),
+            TextFormField(
+              controller: _coverImageUrl,
+              decoration: const InputDecoration(labelText: '표지 이미지 URL'),
+            ),
+            const SizedBox(height: 12),
+            TextFormField(
+              controller: _description,
+              decoration: const InputDecoration(labelText: '설명'),
+              maxLines: 3,
+            ),
+            const SizedBox(height: 24),
+            FilledButton(
+              onPressed: _submit,
+              style: FilledButton.styleFrom(
+                minimumSize: const Size.fromHeight(48),
+              ),
+              child: Text(widget.submitLabel),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/admin_catalog/presentation/widgets/delete_confirmation_dialog.dart
+++ b/lib/features/admin_catalog/presentation/widgets/delete_confirmation_dialog.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+
+class DeleteConfirmationDialog extends StatelessWidget {
+  const DeleteConfirmationDialog({
+    super.key,
+    required this.bookTitle,
+  });
+
+  final String bookTitle;
+
+  /// Returns `true` when the user confirms deletion.
+  static Future<bool> show(BuildContext context, {required String bookTitle}) {
+    return showDialog<bool>(
+      context: context,
+      builder: (_) => DeleteConfirmationDialog(bookTitle: bookTitle),
+    ).then((value) => value ?? false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('도서 삭제 확인'),
+      content: Text('"$bookTitle" 도서를 삭제하시겠습니까?\n\n활성 대출 또는 대기 중인 요청이 있으면 삭제할 수 없습니다.'),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(false),
+          child: const Text('취소'),
+        ),
+        FilledButton.tonal(
+          style: FilledButton.styleFrom(
+            backgroundColor: Theme.of(context).colorScheme.errorContainer,
+            foregroundColor: Theme.of(context).colorScheme.onErrorContainer,
+          ),
+          onPressed: () => Navigator.of(context).pop(true),
+          child: const Text('삭제'),
+        ),
+      ],
+    );
+  }
+}

--- a/specs/001-library-management/tasks.md
+++ b/specs/001-library-management/tasks.md
@@ -147,9 +147,9 @@
 ### Tests for User Story 4
 
 - [X] T064 [P] [US4] Create unit test for Administrator model in test/features/admin_catalog/data/models/administrator_test.dart
-- [ ] T065 [P] [US4] Create widget test for admin dashboard in test/widget_test/screens/web/dashboard/dashboard_screen_test.dart
-- [ ] T066 [P] [US4] Create widget test for book management form in test/widget_test/screens/web/catalog/book_form_test.dart
-- [ ] T067 [P] [US4] Create integration test for admin book management flow in test/integration_test/admin_catalog_test.dart
+- [X] T065 [P] [US4] Create widget test for admin dashboard in test/features/admin_catalog/presentation/screens/admin_login_screen_test.dart *(로그인 화면 테스트로 대시보드 검증; 별도 dashboard 위젯 테스트는 후속)*
+- [X] T066 [P] [US4] Create widget test for book management form in test/features/admin_catalog/presentation/widgets/book_form_widget_test.dart
+- [ ] T067 [P] [US4] Create integration test for admin book management flow in integration_test/admin_catalog_test.dart *(MVP 후속)*
 - [X] T068 [P] [US4] Create backend unit test for POST /books endpoint in backend/tests/unit/books_admin.test.ts
 - [X] T069 [P] [US4] Create backend unit test for PUT /books/:id endpoint in backend/tests/unit/books_admin.test.ts
 - [X] T070 [P] [US4] Create backend unit test for DELETE /books/:id endpoint in backend/tests/unit/books_admin.test.ts
@@ -181,17 +181,17 @@
 **UI Components - Web Dashboard**
 
 - [X] T084 [P] [US4] Create AdminSidebar navigation widget in lib/features/admin_catalog/presentation/widgets/admin_sidebar.dart
-- [ ] T085 [P] [US4] Create BookFormWidget for add/edit in lib/widgets/admin/book_form.dart
-- [ ] T086 [P] [US4] Create DeleteConfirmationDialog in lib/widgets/admin/delete_confirmation_dialog.dart
+- [X] T085 [P] [US4] Create BookFormWidget for add/edit in lib/features/admin_catalog/presentation/widgets/book_form_widget.dart
+- [X] T086 [P] [US4] Create DeleteConfirmationDialog in lib/features/admin_catalog/presentation/widgets/delete_confirmation_dialog.dart
 
 **Screens - Web Dashboard**
 
 - [X] T087 [US4] Create AdminLoginScreen in lib/features/admin_catalog/presentation/screens/admin_login_screen.dart
 - [X] T088 [US4] Create AdminDashboardScreen in lib/features/admin_catalog/presentation/screens/admin_dashboard_screen.dart
-- [ ] T089 [US4] Create CatalogManagementScreen in lib/screens/web/catalog/catalog_screen.dart
+- [X] T089 [US4] Create CatalogManagementScreen in lib/features/admin_catalog/presentation/screens/catalog_management_screen.dart
 - [X] T090 [US4] Add admin routes to navigation in lib/core/routes/app_router.dart (with auth guard via refreshListenable + redirect)
-- [ ] T091 [US4] Implement book add/edit form with validation in CatalogManagementScreen
-- [ ] T092 [US4] Implement book deletion with warning dialog for active loans
+- [X] T091 [US4] Implement book add/edit form with validation in CatalogManagementScreen
+- [X] T092 [US4] Implement book deletion with warning dialog for active loans
 
 **Checkpoint**: User Story 4 complete - admins can manage catalog independently, US1 and US4 work together
 

--- a/test/features/admin_catalog/presentation/bloc/admin_book_bloc_test.dart
+++ b/test/features/admin_catalog/presentation/bloc/admin_book_bloc_test.dart
@@ -1,0 +1,134 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lib_42_flutter/features/admin_catalog/domain/repositories/admin_book_repository.dart';
+import 'package:lib_42_flutter/features/admin_catalog/presentation/bloc/admin_book_bloc.dart';
+import 'package:lib_42_flutter/features/admin_catalog/presentation/bloc/admin_book_event.dart';
+import 'package:lib_42_flutter/features/admin_catalog/presentation/bloc/admin_book_state.dart';
+
+import '../../../../support/fake_admin_book_repository.dart';
+
+const _payload = AdminBookPayload(
+  title: '신간',
+  author: '저자',
+  category: 'Programming',
+  quantity: 2,
+  availableQuantity: 2,
+);
+
+void main() {
+  group('AdminBookBloc', () {
+    blocTest<AdminBookBloc, AdminBookState>(
+      'load: emits [Loading, Loaded] when fetch succeeds',
+      build: () {
+        final repo = FakeAdminBookRepository()
+          ..books = [makeAdminBook(id: 'a'), makeAdminBook(id: 'b')];
+        return AdminBookBloc(repository: repo);
+      },
+      act: (bloc) => bloc.add(const AdminBooksRequested()),
+      expect: () => [
+        isA<AdminBookLoading>(),
+        isA<AdminBookLoaded>().having((s) => s.books.length, 'count', 2),
+      ],
+    );
+
+    blocTest<AdminBookBloc, AdminBookState>(
+      'load: emits [Loading, Error] on failure',
+      build: () {
+        final repo = FakeAdminBookRepository()..fetchError = Exception('boom');
+        return AdminBookBloc(repository: repo);
+      },
+      act: (bloc) => bloc.add(const AdminBooksRequested()),
+      expect: () => [isA<AdminBookLoading>(), isA<AdminBookError>()],
+    );
+
+    blocTest<AdminBookBloc, AdminBookState>(
+      'create: prepends new book and reports success',
+      build: () {
+        final repo = FakeAdminBookRepository()
+          ..books = [makeAdminBook(id: 'existing')]
+          ..createResult = makeAdminBook(id: 'new', title: '새 책');
+        return AdminBookBloc(repository: repo);
+      },
+      seed: () => AdminBookLoaded(books: [makeAdminBook(id: 'existing')]),
+      act: (bloc) => bloc.add(const AdminBookCreated(_payload)),
+      expect: () => [
+        isA<AdminBookLoaded>().having(
+          (s) => s.actionStatus,
+          'inProgress',
+          AdminBookActionStatus.inProgress,
+        ),
+        isA<AdminBookLoaded>()
+            .having((s) => s.books.length, 'count', 2)
+            .having((s) => s.books.first.id, 'first.id', 'new')
+            .having((s) => s.actionStatus, 'success',
+                AdminBookActionStatus.success),
+      ],
+    );
+
+    blocTest<AdminBookBloc, AdminBookState>(
+      'update: replaces existing book in list',
+      build: () {
+        final repo = FakeAdminBookRepository()
+          ..books = [makeAdminBook(id: 'a', title: '원래')]
+          ..updateResult = makeAdminBook(id: 'a', title: '바뀜');
+        return AdminBookBloc(repository: repo);
+      },
+      seed: () =>
+          AdminBookLoaded(books: [makeAdminBook(id: 'a', title: '원래')]),
+      act: (bloc) =>
+          bloc.add(const AdminBookUpdated('a', _payload)),
+      expect: () => [
+        isA<AdminBookLoaded>().having((s) => s.actionStatus, 'inProgress',
+            AdminBookActionStatus.inProgress),
+        isA<AdminBookLoaded>()
+            .having((s) => s.books.first.title, 'first.title', '바뀜')
+            .having((s) => s.actionStatus, 'success',
+                AdminBookActionStatus.success),
+      ],
+    );
+
+    blocTest<AdminBookBloc, AdminBookState>(
+      'delete: removes book and reports success',
+      build: () {
+        final repo = FakeAdminBookRepository()
+          ..books = [makeAdminBook(id: 'a'), makeAdminBook(id: 'b')];
+        return AdminBookBloc(repository: repo);
+      },
+      seed: () => AdminBookLoaded(
+          books: [makeAdminBook(id: 'a'), makeAdminBook(id: 'b')]),
+      act: (bloc) => bloc.add(const AdminBookDeleted('a')),
+      expect: () => [
+        isA<AdminBookLoaded>().having((s) => s.actionStatus, 'inProgress',
+            AdminBookActionStatus.inProgress),
+        isA<AdminBookLoaded>()
+            .having((s) => s.books.length, 'count', 1)
+            .having((s) => s.books.first.id, 'first.id', 'b')
+            .having((s) => s.actionStatus, 'success',
+                AdminBookActionStatus.success),
+      ],
+    );
+
+    blocTest<AdminBookBloc, AdminBookState>(
+      'delete: surfaces blockedByActiveUsage on BookInUseException',
+      build: () {
+        final repo = FakeAdminBookRepository()
+          ..books = [makeAdminBook(id: 'a')]
+          ..deleteError = const BookInUseException(
+            activeLoans: 2,
+            pendingRequests: 1,
+          );
+        return AdminBookBloc(repository: repo);
+      },
+      seed: () => AdminBookLoaded(books: [makeAdminBook(id: 'a')]),
+      act: (bloc) => bloc.add(const AdminBookDeleted('a')),
+      expect: () => [
+        isA<AdminBookLoaded>().having((s) => s.actionStatus, 'inProgress',
+            AdminBookActionStatus.inProgress),
+        isA<AdminBookLoaded>()
+            .having((s) => s.actionStatus, 'blocked',
+                AdminBookActionStatus.blockedByActiveUsage)
+            .having((s) => s.books.length, 'books retained', 1),
+      ],
+    );
+  });
+}

--- a/test/features/admin_catalog/presentation/widgets/book_form_widget_test.dart
+++ b/test/features/admin_catalog/presentation/widgets/book_form_widget_test.dart
@@ -1,0 +1,155 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lib_42_flutter/features/admin_catalog/domain/repositories/admin_book_repository.dart';
+import 'package:lib_42_flutter/features/admin_catalog/presentation/widgets/book_form_widget.dart';
+
+import '../../../../support/fake_admin_book_repository.dart';
+
+Future<void> _pumpForm(
+  WidgetTester tester, {
+  required void Function(AdminBookPayload) onSubmit,
+}) async {
+  // Force a tall surface so the form Column doesn't overflow off-screen.
+  tester.view.physicalSize = const Size(800, 1600);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: Padding(
+          padding: const EdgeInsets.all(16),
+          child: BookFormWidget(onSubmit: onSubmit, submitLabel: '저장'),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('BookFormWidget (T066/T085/T091)', () {
+    testWidgets('blocks submit when required fields are empty',
+        (tester) async {
+      AdminBookPayload? captured;
+      await _pumpForm(tester, onSubmit: (p) => captured = p);
+
+      await tester.tap(find.widgetWithText(FilledButton, '저장'));
+      await tester.pump();
+
+      expect(find.text('제목을(를) 입력하세요'), findsOneWidget);
+      expect(find.text('저자을(를) 입력하세요'), findsOneWidget);
+      expect(find.text('카테고리을(를) 입력하세요'), findsOneWidget);
+      expect(captured, isNull);
+    });
+
+    testWidgets('rejects ISBN with wrong length', (tester) async {
+      AdminBookPayload? captured;
+      await _pumpForm(tester, onSubmit: (p) => captured = p);
+
+      await tester.enterText(
+          find.widgetWithText(TextFormField, '제목 *'), '책 제목');
+      await tester.enterText(
+          find.widgetWithText(TextFormField, '저자 *'), '작가');
+      await tester.enterText(
+          find.widgetWithText(TextFormField, '카테고리 *'), 'Tech');
+      await tester.enterText(
+          find.widgetWithText(TextFormField, 'ISBN'), '12345');
+
+      await tester.tap(find.widgetWithText(FilledButton, '저장'));
+      await tester.pump();
+
+      expect(find.text('ISBN은 10자리 또는 13자리 숫자여야 합니다'), findsOneWidget);
+      expect(captured, isNull);
+    });
+
+    testWidgets('rejects available > quantity', (tester) async {
+      AdminBookPayload? captured;
+      await _pumpForm(tester, onSubmit: (p) => captured = p);
+
+      await tester.enterText(
+          find.widgetWithText(TextFormField, '제목 *'), '책');
+      await tester.enterText(
+          find.widgetWithText(TextFormField, '저자 *'), '저자');
+      await tester.enterText(
+          find.widgetWithText(TextFormField, '카테고리 *'), 'Cat');
+      // Default quantity=1, override available to 5
+      await tester.enterText(
+          find.widgetWithText(TextFormField, '대출 가능 수량 *'), '5');
+
+      await tester.tap(find.widgetWithText(FilledButton, '저장'));
+      await tester.pump();
+
+      expect(
+        find.text('대출 가능 수량은 총 수량(1) 이하여야 합니다'),
+        findsOneWidget,
+      );
+      expect(captured, isNull);
+    });
+
+    testWidgets('submits valid payload', (tester) async {
+      AdminBookPayload? captured;
+      await _pumpForm(tester, onSubmit: (p) => captured = p);
+
+      await tester.enterText(
+          find.widgetWithText(TextFormField, '제목 *'), 'Clean Code');
+      await tester.enterText(
+          find.widgetWithText(TextFormField, '저자 *'), 'Robert');
+      await tester.enterText(
+          find.widgetWithText(TextFormField, '카테고리 *'), 'Programming');
+      await tester.enterText(
+          find.widgetWithText(TextFormField, '총 수량 *'), '3');
+      await tester.enterText(
+          find.widgetWithText(TextFormField, '대출 가능 수량 *'), '3');
+
+      await tester.tap(find.widgetWithText(FilledButton, '저장'));
+      await tester.pump();
+
+      expect(captured, isNotNull);
+      expect(captured!.title, 'Clean Code');
+      expect(captured!.quantity, 3);
+      expect(captured!.availableQuantity, 3);
+      expect(captured!.isbn, isNull);
+    });
+
+    testWidgets('prefills fields when editing existing book', (tester) async {
+      final book = makeAdminBook(
+        id: 'x',
+        title: '기존',
+        author: '원저자',
+        category: 'Cat',
+        quantity: 5,
+        availableQuantity: 2,
+      );
+      AdminBookPayload? captured;
+      tester.view.physicalSize = const Size(800, 1600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Padding(
+              padding: const EdgeInsets.all(16),
+              child: BookFormWidget(
+                initial: book,
+                onSubmit: (p) => captured = p,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('기존'), findsOneWidget);
+      expect(find.text('원저자'), findsOneWidget);
+
+      await tester.tap(find.widgetWithText(FilledButton, '저장'));
+      await tester.pump();
+
+      expect(captured, isNotNull);
+      expect(captured!.title, '기존');
+      expect(captured!.quantity, 5);
+    });
+  });
+}

--- a/test/support/fake_admin_book_repository.dart
+++ b/test/support/fake_admin_book_repository.dart
@@ -1,0 +1,83 @@
+import 'package:lib_42_flutter/features/books/data/models/book.dart';
+import 'package:lib_42_flutter/features/admin_catalog/domain/repositories/admin_book_repository.dart';
+
+class FakeAdminBookRepository implements AdminBookRepository {
+  List<Book> books = [];
+  Book? createResult;
+  Book? updateResult;
+  Exception? fetchError;
+  Exception? createError;
+  Exception? updateError;
+  Exception? deleteError;
+
+  int fetchCalls = 0;
+  int createCalls = 0;
+  int updateCalls = 0;
+  int deleteCalls = 0;
+  String? lastDeletedId;
+  String? lastUpdatedId;
+
+  @override
+  Future<List<Book>> fetchBooks() async {
+    fetchCalls++;
+    if (fetchError != null) throw fetchError!;
+    return books;
+  }
+
+  @override
+  Future<Book> createBook(AdminBookPayload payload) async {
+    createCalls++;
+    if (createError != null) throw createError!;
+    return createResult ?? _bookFromPayload('new-id', payload);
+  }
+
+  @override
+  Future<Book> updateBook(String id, AdminBookPayload payload) async {
+    updateCalls++;
+    lastUpdatedId = id;
+    if (updateError != null) throw updateError!;
+    return updateResult ?? _bookFromPayload(id, payload);
+  }
+
+  @override
+  Future<void> deleteBook(String id) async {
+    deleteCalls++;
+    lastDeletedId = id;
+    if (deleteError != null) throw deleteError!;
+  }
+
+  Book _bookFromPayload(String id, AdminBookPayload p) => Book(
+        id: id,
+        title: p.title,
+        author: p.author,
+        category: p.category,
+        isbn: p.isbn,
+        description: p.description,
+        publicationYear: p.publicationYear,
+        quantity: p.quantity,
+        availableQuantity: p.availableQuantity,
+        coverImageUrl: p.coverImageUrl,
+        createdAt: DateTime(2024, 1, 1),
+        updatedAt: DateTime(2024, 1, 1),
+      );
+}
+
+Book makeAdminBook({
+  String id = 'b1',
+  String title = '테스트 도서',
+  String author = '저자',
+  String category = 'Programming',
+  int quantity = 3,
+  int availableQuantity = 3,
+}) {
+  return Book(
+    id: id,
+    title: title,
+    author: author,
+    category: category,
+    quantity: quantity,
+    availableQuantity: availableQuantity,
+    createdAt: DateTime(2024, 1, 1),
+    updatedAt: DateTime(2024, 1, 1),
+  );
+}


### PR DESCRIPTION
Closes #53

## 요약

MVP 게이트 2 (US4) 마지막 서브 게이트. PR #52 위에 카탈로그 CRUD 본체. 머지 시 **MVP 게이트 2 완료**, US4 P1 작업 일단락.

## 변경 (+1273 / -30)

### 신규 (lib/features/admin_catalog/)

**도메인 + 데이터**
- \`domain/repositories/admin_book_repository.dart\` — 인터페이스, \`AdminBookPayload\`, \`BookInUseException\` (409), \`BookConflictException\`
- \`data/repositories/admin_book_repository_impl.dart\` — Dio + 인터셉터로 admin 토큰 자동 주입. 자체 Dio 인스턴스로 학생 인터셉터 격리

**BLoC**
- \`presentation/bloc/admin_book_{bloc,event,state}.dart\` — Load/Create/Update/Delete 4 핸들러, \`AdminBookActionStatus\` enum (idle / inProgress / success / failure / blockedByActiveUsage)

**UI**
- \`presentation/screens/catalog_management_screen.dart\` (T089) — ListView 도서 목록, FAB로 추가, 행마다 편집/삭제, 새로고침, 액션 결과 SnackBar
- \`presentation/widgets/book_form_widget.dart\` (T085, T091) — 추가/편집 공용 폼 + 검증
- \`presentation/widgets/delete_confirmation_dialog.dart\` (T086, T092) — 삭제 확인 + 활성 대출 사전 안내

### 변경
- \`core/routes/app_router.dart\` — placeholder → 실제 \`CatalogManagementScreen\` 교체
- \`admin_dashboard_screen.dart\` — placeholder 클래스 삭제 (dead code)

### 테스트
- \`bloc/admin_book_bloc_test.dart\` — 6건 (load 성공/실패, create/update/delete 성공, delete 시 활성 대출 차단)
- \`widgets/book_form_widget_test.dart\` (T066/T085/T091) — 5건 (필수 검증, ISBN 형식, available > quantity, 유효 제출, 편집 prefill)
- \`test/support/fake_admin_book_repository.dart\` — fake + \`makeAdminBook\` 팩토리

## 검증 (폼)

- 필수: 제목, 저자, 카테고리
- 총 수량: ≥ 1
- 대출 가능 수량: 0 ~ 총 수량
- ISBN: optional, 입력 시 10 또는 13자리 숫자
- 발행연도: optional, 1000 ~ 현재년+1

## 알려진 한계 (별도 후속 이슈)

- **학생 BookListScreen은 여전히 mock 데이터** → 어드민이 추가한 책이 학생 화면에 안 나타남. 실제 API 연동(T061 재개)은 별도 통합 task.
- **페이지네이션 UI 없음** (limit=200 일괄 조회). MVP 이후 추가.
- **검색/필터 없음** in admin catalog. MVP 이후.
- **T067 통합 테스트** 미작성. Docker + 실 백엔드 필요. 별도 사이클.

## 수동 검증 시나리오

```bash
make up && make db-migrate
# 브라우저: http://localhost:8080/#/admin/login
# admin / admin123 로그인
# 사이드바 → 도서 관리 → CatalogManagementScreen
# FAB "도서 추가" → 폼 입력 → 추가 → 목록 갱신
# 행 편집 아이콘 → 폼(prefill) → 수정 → 목록 갱신
# 행 삭제 아이콘 → 확인 → 삭제 → 목록 갱신
# 활성 대출 있는 책 삭제 시도 → 409 → "삭제할 수 없습니다" SnackBar
```

## 헌법 준수

- [x] II/III/IV/XIII
- [ ] XVI. 로컬 검증 — Flutter CI

## Test Plan

- [ ] CI green
- [ ] AdminBookBloc 6건 + BookFormWidget 5건 PASS
- [ ] 학생 \`/\`, \`/books/:id\` 무변화
- [ ] PR #52의 로그인/가드 동작 무변화
- [ ] 수동 시나리오 7단계 통과