### PR TITLE
[Test #83] US2 백엔드 테스트 T099/T100/T101 + Jest TypeScript 셋업

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,18 @@
+/**
+ * Jest configuration for backend tests.
+ *
+ * Uses ts-jest preset so .ts test files (and TypeScript modules they import)
+ * are type-stripped at test time without a separate build step.
+ */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['<rootDir>/tests/**/*.test.ts'],
+  moduleFileExtensions: ['ts', 'js', 'json'],
+  // Keep tests serial — they share the live Postgres in dev compose and
+  // would race on shared rows otherwise.
+  maxWorkers: 1,
+  testTimeout: 30000,
+  // Server only opens an HTTP listener when NODE_ENV !== 'test'.
+  globalSetup: '<rootDir>/tests/jest.setup.js',
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -41,8 +41,11 @@
     "@types/jest": "^29.5.11",
     "@types/jsonwebtoken": "^9.0.5",
     "@types/node": "^20.10.6",
+    "@types/supertest": "^6.0.2",
     "jest": "^29.7.0",
     "prisma": "^5.7.0",
+    "supertest": "^7.0.0",
+    "ts-jest": "^29.1.1",
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.3.3"

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -46,13 +46,15 @@ app.get('/api/v1', (req, res) => {
 // 에러 핸들링 미들웨어 (마지막에 추가)
 app.use(errorHandler);
 
-// 서버 시작
-app.listen(PORT, () => {
-  logger.info(`🚀 Server running on port ${PORT}`);
-  logger.info(`📚 42lib Backend API v1`);
-  logger.info(`🔗 Health: http://localhost:${PORT}/health`);
-  logger.info(`🔗 API: http://localhost:${PORT}/api/v1`);
-});
+// 서버 시작 (테스트 환경에서는 listen 안 함 — supertest가 app 객체로 직접 호출)
+if (process.env.NODE_ENV !== 'test') {
+  app.listen(PORT, () => {
+    logger.info(`🚀 Server running on port ${PORT}`);
+    logger.info(`📚 42lib Backend API v1`);
+    logger.info(`🔗 Health: http://localhost:${PORT}/health`);
+    logger.info(`🔗 API: http://localhost:${PORT}/api/v1`);
+  });
+}
 
 // Graceful shutdown
 process.on('SIGTERM', async () => {

--- a/backend/tests/jest.setup.js
+++ b/backend/tests/jest.setup.js
@@ -1,0 +1,3 @@
+module.exports = async () => {
+  process.env.NODE_ENV = 'test';
+};

--- a/backend/tests/unit/auth_42.test.ts
+++ b/backend/tests/unit/auth_42.test.ts
@@ -1,0 +1,77 @@
+// T099: 42 OAuth Service tests
+// Verifies lazy credential validation: construction succeeds without env vars,
+// but OAuth methods throw when credentials are missing.
+
+describe('Auth42Service (T099)', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    // Restore env between tests so module re-imports see expected state.
+    process.env = { ...originalEnv };
+    jest.resetModules();
+  });
+
+  it('constructs without throwing when env vars are missing (lazy mode)', () => {
+    delete process.env.FORTYTWO_CLIENT_ID;
+    delete process.env.FORTYTWO_CLIENT_SECRET;
+    delete process.env.FORTYTWO_REDIRECT_URI;
+
+    jest.resetModules();
+    const { Auth42Service } = require('../../src/services/auth_42_service');
+    expect(() => new Auth42Service()).not.toThrow();
+  });
+
+  it('constructs without throwing when credentials are configured', () => {
+    process.env.FORTYTWO_CLIENT_ID = 'test-client-id';
+    process.env.FORTYTWO_CLIENT_SECRET = 'test-client-secret';
+    process.env.FORTYTWO_REDIRECT_URI = 'http://localhost:8080/auth/callback';
+
+    jest.resetModules();
+    const { Auth42Service } = require('../../src/services/auth_42_service');
+    expect(() => new Auth42Service()).not.toThrow();
+  });
+
+  it('getAuthorizationUrl throws when credentials missing', () => {
+    delete process.env.FORTYTWO_CLIENT_ID;
+    delete process.env.FORTYTWO_CLIENT_SECRET;
+    delete process.env.FORTYTWO_REDIRECT_URI;
+
+    jest.resetModules();
+    const { Auth42Service } = require('../../src/services/auth_42_service');
+    const service = new Auth42Service();
+
+    expect(() => service.getAuthorizationUrl()).toThrow(
+      '42 OAuth configuration missing',
+    );
+  });
+
+  it('getAuthorizationUrl returns 42 OAuth URL when configured', () => {
+    process.env.FORTYTWO_CLIENT_ID = 'test-client';
+    process.env.FORTYTWO_CLIENT_SECRET = 'test-secret';
+    process.env.FORTYTWO_REDIRECT_URI = 'http://localhost:8080/cb';
+
+    jest.resetModules();
+    const { Auth42Service } = require('../../src/services/auth_42_service');
+    const service = new Auth42Service();
+    const url = service.getAuthorizationUrl('state-xyz');
+
+    expect(url).toContain('https://api.intra.42.fr/oauth/authorize');
+    expect(url).toContain('client_id=test-client');
+    expect(url).toContain('redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Fcb');
+    expect(url).toContain('state=state-xyz');
+  });
+
+  it('exchangeCodeForToken rejects when credentials missing', async () => {
+    delete process.env.FORTYTWO_CLIENT_ID;
+    delete process.env.FORTYTWO_CLIENT_SECRET;
+    delete process.env.FORTYTWO_REDIRECT_URI;
+
+    jest.resetModules();
+    const { Auth42Service } = require('../../src/services/auth_42_service');
+    const service = new Auth42Service();
+
+    await expect(service.exchangeCodeForToken('code')).rejects.toThrow(
+      '42 OAuth configuration missing',
+    );
+  });
+});

--- a/backend/tests/unit/loan_requests.test.ts
+++ b/backend/tests/unit/loan_requests.test.ts
@@ -1,0 +1,173 @@
+// T100: POST /loan-requests integration tests
+
+import request from 'supertest';
+import { app } from '../../src/server';
+import { PrismaClient } from '@prisma/client';
+import { generateStudentToken } from '../../src/utils/jwt';
+
+const prisma = new PrismaClient();
+
+const STUDENT = {
+  fortytwoUserId: 999100,
+  username: 'lr_student',
+  email: 'lr_student@42.fr',
+  fullName: '대출 테스트 학생',
+};
+
+const BOOK_AVAILABLE = {
+  id: '00000000-0000-0000-0000-000000000a00',
+  title: '[T100] 사용 가능 도서',
+  author: 'T100 저자',
+  isbn: '9780000000a00',
+  category: 'Programming',
+  quantity: 2,
+  availableQuantity: 2,
+};
+
+const BOOK_UNAVAILABLE = {
+  id: '00000000-0000-0000-0000-000000000a01',
+  title: '[T100] 모두 대출 중',
+  author: 'T100 저자',
+  isbn: '9780000000a01',
+  category: 'Programming',
+  quantity: 1,
+  availableQuantity: 0,
+};
+
+async function cleanup(): Promise<void> {
+  await prisma.loanRequest.deleteMany({ where: { book: { title: { startsWith: '[T100]' } } } });
+  await prisma.reservation.deleteMany({ where: { book: { title: { startsWith: '[T100]' } } } });
+  await prisma.book.deleteMany({ where: { title: { startsWith: '[T100]' } } });
+  await prisma.student.deleteMany({ where: { username: STUDENT.username } });
+}
+
+describe('POST /api/v1/loan-requests (T100)', () => {
+  let studentId: string;
+  let token: string;
+
+  beforeAll(async () => {
+    await cleanup();
+    const student = await prisma.student.create({ data: STUDENT });
+    studentId = student.id;
+    await prisma.book.create({ data: BOOK_AVAILABLE });
+    await prisma.book.create({ data: BOOK_UNAVAILABLE });
+
+    token = generateStudentToken(
+      student.id,
+      student.username,
+      student.email,
+      student.fortytwoUserId,
+    );
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    await prisma.$disconnect();
+  });
+
+  beforeEach(async () => {
+    // Reset transactional rows between tests so duplicates don't bleed.
+    await prisma.loanRequest.deleteMany({ where: { studentId } });
+    await prisma.reservation.deleteMany({ where: { studentId } });
+  });
+
+  it('rejects anonymous request with 401', async () => {
+    await request(app)
+      .post('/api/v1/loan-requests')
+      .send({ bookId: BOOK_AVAILABLE.id })
+      .expect(401);
+  });
+
+  it('rejects admin token with 403', async () => {
+    const adminLikeToken = generateStudentToken(
+      'admin-id',
+      'admin-as-student',
+      'a@x',
+      0,
+    );
+    // Manually craft a token whose role isn't student — easier path:
+    // student tokens with role=student should pass; this test demonstrates
+    // that the route uses authenticateStudent. We assert with a non-student
+    // role by signing manually.
+    const jwt = require('jsonwebtoken');
+    const adminToken = jwt.sign(
+      {
+        userId: 'a',
+        username: 'a',
+        email: 'a@x',
+        role: 'admin',
+      },
+      process.env.JWT_SECRET || 'dev-secret-change-in-production',
+      { expiresIn: '1h' },
+    );
+
+    await request(app)
+      .post('/api/v1/loan-requests')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ bookId: BOOK_AVAILABLE.id })
+      .expect(403);
+
+    // adminLikeToken intentionally unused; kept above to document the role
+    // distinction.
+    expect(adminLikeToken).toEqual(expect.any(String));
+  });
+
+  it('returns 400 when bookId is missing', async () => {
+    const res = await request(app)
+      .post('/api/v1/loan-requests')
+      .set('Authorization', `Bearer ${token}`)
+      .send({})
+      .expect(400);
+    expect(res.body.error).toBe('Bad Request');
+  });
+
+  it('creates pending loan request when book is available (no reservation)', async () => {
+    const res = await request(app)
+      .post('/api/v1/loan-requests')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ bookId: BOOK_AVAILABLE.id })
+      .expect(201);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.status).toBe('pending');
+    expect(res.body.data.book.id).toBe(BOOK_AVAILABLE.id);
+
+    const reservationCount = await prisma.reservation.count({
+      where: { studentId, bookId: BOOK_AVAILABLE.id },
+    });
+    expect(reservationCount).toBe(0);
+  });
+
+  it('creates loan request AND reservation when book is unavailable', async () => {
+    const res = await request(app)
+      .post('/api/v1/loan-requests')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ bookId: BOOK_UNAVAILABLE.id })
+      .expect(201);
+
+    expect(res.body.data.status).toBe('pending');
+
+    const reservation = await prisma.reservation.findFirst({
+      where: { studentId, bookId: BOOK_UNAVAILABLE.id },
+    });
+    expect(reservation).not.toBeNull();
+    expect(reservation!.queuePosition).toBe(1);
+    expect(reservation!.status).toBe('waiting');
+  });
+
+  it('rejects duplicate pending request for same book (VR-205)', async () => {
+    await request(app)
+      .post('/api/v1/loan-requests')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ bookId: BOOK_AVAILABLE.id })
+      .expect(201);
+
+    const res = await request(app)
+      .post('/api/v1/loan-requests')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ bookId: BOOK_AVAILABLE.id })
+      .expect(400);
+
+    expect(res.body.message).toContain('이미');
+  });
+});

--- a/backend/tests/unit/reservations.test.ts
+++ b/backend/tests/unit/reservations.test.ts
@@ -1,0 +1,121 @@
+// T101: Reservation queue logic tests
+// Verifies FIFO queue position assignment per book.
+
+import request from 'supertest';
+import { app } from '../../src/server';
+import { PrismaClient } from '@prisma/client';
+import { generateStudentToken } from '../../src/utils/jwt';
+
+const prisma = new PrismaClient();
+
+const STUDENT_PREFIX = 'rsv_test_';
+
+const BOOK_FULL = {
+  id: '00000000-0000-0000-0000-000000000b00',
+  title: '[T101] 매진 도서',
+  author: 'T101 Author',
+  isbn: '9780000000b00',
+  category: 'Programming',
+  quantity: 1,
+  availableQuantity: 0,
+};
+
+async function cleanup(): Promise<void> {
+  await prisma.loanRequest.deleteMany({ where: { book: { title: { startsWith: '[T101]' } } } });
+  await prisma.reservation.deleteMany({ where: { book: { title: { startsWith: '[T101]' } } } });
+  await prisma.book.deleteMany({ where: { title: { startsWith: '[T101]' } } });
+  await prisma.student.deleteMany({ where: { username: { startsWith: STUDENT_PREFIX } } });
+}
+
+async function createStudent(suffix: string) {
+  const u = `${STUDENT_PREFIX}${suffix}`;
+  return prisma.student.create({
+    data: {
+      fortytwoUserId: 990000 + suffix.charCodeAt(0),
+      username: u,
+      email: `${u}@42.fr`,
+      fullName: `예약 학생 ${suffix}`,
+    },
+  });
+}
+
+function tokenFor(s: { id: string; username: string; email: string; fortytwoUserId: number }) {
+  return generateStudentToken(s.id, s.username, s.email, s.fortytwoUserId);
+}
+
+describe('Reservation queue (T101)', () => {
+  beforeAll(async () => {
+    await cleanup();
+    await prisma.book.create({ data: BOOK_FULL });
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    await prisma.$disconnect();
+  });
+
+  it('assigns increasing queue positions to sequential reservations', async () => {
+    // Three students each request the unavailable book → three reservations
+    // at positions 1, 2, 3 in arrival order.
+    const a = await createStudent('a');
+    const b = await createStudent('b');
+    const c = await createStudent('c');
+
+    await request(app)
+      .post('/api/v1/loan-requests')
+      .set('Authorization', `Bearer ${tokenFor(a)}`)
+      .send({ bookId: BOOK_FULL.id })
+      .expect(201);
+
+    await request(app)
+      .post('/api/v1/loan-requests')
+      .set('Authorization', `Bearer ${tokenFor(b)}`)
+      .send({ bookId: BOOK_FULL.id })
+      .expect(201);
+
+    await request(app)
+      .post('/api/v1/loan-requests')
+      .set('Authorization', `Bearer ${tokenFor(c)}`)
+      .send({ bookId: BOOK_FULL.id })
+      .expect(201);
+
+    const reservations = await prisma.reservation.findMany({
+      where: { bookId: BOOK_FULL.id },
+      orderBy: { queuePosition: 'asc' },
+      include: { student: { select: { username: true } } },
+    });
+
+    expect(reservations).toHaveLength(3);
+    expect(reservations.map((r) => r.queuePosition)).toEqual([1, 2, 3]);
+    expect(reservations.map((r) => r.student.username)).toEqual([
+      `${STUDENT_PREFIX}a`,
+      `${STUDENT_PREFIX}b`,
+      `${STUDENT_PREFIX}c`,
+    ]);
+    expect(reservations.every((r) => r.status === 'waiting')).toBe(true);
+  });
+
+  it('exposes student reservations via GET /api/v1/loan-requests/my/reservations', async () => {
+    const student = await prisma.student.findFirst({
+      where: { username: `${STUDENT_PREFIX}a` },
+    });
+    expect(student).not.toBeNull();
+
+    const token = tokenFor({
+      id: student!.id,
+      username: student!.username,
+      email: student!.email,
+      fortytwoUserId: student!.fortytwoUserId,
+    });
+
+    const res = await request(app)
+      .get('/api/v1/loan-requests/my/reservations')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(Array.isArray(res.body.data)).toBe(true);
+    expect(res.body.data.length).toBeGreaterThanOrEqual(1);
+    expect(res.body.data[0].queuePosition).toBe(1);
+  });
+});

--- a/specs/001-library-management/tasks.md
+++ b/specs/001-library-management/tasks.md
@@ -211,9 +211,9 @@
 - [ ] T096 [P] [US2] Create unit test for LoanBloc in test/unit_test/state/loan/loan_bloc_test.dart
 - [ ] T097 [P] [US2] Create widget test for loan request flow in test/widget_test/screens/mobile/loan/loan_request_test.dart
 - [ ] T098 [P] [US2] Create integration test for 42 OAuth flow in test/integration_test/auth_42_test.dart
-- [ ] T099 [P] [US2] Create backend unit test for 42 OAuth integration in backend/tests/unit/auth_42.test.ts
-- [ ] T100 [P] [US2] Create backend unit test for POST /loan-requests in backend/tests/unit/loan_requests.test.ts
-- [ ] T101 [P] [US2] Create backend unit test for reservation queue logic in backend/tests/unit/reservations.test.ts
+- [X] T099 [P] [US2] Create backend unit test for 42 OAuth integration in backend/tests/unit/auth_42.test.ts
+- [X] T100 [P] [US2] Create backend unit test for POST /loan-requests in backend/tests/unit/loan_requests.test.ts
+- [X] T101 [P] [US2] Create backend unit test for reservation queue logic in backend/tests/unit/reservations.test.ts
 
 ### Implementation for User Story 2
 


### PR DESCRIPTION
Closes #83

## 변경 (+407 / -10)

### 신규 테스트 (13건 PASS)
- T099 `auth_42.test.ts` — Auth42Service lazy init 5건
- T100 `loan_requests.test.ts` — POST /loan-requests 5건 (인증/검증/예약 분기)
- T101 `reservations.test.ts` — FIFO 큐 위치 3건

### 인프라
- `jest.config.js` — ts-jest preset, maxWorkers=1, globalSetup으로 NODE_ENV='test'
- `tests/jest.setup.js` — env 설정
- `package.json`: `ts-jest`, `supertest`, `@types/supertest` 추가
- `server.ts`: `if (NODE_ENV !== 'test')` 가드로 listen 분기 (테스트는 supertest로 app 직접 사용)

### 검증
`docker compose exec backend-api npx jest --testPathPattern="(auth_42|loan_requests|reservations)"` → 3 passed, 13 tests passed.

## 사전 발견된 별개 이슈 (본 PR 범위 외)
기존 `books.test.ts`/`books_admin.test.ts` 가 `/api/books` (v1 누락) 또는 사전 깨진 path 사용 → 별도 cleanup 후속.

tasks.md T099/T100/T101 [X].