### PR TITLE
[Fix #67] win32 ^5.5.0 override로 Android Dart 3.5 호환

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,6 +50,12 @@ dev_dependencies:
   mockito: ^5.4.4
   build_runner: ^2.4.7
   json_serializable: ^6.7.1
+
+# Transitive dep override: win32 5.2.0 (pinned via flutter_secure_storage_windows)
+# uses UnmodifiableUint8ListView which was removed in Dart SDK 3.5. Force ≥5.5.0.
+# See: https://github.com/gdtknight/42lib-flutter/issues/67
+dependency_overrides:
+  win32: ^5.5.0
   
   # Linting
   flutter_lints: ^3.0.1


### PR DESCRIPTION
Closes #67 (부분: Android만, iOS는 별도)

## 변경

\`pubspec.yaml\` 에 \`dependency_overrides: win32: ^5.5.0\` 추가.

## 원인

\`win32 5.2.0\` 이 \`UnmodifiableUint8ListView\` 사용 → Dart SDK 3.5에서 제거됨 → Flutter 3.24의 Dart SDK가 3.5.x 라 컴파일 실패.

## 검증

- 본 PR CI: Web/analyze/test 영향 없음 확인 (win32는 모바일 platform 전용)
- 머지 후 \`release/0.2.2\` → \`v0.2.2\` 태그 푸시 시 \`build-android\` job 통과 종단 검증

## 한계

- iOS 빌드 실패는 별개 (서명/Xcode 관련), 본 PR 범위 외 — #67 일부만 처리, 별도 이슈로 트래킹 가능
- \`pubspec.lock\` 은 Docker 환경 미가동으로 로컬 재생성 안 됨. CI 가 pub get 시 override 적용하므로 빌드 정상이지만, 향후 dev에서 \`flutter pub get\` 시 lock 갱신 필요할 수 있음