### PR TITLE
[Release #69] v0.2.2 패치 — Android 빌드 복구 (#67) 검증

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "42lib-backend",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "42 Learning Space Library Management System - Backend API",
   "main": "src/server.ts",
   "scripts": {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lib_42_flutter
 description: 42 Learning Space Library Management System - Flutter App
 publish_to: 'none'
-version: 0.2.1+1
+version: 0.2.2+1
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,6 +50,12 @@ dev_dependencies:
   mockito: ^5.4.4
   build_runner: ^2.4.7
   json_serializable: ^6.7.1
+
+# Transitive dep override: win32 5.2.0 (pinned via flutter_secure_storage_windows)
+# uses UnmodifiableUint8ListView which was removed in Dart SDK 3.5. Force ≥5.5.0.
+# See: https://github.com/gdtknight/42lib-flutter/issues/67
+dependency_overrides:
+  win32: ^5.5.0
   
   # Linting
   flutter_lints: ^3.0.1


### PR DESCRIPTION
Closes #69

## v0.2.2 패치

\`win32\` dep override (PR #68, #67) 효력 검증.

### 변경
- \`pubspec.yaml\`: 0.2.1+1 → 0.2.2+1
- \`backend/package.json\`: 0.2.1 → 0.2.2

### 머지 후

1. \`v0.2.2\` 태그 → CI \`build-android\` job 통과 기대 (이전 v0.2.1 fail)
2. \`build-ios\` 는 여전히 fail 예상 (별도 진단)
3. 백머지 main → dev