### PR TITLE
[Fix #76] Docker dev env hygiene — env_file optional + flutter context + Flutter 3.24 + 42 OAuth lazy

### DIFF
--- a/backend/src/services/auth_42_service.ts
+++ b/backend/src/services/auth_42_service.ts
@@ -38,8 +38,17 @@ export class Auth42Service {
     this.clientSecret = process.env.FORTYTWO_CLIENT_SECRET || '';
     this.redirectUri = process.env.FORTYTWO_REDIRECT_URI || '';
 
+    // Don't throw at construction — let MVP/admin flows boot without 42 creds.
+    // Only the OAuth-using methods reject when creds are missing.
     if (!this.clientId || !this.clientSecret || !this.redirectUri) {
-      logger.error('42 OAuth credentials not configured');
+      logger.warn(
+        '42 OAuth credentials not configured. Student OAuth flows will be unavailable.',
+      );
+    }
+  }
+
+  private requireConfigured(): void {
+    if (!this.clientId || !this.clientSecret || !this.redirectUri) {
       throw new Error('42 OAuth configuration missing');
     }
   }
@@ -48,6 +57,7 @@ export class Auth42Service {
    * Generate authorization URL for OAuth flow
    */
   getAuthorizationUrl(state?: string): string {
+    this.requireConfigured();
     const params = new URLSearchParams({
       client_id: this.clientId,
       redirect_uri: this.redirectUri,
@@ -63,6 +73,7 @@ export class Auth42Service {
    * Exchange authorization code for access token
    */
   async exchangeCodeForToken(code: string): Promise<TokenResponse> {
+    this.requireConfigured();
     try {
       const response = await axios.post<TokenResponse>(
         this.tokenUrl,

--- a/docker/Dockerfile.flutter
+++ b/docker/Dockerfile.flutter
@@ -4,7 +4,7 @@ FROM ubuntu:22.04
 # 환경 변수 설정
 ENV DEBIAN_FRONTEND=noninteractive
 ENV FLUTTER_HOME=/opt/flutter
-ENV FLUTTER_VERSION=3.16.0
+ENV FLUTTER_VERSION=3.24.0
 ENV PATH="$FLUTTER_HOME/bin:$PATH"
 
 # 기본 도구 설치

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -71,8 +71,8 @@ services:
   # Flutter Development Environment
   flutter-dev:
     build:
-      context: .
-      dockerfile: Dockerfile.flutter
+      context: ..
+      dockerfile: docker/Dockerfile.flutter
     container_name: 42lib-flutter-dev
     depends_on:
       - backend-api

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -57,7 +57,10 @@ services:
       - DATABASE_URL=postgresql://library_user:library_pass@postgres-db:5432/library_db?schema=public
       - PORT=3000
     env_file:
-      - ../backend/.env
+      # backend/.env가 없어도 환경 블록의 기본값으로 동작.
+      # 42 OAuth 등 추가 변수 필요 시 cp backend/.env.example backend/.env
+      - path: ../backend/.env
+        required: false
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000/health"]
       interval: 30s


### PR DESCRIPTION
Closes #76

## 요약

새 클론 후 \`make up\` 으로 첫 시도 시 막히는 4가지 이슈 종합 수정. 로컬 검증 완료 (backend/frontend 모두 200).

## 수정 (4건)

### 1. \`docker/docker-compose.yml\` — env_file optional
\`\`\`diff
 env_file:
-  - ../backend/.env
+  - path: ../backend/.env
+    required: false
\`\`\`
backend/.env 부재해도 \`environment:\` 블록 기본값으로 동작.

### 2. \`docker/docker-compose.yml\` — flutter-dev build context 정정
\`\`\`diff
 flutter-dev:
   build:
-    context: .
-    dockerfile: Dockerfile.flutter
+    context: ..
+    dockerfile: docker/Dockerfile.flutter
\`\`\`
이전 context는 \`docker/\` 디렉토리라 \`COPY pubspec.yaml\` 실패.

### 3. \`docker/Dockerfile.flutter\` — Flutter 3.16 → 3.24
CI는 3.24.0 (Dart 3.5.x). 로컬도 정합. win32 override가 Dart 3.3+ 요구.

### 4. \`backend/src/services/auth_42_service.ts\` — 42 OAuth lazy 검증
생성자에서 throw → 모듈 로드 시 backend crash. 생성자는 warn만, OAuth 메서드 호출 시점에 \`requireConfigured()\` 검증.

## 로컬 검증

\`\`\`bash
$ make up
$ curl -o /dev/null -w "%{http_code}" http://localhost:3000/health
200
$ curl -o /dev/null -w "%{http_code}" http://localhost:8080
200
\`\`\`

## 새 개발자 시작 흐름

\`\`\`bash
git clone ...
cd 42lib-flutter
# (선택) cp backend/.env.example backend/.env  # OAuth 사용 시
make up
# → http://localhost:8080 (학생), http://localhost:8080/#/admin/login (관리자)
\`\`\`