### PR TITLE
[Fix #67 v2] win32 범위 '>=5.5.0 <5.10.0' + flutter_lints 위치 정정

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,14 +51,16 @@ dev_dependencies:
   build_runner: ^2.4.7
   json_serializable: ^6.7.1
 
-# Transitive dep override: win32 5.2.0 (pinned via flutter_secure_storage_windows)
-# uses UnmodifiableUint8ListView which was removed in Dart SDK 3.5. Force ≥5.5.0.
-# See: https://github.com/gdtknight/42lib-flutter/issues/67
-dependency_overrides:
-  win32: ^5.5.0
-  
   # Linting
   flutter_lints: ^3.0.1
+
+# Transitive dep override: win32 5.2.0 (pinned via flutter_secure_storage_windows)
+# uses UnmodifiableUint8ListView (removed in Dart 3.5). Need ≥5.5.0.
+# But win32 5.10+ requires Dart 3.6+ language level (Flutter 3.24 = Dart 3.5).
+# Pin to range compatible with Dart 3.5: 5.5.x ~ 5.9.x.
+# See: https://github.com/gdtknight/42lib-flutter/issues/67
+dependency_overrides:
+  win32: '>=5.5.0 <5.10.0'
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
Closes #67 (Android 부분, 재시도)

## 배경

PR #68의 \`^5.5.0\` override가 win32 5.13.0까지 끌어오고, win32 5.10+은 Dart 3.6+ 요구. v0.2.2 태그 \`build-android\` 여전히 fail.

## 변경

\`\`\`diff
- win32: ^5.5.0
+ win32: '>=5.5.0 <5.10.0'
\`\`\`

추가로 PR #68 Edit가 의도치 않게 \`flutter_lints\`를 \`dependency_overrides\` 블록 아래로 이동시켰던 것을 원래 \`dev_dependencies\` 위치로 복구.

## 검증

머지 → release/0.2.3 → tag v0.2.3 → \`build-android\` 통과 검증. iOS는 여전히 별도 이슈.