### PR TITLE
[Release #78] v0.2.4 패치 — Docker dev env hygiene

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "42lib-backend",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "42 Learning Space Library Management System - Backend API",
   "main": "src/server.ts",
   "scripts": {

--- a/backend/src/services/auth_42_service.ts
+++ b/backend/src/services/auth_42_service.ts
@@ -38,8 +38,17 @@ export class Auth42Service {
     this.clientSecret = process.env.FORTYTWO_CLIENT_SECRET || '';
     this.redirectUri = process.env.FORTYTWO_REDIRECT_URI || '';
 
+    // Don't throw at construction — let MVP/admin flows boot without 42 creds.
+    // Only the OAuth-using methods reject when creds are missing.
     if (!this.clientId || !this.clientSecret || !this.redirectUri) {
-      logger.error('42 OAuth credentials not configured');
+      logger.warn(
+        '42 OAuth credentials not configured. Student OAuth flows will be unavailable.',
+      );
+    }
+  }
+
+  private requireConfigured(): void {
+    if (!this.clientId || !this.clientSecret || !this.redirectUri) {
       throw new Error('42 OAuth configuration missing');
     }
   }
@@ -48,6 +57,7 @@ export class Auth42Service {
    * Generate authorization URL for OAuth flow
    */
   getAuthorizationUrl(state?: string): string {
+    this.requireConfigured();
     const params = new URLSearchParams({
       client_id: this.clientId,
       redirect_uri: this.redirectUri,
@@ -63,6 +73,7 @@ export class Auth42Service {
    * Exchange authorization code for access token
    */
   async exchangeCodeForToken(code: string): Promise<TokenResponse> {
+    this.requireConfigured();
     try {
       const response = await axios.post<TokenResponse>(
         this.tokenUrl,

--- a/docker/Dockerfile.flutter
+++ b/docker/Dockerfile.flutter
@@ -4,7 +4,7 @@ FROM ubuntu:22.04
 # 환경 변수 설정
 ENV DEBIAN_FRONTEND=noninteractive
 ENV FLUTTER_HOME=/opt/flutter
-ENV FLUTTER_VERSION=3.16.0
+ENV FLUTTER_VERSION=3.24.0
 ENV PATH="$FLUTTER_HOME/bin:$PATH"
 
 # 기본 도구 설치

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -57,7 +57,10 @@ services:
       - DATABASE_URL=postgresql://library_user:library_pass@postgres-db:5432/library_db?schema=public
       - PORT=3000
     env_file:
-      - ../backend/.env
+      # backend/.env가 없어도 환경 블록의 기본값으로 동작.
+      # 42 OAuth 등 추가 변수 필요 시 cp backend/.env.example backend/.env
+      - path: ../backend/.env
+        required: false
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000/health"]
       interval: 30s
@@ -68,8 +71,8 @@ services:
   # Flutter Development Environment
   flutter-dev:
     build:
-      context: .
-      dockerfile: Dockerfile.flutter
+      context: ..
+      dockerfile: docker/Dockerfile.flutter
     container_name: 42lib-flutter-dev
     depends_on:
       - backend-api

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lib_42_flutter
 description: 42 Learning Space Library Management System - Flutter App
 publish_to: 'none'
-version: 0.2.3+1
+version: 0.2.4+1
 
 environment:
   sdk: '>=3.0.0 <4.0.0'


### PR DESCRIPTION
Closes #78

PR #77 (#76) Docker dev env hygiene 4건을 main으로 릴리스.

새 클론 후 `make up` 만으로 즉시 기동:
- env_file optional
- flutter-dev build context 정정
- Flutter 3.16 → 3.24 (CI 정합)
- Auth42Service lazy 검증

머지 후 v0.2.4 태그 → main → dev 백머지.