### PR TITLE
[Release #64] v0.2.1 패치

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [dev, main]
   push:
     branches: [dev, main]
+    tags: ['v*']
 
 jobs:
   analyze:

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "42lib-backend",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "42 Learning Space Library Management System - Backend API",
   "main": "src/server.ts",
   "scripts": {

--- a/lib/app/config.dart
+++ b/lib/app/config.dart
@@ -1,7 +1,22 @@
 /// 환경 설정 관리
 class AppConfig {
   static const String appName = '42lib';
-  static const String apiBaseUrl = 'http://localhost:3000/api';
+
+  /// 백엔드 API base URL.
+  ///
+  /// 빌드 시 `--dart-define=API_BASE_URL=...` 로 override 가능.
+  /// 기본값은 웹 개발 환경 (호스트의 localhost:3000).
+  ///
+  /// 예시:
+  /// - Web/iOS Simulator: 기본값 사용
+  /// - Android Emulator: `--dart-define=API_BASE_URL=http://10.0.2.2:3000/api`
+  /// - 실 디바이스: `--dart-define=API_BASE_URL=http://<host-ip>:3000/api`
+  /// - Production: `--dart-define=API_BASE_URL=https://api.example.com/api`
+  static const String apiBaseUrl = String.fromEnvironment(
+    'API_BASE_URL',
+    defaultValue: 'http://localhost:3000/api',
+  );
+
   static const String oauth42AuthUrl =
       'https://api.intra.42.fr/oauth/authorize';
   static const String oauth42TokenUrl = 'https://api.intra.42.fr/oauth/token';

--- a/lib/features/books/presentation/screens/book_list_screen.dart
+++ b/lib/features/books/presentation/screens/book_list_screen.dart
@@ -45,6 +45,10 @@ class _BookListViewState extends State<_BookListView> {
     setState(() => _isGridView = !_isGridView);
   }
 
+  void _loadMore(BuildContext context) {
+    context.read<BookBloc>().add(const LoadMoreBooks());
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -95,12 +99,23 @@ class _BookListViewState extends State<_BookListView> {
       if (state.books.isEmpty) {
         return _EmptyView(searchQuery: state.searchQuery);
       }
+      final onLoadMore = () => _loadMore(context);
       return RefreshIndicator(
         onRefresh: () async =>
             context.read<BookBloc>().add(const RefreshBooks()),
         child: _isGridView
-            ? _BookGrid(books: state.books, onTap: _onBookTap)
-            : _BookList(books: state.books, onTap: _onBookTap),
+            ? _BookGrid(
+                books: state.books,
+                hasMore: state.hasMore,
+                onTap: _onBookTap,
+                onLoadMore: onLoadMore,
+              )
+            : _BookList(
+                books: state.books,
+                hasMore: state.hasMore,
+                onTap: _onBookTap,
+                onLoadMore: onLoadMore,
+              ),
       );
     }
 
@@ -181,11 +196,69 @@ class _EmptyView extends StatelessWidget {
   }
 }
 
-class _BookGrid extends StatelessWidget {
-  final List<Book> books;
-  final void Function(Book) onTap;
+/// Mixin for the grid/list views to share infinite-scroll pagination wiring.
+/// Triggers [onLoadMore] when the user scrolls within [_loadMoreThreshold]
+/// pixels of the bottom AND a new page is available AND we haven't already
+/// triggered for the current item count.
+mixin _PaginationMixin<W extends StatefulWidget> on State<W> {
+  static const double _loadMoreThreshold = 200;
 
-  const _BookGrid({required this.books, required this.onTap});
+  late final ScrollController _scrollController;
+  int _lastTriggerCount = 0;
+
+  bool get hasMore;
+  int get itemCount;
+  VoidCallback get onLoadMore;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController = ScrollController()..addListener(_onScroll);
+  }
+
+  @override
+  void dispose() {
+    _scrollController
+      ..removeListener(_onScroll)
+      ..dispose();
+    super.dispose();
+  }
+
+  void _onScroll() {
+    if (!hasMore) return;
+    if (!_scrollController.hasClients) return;
+    final position = _scrollController.position;
+    if (position.pixels < position.maxScrollExtent - _loadMoreThreshold) return;
+    if (itemCount <= _lastTriggerCount) return;
+    _lastTriggerCount = itemCount;
+    onLoadMore();
+  }
+}
+
+class _BookGrid extends StatefulWidget {
+  final List<Book> books;
+  final bool hasMore;
+  final void Function(Book) onTap;
+  final VoidCallback onLoadMore;
+
+  const _BookGrid({
+    required this.books,
+    required this.hasMore,
+    required this.onTap,
+    required this.onLoadMore,
+  });
+
+  @override
+  State<_BookGrid> createState() => _BookGridState();
+}
+
+class _BookGridState extends State<_BookGrid> with _PaginationMixin<_BookGrid> {
+  @override
+  bool get hasMore => widget.hasMore;
+  @override
+  int get itemCount => widget.books.length;
+  @override
+  VoidCallback get onLoadMore => widget.onLoadMore;
 
   int _getCrossAxisCount(BuildContext context) {
     final width = MediaQuery.of(context).size.width;
@@ -198,6 +271,7 @@ class _BookGrid extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return GridView.builder(
+      controller: _scrollController,
       padding: const EdgeInsets.all(16),
       gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
         crossAxisCount: _getCrossAxisCount(context),
@@ -205,33 +279,63 @@ class _BookGrid extends StatelessWidget {
         crossAxisSpacing: 16,
         mainAxisSpacing: 16,
       ),
-      itemCount: books.length,
+      itemCount: widget.books.length,
       itemBuilder: (context, index) => BookCard(
-        book: books[index],
-        onTap: () => onTap(books[index]),
+        book: widget.books[index],
+        onTap: () => widget.onTap(widget.books[index]),
       ),
     );
   }
 }
 
-class _BookList extends StatelessWidget {
+class _BookList extends StatefulWidget {
   final List<Book> books;
+  final bool hasMore;
   final void Function(Book) onTap;
+  final VoidCallback onLoadMore;
 
-  const _BookList({required this.books, required this.onTap});
+  const _BookList({
+    required this.books,
+    required this.hasMore,
+    required this.onTap,
+    required this.onLoadMore,
+  });
+
+  @override
+  State<_BookList> createState() => _BookListState();
+}
+
+class _BookListState extends State<_BookList> with _PaginationMixin<_BookList> {
+  @override
+  bool get hasMore => widget.hasMore;
+  @override
+  int get itemCount => widget.books.length;
+  @override
+  VoidCallback get onLoadMore => widget.onLoadMore;
 
   @override
   Widget build(BuildContext context) {
+    final showSpinner = widget.hasMore;
+    final listLength = widget.books.length + (showSpinner ? 1 : 0);
     return ListView.builder(
+      controller: _scrollController,
       padding: const EdgeInsets.all(16),
-      itemCount: books.length,
-      itemBuilder: (context, index) => Padding(
-        padding: const EdgeInsets.only(bottom: 16),
-        child: BookCard(
-          book: books[index],
-          onTap: () => onTap(books[index]),
-        ),
-      ),
+      itemCount: listLength,
+      itemBuilder: (context, index) {
+        if (index >= widget.books.length) {
+          return const Padding(
+            padding: EdgeInsets.symmetric(vertical: 16),
+            child: Center(child: CircularProgressIndicator()),
+          );
+        }
+        return Padding(
+          padding: const EdgeInsets.only(bottom: 16),
+          child: BookCard(
+            book: widget.books[index],
+            onTap: () => widget.onTap(widget.books[index]),
+          ),
+        );
+      },
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lib_42_flutter
 description: 42 Learning Space Library Management System - Flutter App
 publish_to: 'none'
-version: 0.2.0+1
+version: 0.2.1+1
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/specs/001-library-management/tasks.md
+++ b/specs/001-library-management/tasks.md
@@ -130,7 +130,7 @@
 - [X] T060 [US1] Add search debouncing (500ms) to SearchBar widget
 - [ ] T061 [US1] Implement offline caching for book catalog in BookRepository *(PR #55로 BookHttpDataSource 도입 — 학생도 실 API 사용. 오프라인 SQLite 캐시는 여전히 미구현, 별도 후속)*
 - [X] T062 [US1] Add loading states and error handling to BookListScreen
-- [ ] T063 [US1] Add pagination for book list (20 books per page)
+- [X] T063 [US1] Add pagination for book list (20 books per page) *(BookListScreen에 ScrollController + _PaginationMixin로 무한 스크롤. BookBloc.LoadMoreBooks 디스패치. 검색/필터 페이지네이션은 후속 — 백엔드 searchBooks API에 page 파라미터 부재)*
 
 **Checkpoint**: User Story 1 complete - students can browse and search books independently
 


### PR DESCRIPTION
Closes #64

## v0.2.1 패치 릴리스

### 포함 변경

- **PR #61** ([Fix #60]): \`ci.yml\` 에 \`tags: ['v*']\` 푸시 트리거 추가 — v0.2.0 릴리스에서 발견된 워크플로우 누락 수정
- **PR #63** ([Feature #62]): T063 학생 무한 스크롤 페이지네이션 + \`AppConfig.apiBaseUrl\` \`--dart-define\` override 지원

### 본 PR 변경

- \`pubspec.yaml\`: 0.2.0+1 → 0.2.1+1
- \`backend/package.json\`: 0.2.0 → 0.2.1

### 핵심 검증 포인트

머지 + \`v0.2.1\` 태그 푸시 후 GitHub Actions에서 **\`build-android\` 와 \`build-ios\` job이 실제로 실행됨** (v0.2.0에선 트리거 누락으로 skip됨). 이번 릴리스가 #60 수정의 종단 검증.

### 후속

- 백머지 \`main\` → \`dev\`
- 모바일 빌드 검증 결과 본 이슈에 코멘트