### PR TITLE
[Release #57] v0.2.0 MVP — 버전 범프 + CI iOS/Android 활성화

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,57 +61,56 @@ jobs:
         with:
           files: ./coverage/lcov.info
 
-  # Android/iOS 빌드는 MVP 완성 후 활성화 (Constitution v1.10.0)
-  # MVP 개발 단계에서는 로컬 검증 필수, CI/CD는 Web만 수행
-  # TODO: v0.1.0 릴리스 후 아래 주석 해제
-  
-  # build-android:
-  #   name: Android 빌드
-  #   runs-on: ubuntu-latest
-  #   needs: test
-  #   if: github.event_name == 'push' && contains(github.ref, 'refs/tags/v')
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     
-  #     - name: Flutter 설정
-  #       uses: subosito/flutter-action@v2
-  #       with:
-  #         flutter-version: '3.24.0'
-  #         channel: 'stable'
-  #         cache: true
-  #     
-  #     - name: 의존성 설치
-  #       run: flutter pub get
-  #     
-  #     - name: Android APK 빌드
-  #       run: flutter build apk --release
-  #     
-  #     - name: 빌드 산출물 업로드
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: android-apk
-  #         path: build/app/outputs/flutter-apk/app-release.apk
+  # Android/iOS 빌드: v0.2.0 MVP 릴리스 후 활성화 (Constitution v1.10.0).
+  # 태그 푸시 시에만 실행하여 PR/일반 푸시 피드백 시간을 보호.
 
-  # build-ios:
-  #   name: iOS 빌드
-  #   runs-on: macos-latest
-  #   needs: test
-  #   if: github.event_name == 'push' && contains(github.ref, 'refs/tags/v')
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     
-  #     - name: Flutter 설정
-  #       uses: subosito/flutter-action@v2
-  #       with:
-  #         flutter-version: '3.24.0'
-  #         channel: 'stable'
-  #         cache: true
-  #     
-  #     - name: 의존성 설치
-  #       run: flutter pub get
-  #     
-  #     - name: iOS 빌드 (서명 없이)
-  #       run: flutter build ios --release --no-codesign
+  build-android:
+    name: Android 빌드
+    runs-on: ubuntu-latest
+    needs: test
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Flutter 설정
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.24.0'
+          channel: 'stable'
+          cache: true
+
+      - name: 의존성 설치
+        run: flutter pub get
+
+      - name: Android APK 빌드
+        run: flutter build apk --release
+
+      - name: 빌드 산출물 업로드
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-apk
+          path: build/app/outputs/flutter-apk/app-release.apk
+
+  build-ios:
+    name: iOS 빌드
+    runs-on: macos-latest
+    needs: test
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Flutter 설정
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.24.0'
+          channel: 'stable'
+          cache: true
+
+      - name: 의존성 설치
+        run: flutter pub get
+
+      - name: iOS 빌드 (서명 없이)
+        run: flutter build ios --release --no-codesign
 
   build-web:
     name: Web 빌드

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "42lib-backend",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "42 Learning Space Library Management System - Backend API",
   "main": "src/server.ts",
   "scripts": {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lib_42_flutter
 description: 42 Learning Space Library Management System - Flutter App
 publish_to: 'none'
-version: 0.1.0+1
+version: 0.2.0+1
 
 environment:
   sdk: '>=3.0.0 <4.0.0'


### PR DESCRIPTION
Closes #57

## v0.2.0 MVP 릴리스

### 포함된 주요 기능 (이전 PR들에서 누적)

**MVP 게이트 1 — US1 도서 검색·열람 (28/31)**
- BookListScreen + BookBloc (feature-first, ADR 0001/0002)
- 검색 debounce 500ms, Grid/List 토글, 반응형 layout, pull-to-refresh
- 백엔드 GET /api/v1/books, /:id, ?title=, ?category=
- T034 repository, T035 BLoC, T038 widget, T039 integration 테스트
- T040/T041 백엔드 GET 엔드포인트 테스트

**MVP 게이트 2 — US4 관리자 카탈로그 관리 (28/29)**
- AdminLoginScreen → 가드된 \`/admin/*\` 라우트
- AdminDashboardScreen + AdminSidebar
- CatalogManagementScreen + BookFormWidget + DeleteConfirmationDialog
- AdminAuthBloc (bcrypt + JWT), AdminBookBloc (CRUD + 활성 대출 차단)
- 백엔드 POST /admin/login, POST/PUT/DELETE /books (admin 인증)

**통합 PR #56**
- 학생 BookRepository → BookHttpDataSource — 어드민 추가 도서가 학생 화면에 즉시 반영

**아키텍처 정착**
- ADR 0001: lib/ 조직 동결 (legacy + feature-first 공존 공식화)
- ADR 0002: 도서 도메인도 BLoC, lib/features/admin_catalog/ 신규
- main 브랜치 신설로 Constitution II 정합

### 본 PR 변경

- \`pubspec.yaml\`: 0.1.0+1 → 0.2.0+1
- \`backend/package.json\`: 0.1.0 → 0.2.0
- \`.github/workflows/ci.yml\`: \`build-android\`, \`build-ios\` 주석 해제. 트리거는 \`refs/tags/v*\` 푸시 시에만

### 머지 후 작업 순서

1. 본 PR \`release/0.2.0\` → \`main\` 머지
2. \`main\` 에 \`v0.2.0\` 태그 (CI에서 iOS/Android 빌드 트리거됨)
3. \`main\` → \`dev\` 백머지 (버전 범프 동기화)
4. \`v0.2.0 - MVP\` 마일스톤 닫기

### 알려진 후속 (v0.2.1 또는 별도 사이클)

- T063 학생 페이지네이션 UI (BookBloc \`LoadMoreBooks\` 이미 지원)
- T067 admin 통합 테스트 (Docker + 실 백엔드 필요)
- T061 SQLite 오프라인 캐시
- 80% 커버리지 측정 게이트
- 모바일 baseUrl 환경별 분기 (현재 \`localhost\` 하드코딩)

### 헌법 준수

- [x] II. Branch Strategy — \`main\` 신설 + \`release/*\` 사용
- [x] III. Issue-Driven Commits
- [x] IV. 한글 문서화
- [x] XIII. 명확한 PR 제목
- [x] XVI. 로컬 검증 — Flutter CI

### Test Plan

- [ ] CI green (analyze, format, test, web build)
- [ ] 머지 후 main 태그 v0.2.0 → mobile build job 실행
- [ ] 태그 후 main → dev 백머지
- [ ] v0.2.0 - MVP 마일스톤 닫기