### PR TITLE
[Chore] v0.2.1 release back-merge: main → dev

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "42lib-backend",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "42 Learning Space Library Management System - Backend API",
   "main": "src/server.ts",
   "scripts": {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lib_42_flutter
 description: 42 Learning Space Library Management System - Flutter App
 publish_to: 'none'
-version: 0.2.0+1
+version: 0.2.1+1
 
 environment:
   sdk: '>=3.0.0 <4.0.0'


### PR DESCRIPTION
## 백머지

v0.2.1 릴리스 PR (#65) 머지 후 main → dev 동기화. 추가 커밋:
- \`e51660a\` [#64] release: v0.2.1 버전 범프
- \`7df3779\` Merge pull request #65 from gdtknight/release/0.2.1

## #60 검증 결과

✅ \`v0.2.1\` 태그 푸시 시 워크플로우 트리거됨 (\`run id 25031848510\` in_progress).
v0.2.0에선 트리거조차 안 됐던 것과 대조 — \`tags: ['v*']\` 추가가 정상 작동.
\`build-android\`/\`build-ios\` job 결과는 본 PR 머지 후 별도 확인.