### PR TITLE
[Fix #60] CI 태그 v* 푸시 시 워크플로우 트리거 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [dev, main]
   push:
     branches: [dev, main]
+    tags: ['v*']
 
 jobs:
   analyze:


### PR DESCRIPTION
Closes #60

## 요약

v0.2.0 릴리스에서 발견한 워크플로우 트리거 누락 수정. 한 줄 변경.

## 변경

\`\`\`diff
 on:
   pull_request:
     branches: [dev, main]
   push:
     branches: [dev, main]
+    tags: ['v*']
\`\`\`

## 검증 시점

다음 릴리스 태그 (예: \`v0.2.1\`) 푸시 시 \`build-android\`/\`build-ios\` job 실행 확인.