### PR TITLE
[β #87] US5 백엔드 — Loan 승인/반려/반납/이력/연체 (T135-T148)

### DIFF
--- a/backend/src/routes/loan_requests.ts
+++ b/backend/src/routes/loan_requests.ts
@@ -5,7 +5,12 @@
 
 import express, { Response } from 'express';
 import { loanRequestService } from '../services/loan_request_service';
-import { authenticateStudent, AuthenticatedRequest } from '../middleware/auth';
+import { loanService, LoanError } from '../services/loan_service';
+import {
+  authenticateStudent,
+  authenticateAdmin,
+  AuthenticatedRequest,
+} from '../middleware/auth';
 import { logger } from '../utils/logger';
 
 const router = express.Router();
@@ -131,6 +136,75 @@ router.delete('/:id', authenticateStudent, async (req: AuthenticatedRequest, res
       error: 'Bad Request',
       message: error.message || '대출 신청 취소에 실패했습니다.',
     });
+  }
+});
+
+/**
+ * T140: GET /api/v1/loan-requests
+ * List pending loan requests (admin only).
+ */
+router.get('/', authenticateAdmin, async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const data = await loanRequestService.getPendingLoanRequests();
+    res.json({ success: true, data });
+  } catch (error: any) {
+    logger.error('Failed to list loan requests for admin', { error: error.message });
+    res.status(500).json({
+      error: 'Internal Server Error',
+      message: '대출 요청 목록을 불러오지 못했습니다.',
+    });
+  }
+});
+
+/**
+ * T141: PUT /api/v1/loan-requests/:id/approve
+ * Approve a pending loan request — creates an active Loan.
+ */
+router.put('/:id/approve', authenticateAdmin, async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const adminId = req.user!.userId;
+    const { dueInDays, notes } = req.body ?? {};
+    const loan = await loanService.approveLoanRequest(req.params.id, adminId, {
+      dueInDays: typeof dueInDays === 'number' ? dueInDays : undefined,
+      notes,
+    });
+    res.json({ success: true, data: loan });
+  } catch (error: any) {
+    if (error instanceof LoanError) {
+      const status =
+        error.code === 'request_not_found' ? 404
+          : error.code === 'book_unavailable' ? 409
+            : 400;
+      return res.status(status).json({ error: error.code, message: error.message });
+    }
+    logger.error('Failed to approve loan request', { error: error.message });
+    res.status(500).json({ error: 'Internal Server Error', message: error.message });
+  }
+});
+
+/**
+ * T142: PUT /api/v1/loan-requests/:id/reject
+ * Reject a pending loan request with required reason.
+ */
+router.put('/:id/reject', authenticateAdmin, async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const adminId = req.user!.userId;
+    const reason = (req.body?.rejectionReason as string | undefined)?.trim();
+    if (!reason) {
+      return res.status(400).json({
+        error: 'Bad Request',
+        message: '반려 사유는 필수입니다.',
+      });
+    }
+    const updated = await loanService.rejectLoanRequest(req.params.id, adminId, reason);
+    res.json({ success: true, data: updated });
+  } catch (error: any) {
+    if (error instanceof LoanError) {
+      const status = error.code === 'request_not_found' ? 404 : 400;
+      return res.status(status).json({ error: error.code, message: error.message });
+    }
+    logger.error('Failed to reject loan request', { error: error.message });
+    res.status(500).json({ error: 'Internal Server Error', message: error.message });
   }
 });
 

--- a/backend/src/routes/loans.ts
+++ b/backend/src/routes/loans.ts
@@ -1,0 +1,59 @@
+// US5: Admin Loan Routes
+// GET    /api/v1/loans              — list loans (admin)
+// GET    /api/v1/loans/history      — loan history with date filters
+// PUT    /api/v1/loans/:id/return   — mark loan returned, notify queue
+
+import express, { Response, NextFunction } from 'express';
+import { LoanStatus } from '@prisma/client';
+import { z } from 'zod';
+import { authenticateAdmin, AuthenticatedRequest } from '../middleware/auth';
+import { loanService, LoanError } from '../services/loan_service';
+
+const router = express.Router();
+
+const statusSchema = z.nativeEnum(LoanStatus).optional();
+
+router.get('/', authenticateAdmin, async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+  try {
+    const status = statusSchema.parse(req.query.status as string | undefined);
+    const result = await loanService.getLoans({
+      status,
+      studentId: req.query.studentId as string | undefined,
+      bookId: req.query.bookId as string | undefined,
+      page: req.query.page ? parseInt(req.query.page as string, 10) : undefined,
+      limit: req.query.limit ? parseInt(req.query.limit as string, 10) : undefined,
+    });
+    res.json(result);
+  } catch (e) {
+    next(e);
+  }
+});
+
+router.get('/history', authenticateAdmin, async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+  try {
+    const result = await loanService.getHistory({
+      from: req.query.from ? new Date(req.query.from as string) : undefined,
+      to: req.query.to ? new Date(req.query.to as string) : undefined,
+      page: req.query.page ? parseInt(req.query.page as string, 10) : undefined,
+      limit: req.query.limit ? parseInt(req.query.limit as string, 10) : undefined,
+    });
+    res.json(result);
+  } catch (e) {
+    next(e);
+  }
+});
+
+router.put('/:id/return', authenticateAdmin, async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+  try {
+    const loan = await loanService.returnLoan(req.params.id);
+    res.json({ success: true, data: loan });
+  } catch (e) {
+    if (e instanceof LoanError) {
+      const status = e.code === 'loan_not_found' ? 404 : 409;
+      return res.status(status).json({ error: e.code, message: e.message });
+    }
+    next(e);
+  }
+});
+
+export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -8,6 +8,7 @@ import { errorHandler } from './middleware/error_handler';
 import bookRoutes from './routes/books';
 import authRoutes from './routes/auth';
 import loanRequestRoutes from './routes/loan_requests';
+import loanRoutes from './routes/loans';
 import adminRoutes from './routes/admin';
 
 const app: Express = express();
@@ -37,6 +38,7 @@ app.get('/health', (req, res) => {
 app.use('/api/v1/books', bookRoutes);
 app.use('/api/v1/auth', authRoutes);
 app.use('/api/v1/loan-requests', loanRequestRoutes);
+app.use('/api/v1/loans', loanRoutes);
 app.use('/api/v1/admin', adminRoutes);
 
 app.get('/api/v1', (req, res) => {

--- a/backend/src/services/loan_service.ts
+++ b/backend/src/services/loan_service.ts
@@ -1,0 +1,264 @@
+// T146/T147/T148: Loan Service — admin approval workflow + return + overdue detection
+// Reference: data-model.md Entity 5 (Loan)
+
+import {
+  PrismaClient,
+  LoanRequestStatus,
+  LoanStatus,
+  ReservationStatus,
+} from '@prisma/client';
+import { logger } from '../utils/logger';
+import { reservationService } from './reservation_service';
+
+const prisma = new PrismaClient();
+
+export class LoanError extends Error {
+  constructor(
+    public code:
+      | 'request_not_found'
+      | 'not_pending'
+      | 'book_unavailable'
+      | 'loan_not_found'
+      | 'not_active',
+    message: string,
+  ) {
+    super(message);
+    this.name = 'LoanError';
+  }
+}
+
+const DEFAULT_LOAN_DAYS = 14;
+
+export class LoanService {
+  /**
+   * T141/T146: Approve a pending loan request and create a Loan.
+   * Decrements book.availableQuantity within a transaction.
+   */
+  async approveLoanRequest(
+    loanRequestId: string,
+    adminId: string,
+    options: { dueInDays?: number; notes?: string } = {},
+  ) {
+    const dueInDays = options.dueInDays ?? DEFAULT_LOAN_DAYS;
+    const dueDate = new Date(Date.now() + dueInDays * 24 * 60 * 60 * 1000);
+
+    return prisma.$transaction(async (tx) => {
+      const request = await tx.loanRequest.findUnique({
+        where: { id: loanRequestId },
+        include: { book: true },
+      });
+      if (!request) {
+        throw new LoanError('request_not_found', '대출 요청을 찾을 수 없습니다.');
+      }
+      if (request.status !== LoanRequestStatus.pending) {
+        throw new LoanError(
+          'not_pending',
+          `대기 중인 요청만 승인 가능합니다. 현재 상태: ${request.status}`,
+        );
+      }
+      if (request.book.availableQuantity <= 0) {
+        throw new LoanError('book_unavailable', '도서가 가용하지 않습니다.');
+      }
+
+      // Decrement availability
+      await tx.book.update({
+        where: { id: request.bookId },
+        data: { availableQuantity: { decrement: 1 } },
+      });
+
+      // Create active loan
+      const loan = await tx.loan.create({
+        data: {
+          studentId: request.studentId,
+          bookId: request.bookId,
+          loanRequestId: request.id,
+          status: LoanStatus.active,
+          dueDate,
+          approvedBy: adminId,
+          notes: options.notes,
+        },
+        include: { book: true, student: { select: { id: true, username: true, fullName: true } } },
+      });
+
+      // Update request status
+      await tx.loanRequest.update({
+        where: { id: loanRequestId },
+        data: {
+          status: LoanRequestStatus.approved,
+          reviewedAt: new Date(),
+          reviewedBy: adminId,
+        },
+      });
+
+      logger.info('Loan request approved', { loanRequestId, loanId: loan.id, adminId });
+      return loan;
+    });
+  }
+
+  /**
+   * T142: Reject a pending loan request with reason.
+   */
+  async rejectLoanRequest(
+    loanRequestId: string,
+    adminId: string,
+    rejectionReason: string,
+  ) {
+    const request = await prisma.loanRequest.findUnique({
+      where: { id: loanRequestId },
+    });
+    if (!request) {
+      throw new LoanError('request_not_found', '대출 요청을 찾을 수 없습니다.');
+    }
+    if (request.status !== LoanRequestStatus.pending) {
+      throw new LoanError(
+        'not_pending',
+        `대기 중인 요청만 반려 가능합니다. 현재 상태: ${request.status}`,
+      );
+    }
+
+    const updated = await prisma.loanRequest.update({
+      where: { id: loanRequestId },
+      data: {
+        status: LoanRequestStatus.rejected,
+        reviewedAt: new Date(),
+        reviewedBy: adminId,
+        rejectionReason,
+      },
+    });
+    logger.info('Loan request rejected', { loanRequestId, adminId });
+    return updated;
+  }
+
+  /**
+   * T144/T148: Return a loan and notify next reservation in queue.
+   */
+  async returnLoan(loanId: string) {
+    const loan = await prisma.$transaction(async (tx) => {
+      const existing = await tx.loan.findUnique({
+        where: { id: loanId },
+        include: { book: true },
+      });
+      if (!existing) {
+        throw new LoanError('loan_not_found', '대출을 찾을 수 없습니다.');
+      }
+      if (existing.status !== LoanStatus.active && existing.status !== LoanStatus.overdue) {
+        throw new LoanError('not_active', '진행 중인 대출만 반납 처리할 수 있습니다.');
+      }
+
+      const updated = await tx.loan.update({
+        where: { id: loanId },
+        data: {
+          status: LoanStatus.returned,
+          returnedDate: new Date(),
+        },
+        include: { book: true, student: { select: { id: true, username: true, fullName: true } } },
+      });
+
+      await tx.book.update({
+        where: { id: existing.bookId },
+        data: { availableQuantity: { increment: 1 } },
+      });
+
+      return updated;
+    });
+
+    // Notification happens outside the transaction (best effort).
+    try {
+      await reservationService.notifyNextInQueue(loan.bookId);
+    } catch (err: any) {
+      logger.warn('Failed to notify next in queue', {
+        loanId: loan.id,
+        bookId: loan.bookId,
+        error: err.message,
+      });
+    }
+
+    logger.info('Loan returned', { loanId });
+    return loan;
+  }
+
+  /**
+   * T143: List loans (admin view), optionally filtered by status.
+   */
+  async getLoans(filters: {
+    status?: LoanStatus;
+    studentId?: string;
+    bookId?: string;
+    limit?: number;
+    page?: number;
+  } = {}) {
+    const limit = filters.limit ?? 50;
+    const page = filters.page ?? 1;
+    const where: any = {};
+    if (filters.status) where.status = filters.status;
+    if (filters.studentId) where.studentId = filters.studentId;
+    if (filters.bookId) where.bookId = filters.bookId;
+
+    const [loans, total] = await Promise.all([
+      prisma.loan.findMany({
+        where,
+        skip: (page - 1) * limit,
+        take: limit,
+        orderBy: { checkoutDate: 'desc' },
+        include: {
+          book: { select: { id: true, title: true, author: true } },
+          student: { select: { id: true, username: true, fullName: true } },
+        },
+      }),
+      prisma.loan.count({ where }),
+    ]);
+
+    return { data: loans, total, page, limit };
+  }
+
+  /**
+   * T145: Loan history with date filters.
+   */
+  async getHistory(filters: { from?: Date; to?: Date; limit?: number; page?: number } = {}) {
+    const limit = filters.limit ?? 50;
+    const page = filters.page ?? 1;
+    const where: any = {};
+    if (filters.from || filters.to) {
+      where.checkoutDate = {};
+      if (filters.from) where.checkoutDate.gte = filters.from;
+      if (filters.to) where.checkoutDate.lte = filters.to;
+    }
+
+    const [loans, total] = await Promise.all([
+      prisma.loan.findMany({
+        where,
+        skip: (page - 1) * limit,
+        take: limit,
+        orderBy: { checkoutDate: 'desc' },
+        include: {
+          book: { select: { id: true, title: true } },
+          student: { select: { id: true, username: true } },
+        },
+      }),
+      prisma.loan.count({ where }),
+    ]);
+
+    return { data: loans, total, page, limit };
+  }
+
+  /**
+   * T147: Mark active loans past their dueDate as overdue.
+   * Returns number of rows updated.
+   */
+  async detectOverdue(now: Date = new Date()): Promise<number> {
+    const result = await prisma.loan.updateMany({
+      where: {
+        status: LoanStatus.active,
+        dueDate: { lt: now },
+      },
+      data: { status: LoanStatus.overdue },
+    });
+
+    if (result.count > 0) {
+      logger.info('Marked loans as overdue', { count: result.count });
+    }
+    return result.count;
+  }
+}
+
+export const loanService = new LoanService();

--- a/backend/tests/unit/loan_lifecycle.test.ts
+++ b/backend/tests/unit/loan_lifecycle.test.ts
@@ -1,0 +1,365 @@
+// T135/T136/T137: Loan lifecycle — approve, reject, return, overdue detection,
+// reservation queue notification on return.
+
+import request from 'supertest';
+import { app } from '../../src/server';
+import { PrismaClient, LoanStatus, ReservationStatus } from '@prisma/client';
+import * as bcrypt from 'bcrypt';
+import { generateAdminToken, generateStudentToken } from '../../src/utils/jwt';
+import { loanService } from '../../src/services/loan_service';
+
+const prisma = new PrismaClient();
+
+const TITLE_PREFIX = '[LOAN-CYCLE]';
+
+const ADMIN = {
+  username: 'cycle_admin',
+  password: 'cycle-admin-pass',
+  email: 'cycle_admin@42lib.kr',
+  fullName: '대출 사이클 관리자',
+};
+
+async function cleanup(): Promise<void> {
+  await prisma.loan.deleteMany({ where: { book: { title: { startsWith: TITLE_PREFIX } } } });
+  await prisma.loanRequest.deleteMany({ where: { book: { title: { startsWith: TITLE_PREFIX } } } });
+  await prisma.reservation.deleteMany({ where: { book: { title: { startsWith: TITLE_PREFIX } } } });
+  await prisma.book.deleteMany({ where: { title: { startsWith: TITLE_PREFIX } } });
+  await prisma.student.deleteMany({ where: { username: { startsWith: 'cycle_student_' } } });
+  await prisma.administrator.deleteMany({ where: { username: ADMIN.username } });
+}
+
+async function createStudent(suffix: string) {
+  return prisma.student.create({
+    data: {
+      fortytwoUserId: 970000 + suffix.charCodeAt(0),
+      username: `cycle_student_${suffix}`,
+      email: `cycle_student_${suffix}@42.fr`,
+      fullName: `사이클 학생 ${suffix}`,
+    },
+  });
+}
+
+describe('Loan lifecycle (T135/T136/T137)', () => {
+  let adminId: string;
+  let adminToken: string;
+
+  beforeAll(async () => {
+    await cleanup();
+    const passwordHash = await bcrypt.hash(ADMIN.password, 10);
+    const admin = await prisma.administrator.create({
+      data: {
+        username: ADMIN.username,
+        email: ADMIN.email,
+        fullName: ADMIN.fullName,
+        passwordHash,
+        role: 'admin',
+      },
+    });
+    adminId = admin.id;
+    adminToken = generateAdminToken(admin.id, admin.username, admin.email, admin.role);
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    await prisma.$disconnect();
+  });
+
+  describe('PUT /api/v1/loan-requests/:id/approve (T135)', () => {
+    it('creates Loan and decrements availableQuantity', async () => {
+      const student = await createStudent('a');
+      const book = await prisma.book.create({
+        data: {
+          title: `${TITLE_PREFIX} approve-target`,
+          author: 'Approve Author',
+          category: 'Programming',
+          quantity: 2,
+          availableQuantity: 2,
+        },
+      });
+      const lr = await prisma.loanRequest.create({
+        data: { studentId: student.id, bookId: book.id, status: 'pending' },
+      });
+
+      const res = await request(app)
+        .put(`/api/v1/loan-requests/${lr.id}/approve`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({})
+        .expect(200);
+
+      expect(res.body.data.status).toBe('active');
+      expect(res.body.data.bookId).toBe(book.id);
+
+      const refreshedBook = await prisma.book.findUnique({ where: { id: book.id } });
+      expect(refreshedBook!.availableQuantity).toBe(1);
+
+      const refreshedRequest = await prisma.loanRequest.findUnique({ where: { id: lr.id } });
+      expect(refreshedRequest!.status).toBe('approved');
+      expect(refreshedRequest!.reviewedBy).toBe(adminId);
+    });
+
+    it('rejects approval when book is unavailable (409)', async () => {
+      const student = await createStudent('b');
+      const book = await prisma.book.create({
+        data: {
+          title: `${TITLE_PREFIX} approve-unavailable`,
+          author: 'X',
+          category: 'Programming',
+          quantity: 1,
+          availableQuantity: 0,
+        },
+      });
+      const lr = await prisma.loanRequest.create({
+        data: { studentId: student.id, bookId: book.id, status: 'pending' },
+      });
+
+      const res = await request(app)
+        .put(`/api/v1/loan-requests/${lr.id}/approve`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .expect(409);
+
+      expect(res.body.error).toBe('book_unavailable');
+    });
+
+    it('rejects non-pending requests (400)', async () => {
+      const student = await createStudent('c');
+      const book = await prisma.book.create({
+        data: {
+          title: `${TITLE_PREFIX} approve-already-reviewed`,
+          author: 'X',
+          category: 'Programming',
+          quantity: 1,
+          availableQuantity: 1,
+        },
+      });
+      const lr = await prisma.loanRequest.create({
+        data: {
+          studentId: student.id,
+          bookId: book.id,
+          status: 'rejected',
+          reviewedAt: new Date(),
+          reviewedBy: adminId,
+          rejectionReason: '이전 반려',
+        },
+      });
+
+      await request(app)
+        .put(`/api/v1/loan-requests/${lr.id}/approve`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .expect(400);
+    });
+  });
+
+  describe('PUT /api/v1/loan-requests/:id/reject', () => {
+    it('rejects with reason and updates request', async () => {
+      const student = await createStudent('d');
+      const book = await prisma.book.create({
+        data: {
+          title: `${TITLE_PREFIX} reject-target`,
+          author: 'X',
+          category: 'Programming',
+          quantity: 1,
+          availableQuantity: 1,
+        },
+      });
+      const lr = await prisma.loanRequest.create({
+        data: { studentId: student.id, bookId: book.id, status: 'pending' },
+      });
+
+      const res = await request(app)
+        .put(`/api/v1/loan-requests/${lr.id}/reject`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ rejectionReason: '학생이 이전 도서를 반납하지 않음' })
+        .expect(200);
+
+      expect(res.body.data.status).toBe('rejected');
+      expect(res.body.data.rejectionReason).toContain('학생이 이전');
+    });
+
+    it('returns 400 when rejectionReason missing', async () => {
+      const student = await createStudent('e');
+      const book = await prisma.book.create({
+        data: {
+          title: `${TITLE_PREFIX} reject-no-reason`,
+          author: 'X',
+          category: 'Programming',
+          quantity: 1,
+          availableQuantity: 1,
+        },
+      });
+      const lr = await prisma.loanRequest.create({
+        data: { studentId: student.id, bookId: book.id, status: 'pending' },
+      });
+
+      await request(app)
+        .put(`/api/v1/loan-requests/${lr.id}/reject`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({})
+        .expect(400);
+    });
+  });
+
+  describe('PUT /api/v1/loans/:id/return (T136)', () => {
+    it('marks loan returned, increments availability, notifies queue', async () => {
+      const borrower = await createStudent('f');
+      const waiter = await createStudent('g');
+
+      const book = await prisma.book.create({
+        data: {
+          title: `${TITLE_PREFIX} return-target`,
+          author: 'X',
+          category: 'Programming',
+          quantity: 1,
+          availableQuantity: 0, // borrowed out
+        },
+      });
+
+      // Active loan held by borrower
+      const loan = await prisma.loan.create({
+        data: {
+          studentId: borrower.id,
+          bookId: book.id,
+          status: LoanStatus.active,
+          dueDate: new Date(Date.now() + 7 * 86400_000),
+          approvedBy: adminId,
+        },
+      });
+
+      // Waiter is queued for this book
+      await prisma.reservation.create({
+        data: {
+          studentId: waiter.id,
+          bookId: book.id,
+          queuePosition: 1,
+          status: ReservationStatus.waiting,
+        },
+      });
+
+      const res = await request(app)
+        .put(`/api/v1/loans/${loan.id}/return`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .expect(200);
+
+      expect(res.body.data.status).toBe('returned');
+      expect(res.body.data.returnedDate).not.toBeNull();
+
+      const refreshedBook = await prisma.book.findUnique({ where: { id: book.id } });
+      expect(refreshedBook!.availableQuantity).toBe(1);
+
+      const refreshedReservation = await prisma.reservation.findFirst({
+        where: { studentId: waiter.id, bookId: book.id },
+      });
+      expect(refreshedReservation!.status).toBe(ReservationStatus.notified);
+      expect(refreshedReservation!.notifiedAt).not.toBeNull();
+    });
+
+    it('returns 404 for non-existent loan', async () => {
+      await request(app)
+        .put('/api/v1/loans/00000000-0000-0000-0000-000000000000/return')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .expect(404);
+    });
+
+    it('returns 409 when loan already returned', async () => {
+      const student = await createStudent('h');
+      const book = await prisma.book.create({
+        data: {
+          title: `${TITLE_PREFIX} double-return`,
+          author: 'X',
+          category: 'Programming',
+          quantity: 1,
+          availableQuantity: 1,
+        },
+      });
+      const loan = await prisma.loan.create({
+        data: {
+          studentId: student.id,
+          bookId: book.id,
+          status: LoanStatus.returned,
+          dueDate: new Date(),
+          returnedDate: new Date(),
+          approvedBy: adminId,
+        },
+      });
+
+      await request(app)
+        .put(`/api/v1/loans/${loan.id}/return`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .expect(409);
+    });
+  });
+
+  describe('detectOverdue (T137)', () => {
+    it('marks active loans past dueDate as overdue', async () => {
+      const student = await createStudent('i');
+      const book = await prisma.book.create({
+        data: {
+          title: `${TITLE_PREFIX} overdue-target`,
+          author: 'X',
+          category: 'Programming',
+          quantity: 2,
+          availableQuantity: 0,
+        },
+      });
+      // Two active loans: one past due, one not yet
+      const pastDue = await prisma.loan.create({
+        data: {
+          studentId: student.id,
+          bookId: book.id,
+          status: LoanStatus.active,
+          dueDate: new Date(Date.now() - 86400_000), // 1 day ago
+          approvedBy: adminId,
+        },
+      });
+      const notYet = await prisma.loan.create({
+        data: {
+          studentId: student.id,
+          bookId: book.id,
+          status: LoanStatus.active,
+          dueDate: new Date(Date.now() + 86400_000), // 1 day from now
+          approvedBy: adminId,
+        },
+      });
+
+      const updatedCount = await loanService.detectOverdue();
+      expect(updatedCount).toBeGreaterThanOrEqual(1);
+
+      const refreshedPastDue = await prisma.loan.findUnique({ where: { id: pastDue.id } });
+      const refreshedNotYet = await prisma.loan.findUnique({ where: { id: notYet.id } });
+      expect(refreshedPastDue!.status).toBe('overdue');
+      expect(refreshedNotYet!.status).toBe('active');
+    });
+  });
+
+  describe('GET /api/v1/loans (T143 list)', () => {
+    it('rejects student token (admin only)', async () => {
+      const student = await createStudent('j');
+      const studentToken = generateStudentToken(
+        student.id,
+        student.username,
+        student.email,
+        student.fortytwoUserId,
+      );
+
+      await request(app)
+        .get('/api/v1/loans')
+        .set('Authorization', `Bearer ${studentToken}`)
+        .expect(403);
+    });
+
+    it('returns paginated results for admin', async () => {
+      const res = await request(app)
+        .get('/api/v1/loans?limit=5')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .expect(200);
+
+      expect(res.body).toEqual(
+        expect.objectContaining({
+          data: expect.any(Array),
+          total: expect.any(Number),
+          page: 1,
+          limit: 5,
+        }),
+      );
+    });
+  });
+});

--- a/specs/001-library-management/tasks.md
+++ b/specs/001-library-management/tasks.md
@@ -283,9 +283,9 @@
 - [ ] T132 [P] [US5] Create unit test for Loan model in test/unit_test/models/loan_test.dart
 - [ ] T133 [P] [US5] Create widget test for loan management screen in test/widget_test/screens/web/loans/loans_screen_test.dart
 - [ ] T134 [P] [US5] Create integration test for loan approval flow in test/integration_test/admin_loan_management_test.dart
-- [ ] T135 [P] [US5] Create backend unit test for PUT /loan-requests/:id/approve in backend/tests/unit/loan_requests.test.ts
-- [ ] T136 [P] [US5] Create backend unit test for PUT /loans/:id/return in backend/tests/unit/loans.test.ts
-- [ ] T137 [P] [US5] Create backend unit test for overdue detection in backend/tests/unit/loans.test.ts
+- [X] T135 [P] [US5] Create backend unit test for PUT /loan-requests/:id/approve in backend/tests/unit/loan_requests.test.ts
+- [X] T136 [P] [US5] Create backend unit test for PUT /loans/:id/return in backend/tests/unit/loans.test.ts
+- [X] T137 [P] [US5] Create backend unit test for overdue detection in backend/tests/unit/loans.test.ts
 
 ### Implementation for User Story 5
 
@@ -296,15 +296,15 @@
 
 **Backend API - Loan Management**
 
-- [ ] T140 [P] [US5] Implement GET /loan-requests endpoint (admin) in backend/src/routes/loan_requests.ts
-- [ ] T141 [P] [US5] Implement PUT /loan-requests/:id/approve endpoint in backend/src/routes/loan_requests.ts
-- [ ] T142 [P] [US5] Implement PUT /loan-requests/:id/reject endpoint in backend/src/routes/loan_requests.ts
-- [ ] T143 [P] [US5] Implement GET /loans endpoint (admin) in backend/src/routes/loans.ts
-- [ ] T144 [P] [US5] Implement PUT /loans/:id/return endpoint in backend/src/routes/loans.ts
-- [ ] T145 [P] [US5] Implement GET /loans/history endpoint with filters in backend/src/routes/loans.ts
-- [ ] T146 [US5] Implement loan approval logic with availability check in backend/src/services/loan_service.ts
-- [ ] T147 [US5] Implement automatic overdue detection in backend/src/services/loan_service.ts
-- [ ] T148 [US5] Add notification to reservation queue when book returned
+- [X] T140 [P] [US5] Implement GET /loan-requests endpoint (admin) in backend/src/routes/loan_requests.ts
+- [X] T141 [P] [US5] Implement PUT /loan-requests/:id/approve endpoint in backend/src/routes/loan_requests.ts
+- [X] T142 [P] [US5] Implement PUT /loan-requests/:id/reject endpoint in backend/src/routes/loan_requests.ts
+- [X] T143 [P] [US5] Implement GET /loans endpoint (admin) in backend/src/routes/loans.ts
+- [X] T144 [P] [US5] Implement PUT /loans/:id/return endpoint in backend/src/routes/loans.ts
+- [X] T145 [P] [US5] Implement GET /loans/history endpoint with filters in backend/src/routes/loans.ts
+- [X] T146 [US5] Implement loan approval logic with availability check in backend/src/services/loan_service.ts
+- [X] T147 [US5] Implement automatic overdue detection in backend/src/services/loan_service.ts
+- [X] T148 [US5] Add notification to reservation queue when book returned
 
 **State Management**
 


### PR DESCRIPTION
Closes #87

## 변경 (+777 / -13)

### 신규 파일
- `backend/src/services/loan_service.ts` — 트랜잭션 기반 approve/reject/return + getLoans/getHistory + detectOverdue, `LoanError` 도메인 예외
- `backend/src/routes/loans.ts` — GET /, GET /history, PUT /:id/return
- `backend/tests/unit/loan_lifecycle.test.ts` — 11건

### 수정
- `loan_requests.ts` — admin 라우트 추가 (GET /, PUT /:id/approve, PUT /:id/reject)
- `server.ts` — /api/v1/loans 등록

### 핵심 흐름
- **승인**: 트랜잭션으로 가용량 검증 → -1 → Loan(active, dueDate +14d) → request approved
- **반납**: 트랜잭션으로 returned + 가용량 +1, 트랜잭션 외 `reservation_service.notifyNextInQueue` best-effort 호출
- **연체 감지**: active && dueDate<now 일괄 overdue 갱신

### 테스트 (11/11 PASS)
승인 정상/unavailable 409/non-pending 400, 반려 정상/사유 누락 400, 반납 정상+queue notify/404/409, 연체 감지, 목록 권한 (student 403/admin 200)

tasks.md T135/T136/T137/T140-T148 (12건) [X].