### PR TITLE
[Feature #62] T063 무한 스크롤 페이지네이션 + 모바일 baseUrl 분기

### DIFF
--- a/lib/app/config.dart
+++ b/lib/app/config.dart
@@ -1,7 +1,22 @@
 /// 환경 설정 관리
 class AppConfig {
   static const String appName = '42lib';
-  static const String apiBaseUrl = 'http://localhost:3000/api';
+
+  /// 백엔드 API base URL.
+  ///
+  /// 빌드 시 `--dart-define=API_BASE_URL=...` 로 override 가능.
+  /// 기본값은 웹 개발 환경 (호스트의 localhost:3000).
+  ///
+  /// 예시:
+  /// - Web/iOS Simulator: 기본값 사용
+  /// - Android Emulator: `--dart-define=API_BASE_URL=http://10.0.2.2:3000/api`
+  /// - 실 디바이스: `--dart-define=API_BASE_URL=http://<host-ip>:3000/api`
+  /// - Production: `--dart-define=API_BASE_URL=https://api.example.com/api`
+  static const String apiBaseUrl = String.fromEnvironment(
+    'API_BASE_URL',
+    defaultValue: 'http://localhost:3000/api',
+  );
+
   static const String oauth42AuthUrl =
       'https://api.intra.42.fr/oauth/authorize';
   static const String oauth42TokenUrl = 'https://api.intra.42.fr/oauth/token';

--- a/lib/features/books/presentation/screens/book_list_screen.dart
+++ b/lib/features/books/presentation/screens/book_list_screen.dart
@@ -45,6 +45,10 @@ class _BookListViewState extends State<_BookListView> {
     setState(() => _isGridView = !_isGridView);
   }
 
+  void _loadMore(BuildContext context) {
+    context.read<BookBloc>().add(const LoadMoreBooks());
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -95,12 +99,23 @@ class _BookListViewState extends State<_BookListView> {
       if (state.books.isEmpty) {
         return _EmptyView(searchQuery: state.searchQuery);
       }
+      final onLoadMore = () => _loadMore(context);
       return RefreshIndicator(
         onRefresh: () async =>
             context.read<BookBloc>().add(const RefreshBooks()),
         child: _isGridView
-            ? _BookGrid(books: state.books, onTap: _onBookTap)
-            : _BookList(books: state.books, onTap: _onBookTap),
+            ? _BookGrid(
+                books: state.books,
+                hasMore: state.hasMore,
+                onTap: _onBookTap,
+                onLoadMore: onLoadMore,
+              )
+            : _BookList(
+                books: state.books,
+                hasMore: state.hasMore,
+                onTap: _onBookTap,
+                onLoadMore: onLoadMore,
+              ),
       );
     }
 
@@ -181,11 +196,69 @@ class _EmptyView extends StatelessWidget {
   }
 }
 
-class _BookGrid extends StatelessWidget {
-  final List<Book> books;
-  final void Function(Book) onTap;
+/// Mixin for the grid/list views to share infinite-scroll pagination wiring.
+/// Triggers [onLoadMore] when the user scrolls within [_loadMoreThreshold]
+/// pixels of the bottom AND a new page is available AND we haven't already
+/// triggered for the current item count.
+mixin _PaginationMixin<W extends StatefulWidget> on State<W> {
+  static const double _loadMoreThreshold = 200;
 
-  const _BookGrid({required this.books, required this.onTap});
+  late final ScrollController _scrollController;
+  int _lastTriggerCount = 0;
+
+  bool get hasMore;
+  int get itemCount;
+  VoidCallback get onLoadMore;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController = ScrollController()..addListener(_onScroll);
+  }
+
+  @override
+  void dispose() {
+    _scrollController
+      ..removeListener(_onScroll)
+      ..dispose();
+    super.dispose();
+  }
+
+  void _onScroll() {
+    if (!hasMore) return;
+    if (!_scrollController.hasClients) return;
+    final position = _scrollController.position;
+    if (position.pixels < position.maxScrollExtent - _loadMoreThreshold) return;
+    if (itemCount <= _lastTriggerCount) return;
+    _lastTriggerCount = itemCount;
+    onLoadMore();
+  }
+}
+
+class _BookGrid extends StatefulWidget {
+  final List<Book> books;
+  final bool hasMore;
+  final void Function(Book) onTap;
+  final VoidCallback onLoadMore;
+
+  const _BookGrid({
+    required this.books,
+    required this.hasMore,
+    required this.onTap,
+    required this.onLoadMore,
+  });
+
+  @override
+  State<_BookGrid> createState() => _BookGridState();
+}
+
+class _BookGridState extends State<_BookGrid> with _PaginationMixin<_BookGrid> {
+  @override
+  bool get hasMore => widget.hasMore;
+  @override
+  int get itemCount => widget.books.length;
+  @override
+  VoidCallback get onLoadMore => widget.onLoadMore;
 
   int _getCrossAxisCount(BuildContext context) {
     final width = MediaQuery.of(context).size.width;
@@ -198,6 +271,7 @@ class _BookGrid extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return GridView.builder(
+      controller: _scrollController,
       padding: const EdgeInsets.all(16),
       gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
         crossAxisCount: _getCrossAxisCount(context),
@@ -205,33 +279,63 @@ class _BookGrid extends StatelessWidget {
         crossAxisSpacing: 16,
         mainAxisSpacing: 16,
       ),
-      itemCount: books.length,
+      itemCount: widget.books.length,
       itemBuilder: (context, index) => BookCard(
-        book: books[index],
-        onTap: () => onTap(books[index]),
+        book: widget.books[index],
+        onTap: () => widget.onTap(widget.books[index]),
       ),
     );
   }
 }
 
-class _BookList extends StatelessWidget {
+class _BookList extends StatefulWidget {
   final List<Book> books;
+  final bool hasMore;
   final void Function(Book) onTap;
+  final VoidCallback onLoadMore;
 
-  const _BookList({required this.books, required this.onTap});
+  const _BookList({
+    required this.books,
+    required this.hasMore,
+    required this.onTap,
+    required this.onLoadMore,
+  });
+
+  @override
+  State<_BookList> createState() => _BookListState();
+}
+
+class _BookListState extends State<_BookList> with _PaginationMixin<_BookList> {
+  @override
+  bool get hasMore => widget.hasMore;
+  @override
+  int get itemCount => widget.books.length;
+  @override
+  VoidCallback get onLoadMore => widget.onLoadMore;
 
   @override
   Widget build(BuildContext context) {
+    final showSpinner = widget.hasMore;
+    final listLength = widget.books.length + (showSpinner ? 1 : 0);
     return ListView.builder(
+      controller: _scrollController,
       padding: const EdgeInsets.all(16),
-      itemCount: books.length,
-      itemBuilder: (context, index) => Padding(
-        padding: const EdgeInsets.only(bottom: 16),
-        child: BookCard(
-          book: books[index],
-          onTap: () => onTap(books[index]),
-        ),
-      ),
+      itemCount: listLength,
+      itemBuilder: (context, index) {
+        if (index >= widget.books.length) {
+          return const Padding(
+            padding: EdgeInsets.symmetric(vertical: 16),
+            child: Center(child: CircularProgressIndicator()),
+          );
+        }
+        return Padding(
+          padding: const EdgeInsets.only(bottom: 16),
+          child: BookCard(
+            book: widget.books[index],
+            onTap: () => widget.onTap(widget.books[index]),
+          ),
+        );
+      },
     );
   }
 }

--- a/specs/001-library-management/tasks.md
+++ b/specs/001-library-management/tasks.md
@@ -130,7 +130,7 @@
 - [X] T060 [US1] Add search debouncing (500ms) to SearchBar widget
 - [ ] T061 [US1] Implement offline caching for book catalog in BookRepository *(PR #55로 BookHttpDataSource 도입 — 학생도 실 API 사용. 오프라인 SQLite 캐시는 여전히 미구현, 별도 후속)*
 - [X] T062 [US1] Add loading states and error handling to BookListScreen
-- [ ] T063 [US1] Add pagination for book list (20 books per page)
+- [X] T063 [US1] Add pagination for book list (20 books per page) *(BookListScreen에 ScrollController + _PaginationMixin로 무한 스크롤. BookBloc.LoadMoreBooks 디스패치. 검색/필터 페이지네이션은 후속 — 백엔드 searchBooks API에 page 파라미터 부재)*
 
 **Checkpoint**: User Story 1 complete - students can browse and search books independently
 


### PR DESCRIPTION
Closes #62

## 요약

v0.2.1 패치 후보 두 항목.

## 변경

### T063 페이지네이션 (+109 / -19)
- \`_BookGrid\`/\`_BookList\` → StatefulWidget + \`_PaginationMixin\`
- ScrollController로 끝-200px 임계점 감지. \`itemCount > _lastTriggerCount\` 가드로 중복 디스패치 방지
- ListView 모드에선 끝 spinner 표시 (\`hasMore\` 동안)
- BookBloc.LoadMoreBooks 흐름 활용 (이미 구현됨)

### AppConfig.apiBaseUrl 환경 변수 (+15 / -2)
\`\`\`diff
- static const String apiBaseUrl = 'http://localhost:3000/api';
+ static const String apiBaseUrl = String.fromEnvironment(
+   'API_BASE_URL',
+   defaultValue: 'http://localhost:3000/api',
+ );
\`\`\`

빌드 예시:
- Android 에뮬레이터: \`flutter build apk --dart-define=API_BASE_URL=http://10.0.2.2:3000/api\`
- 실 디바이스: \`--dart-define=API_BASE_URL=http://<host-ip>:3000/api\`
- Production: \`--dart-define=API_BASE_URL=https://api.example.com/api\`

## 한계 (별도 후속)

- **검색/필터 페이지네이션**: 백엔드 \`searchBooks\` API에 page 파라미터 부재. 본 PR 페이지네이션은 무필터 일반 목록에서만 작동.
- **위젯 테스트 추가 안 함**: 스크롤 position 시뮬레이션이 헤드리스 테스트에서 까다로움. 통합 테스트 또는 별도 사이클로 검증 권장.

## v0.2.1 릴리스 흐름

본 PR 머지 후:
1. \`release/0.2.1\` 브랜치 생성, 버전 범프
2. \`release/0.2.1\` → \`main\` PR
3. \`v0.2.1\` 태그 → CI iOS/Android 빌드 트리거 검증 (#60 fix 효력)
4. \`main\` → \`dev\` 백머지

## Test Plan

- [ ] CI green (analyze/format/test/web build)
- [ ] 학생 화면에서 시드 도서 6권 표시 (제한적)
- [ ] 어드민으로 책 25권 추가 후 학생 화면 새로고침 → 첫 20권 표시, 스크롤 끝까지 → 추가 5권 로드
- [ ] 어드민 화면 동작 무영향