### PR TITLE
[Test #85] US2 프론트 테스트 4건 + T128/T129 폴리시 인지

### DIFF
--- a/specs/001-library-management/tasks.md
+++ b/specs/001-library-management/tasks.md
@@ -205,11 +205,11 @@
 
 ### Tests for User Story 2
 
-- [ ] T093 [P] [US2] Create unit test for LoanRequest model in test/unit_test/models/loan_request_test.dart
+- [X] T093 [P] [US2] Create unit test for LoanRequest model in test/unit_test/models/loan_request_test.dart
 - [X] T094 [P] [US2] Create unit test for Reservation model in test/unit_test/models/reservation_test.dart
-- [ ] T095 [P] [US2] Create unit test for Student model in test/unit_test/models/student_test.dart
-- [ ] T096 [P] [US2] Create unit test for LoanBloc in test/unit_test/state/loan/loan_bloc_test.dart
-- [ ] T097 [P] [US2] Create widget test for loan request flow in test/widget_test/screens/mobile/loan/loan_request_test.dart
+- [X] T095 [P] [US2] Create unit test for Student model in test/unit_test/models/student_test.dart
+- [X] T096 [P] [US2] Create unit test for LoanBloc in test/unit_test/state/loan/loan_bloc_test.dart
+- [X] T097 [P] [US2] Create widget test for loan request flow in test/widget_test/screens/mobile/loan/loan_request_test.dart
 - [ ] T098 [P] [US2] Create integration test for 42 OAuth flow in test/integration_test/auth_42_test.dart
 - [X] T099 [P] [US2] Create backend unit test for 42 OAuth integration in backend/tests/unit/auth_42.test.ts
 - [X] T100 [P] [US2] Create backend unit test for POST /loan-requests in backend/tests/unit/loan_requests.test.ts
@@ -263,8 +263,8 @@
 
 **Integration & Polish**
 
-- [ ] T128 [US2] Implement graceful handling of 42 API failures with error messages
-- [ ] T129 [US2] Add loan request confirmation dialogs
+- [X] T128 [US2] Implement graceful handling of 42 API failures with error messages
+- [X] T129 [US2] Add loan request confirmation dialogs
 - [X] T130 [US2] Display reservation queue position in student profile
 - [ ] T131 [US2] Add offline queue for loan requests (sync when online)
 

--- a/test/support/fake_loan_repositories.dart
+++ b/test/support/fake_loan_repositories.dart
@@ -1,0 +1,153 @@
+import 'package:lib_42_flutter/models/loan_request.dart';
+import 'package:lib_42_flutter/models/reservation.dart';
+import 'package:lib_42_flutter/repositories/loan_request_repository.dart';
+import 'package:lib_42_flutter/repositories/reservation_repository.dart';
+
+/// Test fake for [LoanRequestRepository]. Override only the subset of methods
+/// LoanBloc actually invokes; remaining abstract methods fall through to
+/// [_unimplemented] which throws a clear test failure.
+class FakeLoanRequestRepository implements LoanRequestRepository {
+  Object? createReturnValue; // LoanRequest, Reservation, or Exception
+  List<LoanRequest> myLoanRequests = [];
+  Exception? error;
+  int createCalls = 0;
+  int cancelCalls = 0;
+  String? lastCancelledId;
+
+  @override
+  Future<dynamic> createLoanRequest({
+    required String bookId,
+    String? notes,
+  }) async {
+    createCalls++;
+    if (error != null) throw error!;
+    if (createReturnValue is Exception) throw createReturnValue as Exception;
+    return createReturnValue;
+  }
+
+  @override
+  Future<List<LoanRequest>> getMyLoanRequests() async {
+    if (error != null) throw error!;
+    return myLoanRequests;
+  }
+
+  @override
+  Future<void> cancelLoanRequest(String requestId) async {
+    cancelCalls++;
+    lastCancelledId = requestId;
+    if (error != null) throw error!;
+  }
+
+  Never _unimplemented(String name) =>
+      throw UnimplementedError('FakeLoanRequestRepository.$name not configured');
+
+  @override
+  Future<LoanRequest?> getLoanRequestById(String id) => _unimplemented('getLoanRequestById');
+  @override
+  Future<List<LoanRequest>> getStudentLoanRequests({
+    required String studentId,
+    LoanRequestStatus? status,
+    int page = 1,
+    int limit = 20,
+  }) =>
+      _unimplemented('getStudentLoanRequests');
+  @override
+  Future<List<LoanRequest>> getPendingLoanRequests({int page = 1, int limit = 20}) =>
+      _unimplemented('getPendingLoanRequests');
+  @override
+  Future<bool> hasPendingRequestForBook({
+    required String studentId,
+    required String bookId,
+  }) =>
+      _unimplemented('hasPendingRequestForBook');
+  @override
+  Future<void> syncWithApi() => _unimplemented('syncWithApi');
+}
+
+class FakeReservationRepository implements ReservationRepository {
+  List<Reservation> myReservations = [];
+  Map<String, List<Reservation>> queueByBookId = {};
+  Exception? error;
+  int cancelCalls = 0;
+
+  @override
+  Future<List<Reservation>> getMyReservations() async {
+    if (error != null) throw error!;
+    return myReservations;
+  }
+
+  @override
+  Future<List<Reservation>> getReservationQueue({required String bookId}) async {
+    if (error != null) throw error!;
+    return queueByBookId[bookId] ?? [];
+  }
+
+  @override
+  Future<void> cancelReservation(String reservationId) async {
+    cancelCalls++;
+    if (error != null) throw error!;
+  }
+
+  Never _unimplemented(String name) =>
+      throw UnimplementedError('FakeReservationRepository.$name not configured');
+
+  @override
+  Future<Reservation> createReservation({required String studentId, required String bookId}) =>
+      _unimplemented('createReservation');
+  @override
+  Future<Reservation?> getReservationById(String id) => _unimplemented('getReservationById');
+  @override
+  Future<List<Reservation>> getStudentReservations({
+    required String studentId,
+    ReservationStatus? status,
+    int page = 1,
+    int limit = 20,
+  }) =>
+      _unimplemented('getStudentReservations');
+  @override
+  Future<List<Reservation>> getBookReservations({
+    required String bookId,
+    bool onlyActive = true,
+  }) =>
+      _unimplemented('getBookReservations');
+  @override
+  Future<int?> getQueuePosition({required String studentId, required String bookId}) =>
+      _unimplemented('getQueuePosition');
+  @override
+  Future<bool> hasActiveReservationForBook({required String studentId, required String bookId}) =>
+      _unimplemented('hasActiveReservationForBook');
+  @override
+  Future<void> syncWithApi() => _unimplemented('syncWithApi');
+}
+
+LoanRequest makeLoanRequest({
+  String id = 'lr-1',
+  String studentId = 'stu-1',
+  String bookId = 'book-1',
+  LoanRequestStatus status = LoanRequestStatus.pending,
+}) {
+  return LoanRequest(
+    id: id,
+    studentId: studentId,
+    bookId: bookId,
+    status: status,
+    requestDate: DateTime(2024, 1, 1),
+  );
+}
+
+Reservation makeReservation({
+  String id = 'rsv-1',
+  String studentId = 'stu-1',
+  String bookId = 'book-1',
+  int queuePosition = 1,
+  ReservationStatus status = ReservationStatus.waiting,
+}) {
+  return Reservation(
+    id: id,
+    studentId: studentId,
+    bookId: bookId,
+    queuePosition: queuePosition,
+    status: status,
+    createdAt: DateTime(2024, 1, 1),
+  );
+}

--- a/test/unit_test/models/loan_request_test.dart
+++ b/test/unit_test/models/loan_request_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lib_42_flutter/models/loan_request.dart';
+
+LoanRequest _build({
+  String id = 'lr-1',
+  String studentId = 'stu-1',
+  String bookId = 'book-1',
+  LoanRequestStatus status = LoanRequestStatus.pending,
+  DateTime? requestDate,
+  DateTime? reviewedAt,
+  String? rejectionReason,
+  String? notes,
+}) {
+  return LoanRequest(
+    id: id,
+    studentId: studentId,
+    bookId: bookId,
+    status: status,
+    requestDate: requestDate ?? DateTime(2024, 1, 1),
+    reviewedAt: reviewedAt,
+    rejectionReason: rejectionReason,
+    notes: notes,
+  );
+}
+
+void main() {
+  group('LoanRequest model (T093)', () {
+    test('creates valid pending request', () {
+      final r = _build();
+      expect(r.id, 'lr-1');
+      expect(r.isPending, isTrue);
+      expect(r.canBeCancelled, isTrue);
+    });
+
+    test('rejects empty studentId', () {
+      expect(
+        () => _build(studentId: '   '),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('rejects empty bookId', () {
+      expect(
+        () => _build(bookId: ''),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('approved status requires reviewedAt (VR-204)', () {
+      expect(
+        () => _build(status: LoanRequestStatus.approved),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('approved with reviewedAt is valid', () {
+      final r = _build(
+        status: LoanRequestStatus.approved,
+        reviewedAt: DateTime(2024, 1, 2),
+      );
+      expect(r.isApproved, isTrue);
+      expect(r.canBeCancelled, isFalse);
+    });
+
+    test('rejection reason length > 500 throws', () {
+      expect(
+        () => _build(
+          status: LoanRequestStatus.rejected,
+          reviewedAt: DateTime(2024, 1, 2),
+          rejectionReason: 'x' * 501,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('notes length > 1000 throws', () {
+      expect(
+        () => _build(notes: 'x' * 1001),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('status helpers reflect enum value', () {
+      expect(_build(status: LoanRequestStatus.cancelled).isCancelled, isTrue);
+      expect(
+        _build(
+          status: LoanRequestStatus.rejected,
+          reviewedAt: DateTime(2024, 1, 2),
+        ).isRejected,
+        isTrue,
+      );
+    });
+
+    test('JSON roundtrip preserves fields', () {
+      final original = _build(notes: 'hello');
+      final json = original.toJson();
+      final parsed = LoanRequest.fromJson(json);
+      expect(parsed, equals(original)); // equality by id
+      expect(parsed.notes, 'hello');
+    });
+
+    test('copyWith updates only specified fields', () {
+      final r = _build();
+      final copy = r.copyWith(notes: 'updated');
+      expect(copy.id, r.id);
+      expect(copy.notes, 'updated');
+      expect(r.notes, isNull);
+    });
+  });
+}

--- a/test/unit_test/models/student_test.dart
+++ b/test/unit_test/models/student_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lib_42_flutter/models/student.dart';
+
+Student _build({
+  String id = 's1',
+  int fortytwoUserId = 12345,
+  String username = 'alice',
+  String email = 'alice@42.fr',
+  String fullName = '앨리스',
+}) {
+  return Student(
+    id: id,
+    fortytwoUserId: fortytwoUserId,
+    username: username,
+    email: email,
+    fullName: fullName,
+    createdAt: DateTime(2024, 1, 1),
+    lastLoginAt: DateTime(2024, 1, 2),
+  );
+}
+
+void main() {
+  group('Student model (T095)', () {
+    test('creates valid student', () {
+      final s = _build();
+      expect(s.id, 's1');
+      expect(s.fortytwoUserId, 12345);
+    });
+
+    test('rejects invalid email format', () {
+      expect(
+        () => _build(email: 'not-an-email'),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('rejects non-positive fortytwoUserId', () {
+      expect(() => _build(fortytwoUserId: 0), throwsA(isA<ArgumentError>()));
+      expect(() => _build(fortytwoUserId: -5), throwsA(isA<ArgumentError>()));
+    });
+
+    test('rejects empty or too-long username', () {
+      expect(() => _build(username: ''), throwsA(isA<ArgumentError>()));
+      expect(() => _build(username: '   '), throwsA(isA<ArgumentError>()));
+      expect(() => _build(username: 'x' * 51), throwsA(isA<ArgumentError>()));
+    });
+
+    test('rejects empty or too-long fullName', () {
+      expect(() => _build(fullName: ''), throwsA(isA<ArgumentError>()));
+      expect(() => _build(fullName: 'x' * 201), throwsA(isA<ArgumentError>()));
+    });
+
+    test('JSON roundtrip preserves fields', () {
+      final original = _build();
+      final parsed = Student.fromJson(original.toJson());
+      expect(parsed, equals(original));
+      expect(parsed.username, 'alice');
+      expect(parsed.fullName, '앨리스');
+    });
+
+    test('equality compared by id', () {
+      final a = _build(id: 's1', username: 'a');
+      final b = _build(id: 's1', username: 'b');
+      expect(a, equals(b));
+    });
+  });
+}

--- a/test/unit_test/state/loan/loan_bloc_test.dart
+++ b/test/unit_test/state/loan/loan_bloc_test.dart
@@ -1,0 +1,132 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lib_42_flutter/state/loan/loan_bloc.dart';
+import 'package:lib_42_flutter/state/loan/loan_event.dart';
+import 'package:lib_42_flutter/state/loan/loan_state.dart';
+
+import '../../../support/fake_loan_repositories.dart';
+
+void main() {
+  group('LoanBloc (T096)', () {
+    late FakeLoanRequestRepository loanRepo;
+    late FakeReservationRepository rsvRepo;
+
+    LoanBloc build() => LoanBloc(
+          loanRequestRepository: loanRepo,
+          reservationRepository: rsvRepo,
+        );
+
+    setUp(() {
+      loanRepo = FakeLoanRequestRepository();
+      rsvRepo = FakeReservationRepository();
+    });
+
+    blocTest<LoanBloc, LoanState>(
+      'LoadMyLoanRequests: emits [Loading, Loaded] on success',
+      build: () {
+        loanRepo.myLoanRequests = [makeLoanRequest(id: 'a')];
+        rsvRepo.myReservations = [makeReservation(id: 'r1')];
+        return build();
+      },
+      act: (bloc) => bloc.add(const LoadMyLoanRequests()),
+      expect: () => [
+        isA<LoanLoading>(),
+        isA<LoanLoaded>()
+            .having((s) => s.loanRequests.length, 'loanRequests', 1)
+            .having((s) => s.reservations.length, 'reservations', 1),
+      ],
+    );
+
+    blocTest<LoanBloc, LoanState>(
+      'LoadMyLoanRequests: emits [Loading, Error] on failure',
+      build: () {
+        loanRepo.error = Exception('boom');
+        return build();
+      },
+      act: (bloc) => bloc.add(const LoadMyLoanRequests()),
+      expect: () => [isA<LoanLoading>(), isA<LoanError>()],
+    );
+
+    blocTest<LoanBloc, LoanState>(
+      'CreateLoanRequest with available book: emits [Creating, Created, Loading, Loaded]',
+      build: () {
+        loanRepo.createReturnValue = makeLoanRequest(id: 'new');
+        loanRepo.myLoanRequests = [makeLoanRequest(id: 'new')];
+        return build();
+      },
+      act: (bloc) => bloc.add(const CreateLoanRequest(bookId: 'book-1')),
+      expect: () => [
+        isA<LoanRequestCreating>().having((s) => s.bookId, 'bookId', 'book-1'),
+        isA<LoanRequestCreated>()
+            .having((s) => s.loanRequest.id, 'loanRequest.id', 'new'),
+        // Bloc auto-dispatches LoadMyLoanRequests after success
+        isA<LoanLoading>(),
+        isA<LoanLoaded>().having((s) => s.loanRequests.length, 'count', 1),
+      ],
+    );
+
+    blocTest<LoanBloc, LoanState>(
+      'CreateLoanRequest with unavailable book: emits ReservationCreated',
+      build: () {
+        final rsv = makeReservation(id: 'rsv-new', bookId: 'book-X', queuePosition: 3);
+        loanRepo.createReturnValue = rsv;
+        rsvRepo.queueByBookId = {
+          'book-X': [
+            makeReservation(id: 'a', queuePosition: 1),
+            makeReservation(id: 'b', queuePosition: 2),
+            rsv,
+          ],
+        };
+        rsvRepo.myReservations = [rsv];
+        return build();
+      },
+      act: (bloc) => bloc.add(const CreateLoanRequest(bookId: 'book-X')),
+      expect: () => [
+        isA<LoanRequestCreating>(),
+        isA<ReservationCreated>()
+            .having((s) => s.reservation.id, 'reservation.id', 'rsv-new')
+            .having((s) => s.queuePosition, 'queuePosition', 3),
+        isA<LoanLoading>(),
+        isA<LoanLoaded>(),
+      ],
+    );
+
+    blocTest<LoanBloc, LoanState>(
+      'CreateLoanRequest: emits Error on repository failure',
+      build: () {
+        loanRepo.error = Exception('network down');
+        return build();
+      },
+      act: (bloc) => bloc.add(const CreateLoanRequest(bookId: 'book-1')),
+      expect: () => [
+        isA<LoanRequestCreating>(),
+        isA<LoanError>().having((s) => s.message, 'message', '대출 요청 중 오류가 발생했습니다'),
+      ],
+    );
+
+    blocTest<LoanBloc, LoanState>(
+      'CancelLoanRequest: success path',
+      build: () => build(),
+      act: (bloc) => bloc.add(const CancelLoanRequest(requestId: 'lr-1')),
+      expect: () => [
+        isA<LoanOperationInProgress>(),
+        isA<LoanRequestCancelled>().having((s) => s.requestId, 'requestId', 'lr-1'),
+        // Auto-refresh after cancel
+        isA<LoanLoading>(),
+        isA<LoanLoaded>(),
+      ],
+      verify: (_) {
+        expect(loanRepo.cancelCalls, 1);
+        expect(loanRepo.lastCancelledId, 'lr-1');
+      },
+    );
+
+    blocTest<LoanBloc, LoanState>(
+      'ClearLoanError resets to Initial',
+      build: () => build(),
+      seed: () => const LoanError(message: 'old error'),
+      act: (bloc) => bloc.add(const ClearLoanError()),
+      expect: () => [isA<LoanInitial>()],
+    );
+  });
+}

--- a/test/widget_test/widgets/loan/loan_request_button_test.dart
+++ b/test/widget_test/widgets/loan/loan_request_button_test.dart
@@ -1,0 +1,121 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lib_42_flutter/models/student.dart';
+import 'package:lib_42_flutter/state/auth/auth_bloc.dart';
+import 'package:lib_42_flutter/state/auth/auth_event.dart';
+import 'package:lib_42_flutter/state/auth/auth_state.dart';
+import 'package:lib_42_flutter/state/loan/loan_bloc.dart';
+import 'package:lib_42_flutter/widgets/loan/loan_request_button.dart';
+
+import '../../../support/fake_loan_repositories.dart';
+
+Student _makeStudent() => Student(
+      id: 'stu-1',
+      fortytwoUserId: 12345,
+      username: 'alice',
+      email: 'alice@42.fr',
+      fullName: '앨리스',
+      createdAt: DateTime(2024, 1, 1),
+      lastLoginAt: DateTime(2024, 1, 2),
+    );
+
+/// Mock AuthBloc — bloc_test's MockBloc avoids the real constructor's OAuth
+/// deps. Stub to expose a fixed state via `whenListen`.
+class MockAuthBloc extends MockBloc<AuthEvent, AuthState> implements AuthBloc {}
+
+MockAuthBloc _authBlocWith(AuthState state) {
+  final mock = MockAuthBloc();
+  whenListen(mock, const Stream<AuthState>.empty(), initialState: state);
+  return mock;
+}
+
+Future<void> _pump(
+  WidgetTester tester, {
+  required AuthState authState,
+  required LoanBloc loanBloc,
+  required bool isAvailable,
+  String bookId = 'book-1',
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: MultiBlocProvider(
+        providers: [
+          BlocProvider<AuthBloc>.value(value: _authBlocWith(authState)),
+          BlocProvider<LoanBloc>.value(value: loanBloc),
+        ],
+        child: Scaffold(
+          body: LoanRequestButton(bookId: bookId, isAvailable: isAvailable),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('LoanRequestButton (T097)', () {
+    LoanBloc buildLoanBloc() {
+      final bloc = LoanBloc(
+        loanRequestRepository: FakeLoanRequestRepository(),
+        reservationRepository: FakeReservationRepository(),
+      );
+      addTearDown(bloc.close);
+      return bloc;
+    }
+
+    testWidgets('shows login prompt when unauthenticated', (tester) async {
+      await _pump(
+        tester,
+        authState: const Unauthenticated(),
+        loanBloc: buildLoanBloc(),
+        isAvailable: true,
+      );
+
+      expect(find.text('로그인하여 대출 요청'), findsOneWidget);
+      expect(find.text('대출 요청'), findsNothing);
+    });
+
+    testWidgets('shows "대출 요청" when book available and authenticated',
+        (tester) async {
+      await _pump(
+        tester,
+        authState: Authenticated(student: _makeStudent(), token: 'tok'),
+        loanBloc: buildLoanBloc(),
+        isAvailable: true,
+      );
+
+      expect(find.text('대출 요청'), findsOneWidget);
+    });
+
+    testWidgets('shows "예약 대기열 추가" when book unavailable',
+        (tester) async {
+      await _pump(
+        tester,
+        authState: Authenticated(student: _makeStudent(), token: 'tok'),
+        loanBloc: buildLoanBloc(),
+        isAvailable: false,
+      );
+
+      expect(find.text('예약 대기열 추가'), findsOneWidget);
+    });
+
+    testWidgets('opens confirmation dialog when tapped (T129)',
+        (tester) async {
+      await _pump(
+        tester,
+        authState: Authenticated(student: _makeStudent(), token: 'tok'),
+        loanBloc: buildLoanBloc(),
+        isAvailable: true,
+      );
+
+      await tester.tap(find.text('대출 요청'));
+      await tester.pump();
+
+      expect(find.byType(AlertDialog), findsOneWidget);
+      expect(find.text('이 도서를 대출 요청하시겠습니까?'), findsOneWidget);
+      expect(find.text('취소'), findsOneWidget);
+      expect(find.text('확인'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
Closes #85

## 변경 (+589 / -6)

### 신규 테스트 (28건 PASS)
- T093 LoanRequest 모델 — 10건
- T095 Student 모델 — 7건
- T096 LoanBloc — 7건 (load/create 분기/cancel/error)
- T097 LoanRequestButton 위젯 — 4건 (미인증/가용/비가용/확인 다이얼로그)

### 지원 인프라
- `test/support/fake_loan_repositories.dart` — LoanRequestRepository/ReservationRepository fake
- 위젯 테스트 AuthBloc은 bloc_test `MockBloc` + `whenListen`

### 폴리시 인지 (코드 변경 없음)
- T128 (42 API graceful 실패): `LoanRequestButton`이 `LoanError` 시 빨간 SnackBar로 표시
- T129 (확인 다이얼로그): `_handleLoanRequest` 가 AlertDialog로 가용/비가용 확인 + 취소/확인

tasks.md T093/T095/T096/T097/T128/T129 [X].