### PR TITLE
[Chore] v0.2.0 release back-merge: main → dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,57 +61,56 @@ jobs:
         with:
           files: ./coverage/lcov.info
 
-  # Android/iOS 빌드는 MVP 완성 후 활성화 (Constitution v1.10.0)
-  # MVP 개발 단계에서는 로컬 검증 필수, CI/CD는 Web만 수행
-  # TODO: v0.1.0 릴리스 후 아래 주석 해제
-  
-  # build-android:
-  #   name: Android 빌드
-  #   runs-on: ubuntu-latest
-  #   needs: test
-  #   if: github.event_name == 'push' && contains(github.ref, 'refs/tags/v')
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     
-  #     - name: Flutter 설정
-  #       uses: subosito/flutter-action@v2
-  #       with:
-  #         flutter-version: '3.24.0'
-  #         channel: 'stable'
-  #         cache: true
-  #     
-  #     - name: 의존성 설치
-  #       run: flutter pub get
-  #     
-  #     - name: Android APK 빌드
-  #       run: flutter build apk --release
-  #     
-  #     - name: 빌드 산출물 업로드
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: android-apk
-  #         path: build/app/outputs/flutter-apk/app-release.apk
+  # Android/iOS 빌드: v0.2.0 MVP 릴리스 후 활성화 (Constitution v1.10.0).
+  # 태그 푸시 시에만 실행하여 PR/일반 푸시 피드백 시간을 보호.
 
-  # build-ios:
-  #   name: iOS 빌드
-  #   runs-on: macos-latest
-  #   needs: test
-  #   if: github.event_name == 'push' && contains(github.ref, 'refs/tags/v')
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     
-  #     - name: Flutter 설정
-  #       uses: subosito/flutter-action@v2
-  #       with:
-  #         flutter-version: '3.24.0'
-  #         channel: 'stable'
-  #         cache: true
-  #     
-  #     - name: 의존성 설치
-  #       run: flutter pub get
-  #     
-  #     - name: iOS 빌드 (서명 없이)
-  #       run: flutter build ios --release --no-codesign
+  build-android:
+    name: Android 빌드
+    runs-on: ubuntu-latest
+    needs: test
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Flutter 설정
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.24.0'
+          channel: 'stable'
+          cache: true
+
+      - name: 의존성 설치
+        run: flutter pub get
+
+      - name: Android APK 빌드
+        run: flutter build apk --release
+
+      - name: 빌드 산출물 업로드
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-apk
+          path: build/app/outputs/flutter-apk/app-release.apk
+
+  build-ios:
+    name: iOS 빌드
+    runs-on: macos-latest
+    needs: test
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Flutter 설정
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.24.0'
+          channel: 'stable'
+          cache: true
+
+      - name: 의존성 설치
+        run: flutter pub get
+
+      - name: iOS 빌드 (서명 없이)
+        run: flutter build ios --release --no-codesign
 
   build-web:
     name: Web 빌드

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "42lib-backend",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "42 Learning Space Library Management System - Backend API",
   "main": "src/server.ts",
   "scripts": {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lib_42_flutter
 description: 42 Learning Space Library Management System - Flutter App
 publish_to: 'none'
-version: 0.1.0+1
+version: 0.2.0+1
 
 environment:
   sdk: '>=3.0.0 <4.0.0'


### PR DESCRIPTION
## 백머지

Constitution II / git-flow 표준에 따른 \`main\` → \`dev\` 백머지. v0.2.0 릴리스 PR (#58)이 main에 머지되면서 추가된 커밋을 dev로 동기화:

- \`a100f4f\` [#57] release: v0.2.0 버전 범프 + CI iOS/Android 활성화
- \`c66b461\` Merge pull request #58 from gdtknight/release/0.2.0

## 머지 방식

merge commit 사용 (squash 아님). 릴리스 머지 커밋의 history를 dev에서도 보존.

## 완료 후

- v0.2.0 - MVP 마일스톤 닫기
- 본 chore 브랜치 삭제