### PR TITLE
[γ #89] US5 프론트 — 관리자 대출 관리 UI (대기/진행 중/연체)

### DIFF
--- a/lib/core/routes/app_router.dart
+++ b/lib/core/routes/app_router.dart
@@ -5,6 +5,7 @@ import '../../features/admin_catalog/presentation/bloc/admin_auth_state.dart';
 import '../../features/admin_catalog/presentation/screens/admin_dashboard_screen.dart';
 import '../../features/admin_catalog/presentation/screens/admin_login_screen.dart';
 import '../../features/admin_catalog/presentation/screens/catalog_management_screen.dart';
+import '../../features/admin_catalog/presentation/screens/loans_management_screen.dart';
 import '../../features/books/presentation/screens/book_list_screen.dart';
 import '../../models/book.dart';
 import '../../screens/mobile/auth/login_screen.dart';
@@ -76,6 +77,10 @@ class AppRouter {
         GoRoute(
           path: '/admin/catalog',
           builder: (context, state) => const CatalogManagementScreen(),
+        ),
+        GoRoute(
+          path: '/admin/loans',
+          builder: (context, state) => const LoansManagementScreen(),
         ),
       ],
     );

--- a/lib/features/admin_catalog/data/models/loan.dart
+++ b/lib/features/admin_catalog/data/models/loan.dart
@@ -1,0 +1,231 @@
+import 'package:equatable/equatable.dart';
+
+enum LoanStatus { active, returned, overdue }
+
+LoanStatus _parseLoanStatus(String raw) {
+  switch (raw) {
+    case 'active':
+      return LoanStatus.active;
+    case 'returned':
+      return LoanStatus.returned;
+    case 'overdue':
+      return LoanStatus.overdue;
+    default:
+      throw ArgumentError('Unknown loan status: $raw');
+  }
+}
+
+String _loanStatusToJson(LoanStatus s) => s.name;
+
+enum LoanRequestStatusFront { pending, approved, rejected, cancelled }
+
+LoanRequestStatusFront _parseRequestStatus(String raw) {
+  switch (raw) {
+    case 'pending':
+      return LoanRequestStatusFront.pending;
+    case 'approved':
+      return LoanRequestStatusFront.approved;
+    case 'rejected':
+      return LoanRequestStatusFront.rejected;
+    case 'cancelled':
+      return LoanRequestStatusFront.cancelled;
+    default:
+      throw ArgumentError('Unknown loan request status: $raw');
+  }
+}
+
+class LoanBookSummary extends Equatable {
+  final String id;
+  final String title;
+  final String? author;
+
+  const LoanBookSummary({required this.id, required this.title, this.author});
+
+  factory LoanBookSummary.fromJson(Map<String, dynamic> json) {
+    return LoanBookSummary(
+      id: json['id'] as String,
+      title: json['title'] as String,
+      author: json['author'] as String?,
+    );
+  }
+
+  @override
+  List<Object?> get props => [id, title, author];
+}
+
+class LoanStudentSummary extends Equatable {
+  final String id;
+  final String username;
+  final String? fullName;
+
+  const LoanStudentSummary({
+    required this.id,
+    required this.username,
+    this.fullName,
+  });
+
+  factory LoanStudentSummary.fromJson(Map<String, dynamic> json) {
+    return LoanStudentSummary(
+      id: json['id'] as String,
+      username: json['username'] as String,
+      fullName: json['fullName'] as String?,
+    );
+  }
+
+  @override
+  List<Object?> get props => [id, username, fullName];
+}
+
+/// Active or completed loan record (admin view).
+class Loan extends Equatable {
+  final String id;
+  final String studentId;
+  final String bookId;
+  final LoanStatus status;
+  final DateTime checkoutDate;
+  final DateTime dueDate;
+  final DateTime? returnedDate;
+  final String approvedBy;
+  final String? notes;
+  final LoanBookSummary? book;
+  final LoanStudentSummary? student;
+
+  const Loan({
+    required this.id,
+    required this.studentId,
+    required this.bookId,
+    required this.status,
+    required this.checkoutDate,
+    required this.dueDate,
+    this.returnedDate,
+    required this.approvedBy,
+    this.notes,
+    this.book,
+    this.student,
+  });
+
+  factory Loan.fromJson(Map<String, dynamic> json) {
+    return Loan(
+      id: json['id'] as String,
+      studentId: json['studentId'] as String,
+      bookId: json['bookId'] as String,
+      status: _parseLoanStatus(json['status'] as String),
+      checkoutDate: DateTime.parse(json['checkoutDate'] as String),
+      dueDate: DateTime.parse(json['dueDate'] as String),
+      returnedDate: json['returnedDate'] == null
+          ? null
+          : DateTime.parse(json['returnedDate'] as String),
+      approvedBy: json['approvedBy'] as String,
+      notes: json['notes'] as String?,
+      book: json['book'] is Map<String, dynamic>
+          ? LoanBookSummary.fromJson(json['book'] as Map<String, dynamic>)
+          : null,
+      student: json['student'] is Map<String, dynamic>
+          ? LoanStudentSummary.fromJson(json['student'] as Map<String, dynamic>)
+          : null,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'studentId': studentId,
+        'bookId': bookId,
+        'status': _loanStatusToJson(status),
+        'checkoutDate': checkoutDate.toIso8601String(),
+        'dueDate': dueDate.toIso8601String(),
+        if (returnedDate != null)
+          'returnedDate': returnedDate!.toIso8601String(),
+        'approvedBy': approvedBy,
+        if (notes != null) 'notes': notes,
+      };
+
+  bool get isActive => status == LoanStatus.active;
+  bool get isReturned => status == LoanStatus.returned;
+  bool get isOverdue => status == LoanStatus.overdue;
+  bool get canBeReturned =>
+      status == LoanStatus.active || status == LoanStatus.overdue;
+
+  /// Days remaining until due (negative if past due).
+  int daysUntilDue(DateTime now) {
+    return dueDate.difference(now).inDays;
+  }
+
+  @override
+  List<Object?> get props => [
+        id,
+        studentId,
+        bookId,
+        status,
+        checkoutDate,
+        dueDate,
+        returnedDate,
+        approvedBy,
+        notes,
+      ];
+}
+
+/// Pending or reviewed loan request (admin view).
+class AdminLoanRequest extends Equatable {
+  final String id;
+  final String studentId;
+  final String bookId;
+  final LoanRequestStatusFront status;
+  final DateTime requestDate;
+  final DateTime? reviewedAt;
+  final String? reviewedBy;
+  final String? rejectionReason;
+  final String? notes;
+  final LoanBookSummary? book;
+  final LoanStudentSummary? student;
+
+  const AdminLoanRequest({
+    required this.id,
+    required this.studentId,
+    required this.bookId,
+    required this.status,
+    required this.requestDate,
+    this.reviewedAt,
+    this.reviewedBy,
+    this.rejectionReason,
+    this.notes,
+    this.book,
+    this.student,
+  });
+
+  factory AdminLoanRequest.fromJson(Map<String, dynamic> json) {
+    return AdminLoanRequest(
+      id: json['id'] as String,
+      studentId: json['studentId'] as String,
+      bookId: json['bookId'] as String,
+      status: _parseRequestStatus(json['status'] as String),
+      requestDate: DateTime.parse(json['requestDate'] as String),
+      reviewedAt: json['reviewedAt'] == null
+          ? null
+          : DateTime.parse(json['reviewedAt'] as String),
+      reviewedBy: json['reviewedBy'] as String?,
+      rejectionReason: json['rejectionReason'] as String?,
+      notes: json['notes'] as String?,
+      book: json['book'] is Map<String, dynamic>
+          ? LoanBookSummary.fromJson(json['book'] as Map<String, dynamic>)
+          : null,
+      student: json['student'] is Map<String, dynamic>
+          ? LoanStudentSummary.fromJson(json['student'] as Map<String, dynamic>)
+          : null,
+    );
+  }
+
+  bool get isPending => status == LoanRequestStatusFront.pending;
+
+  @override
+  List<Object?> get props => [
+        id,
+        studentId,
+        bookId,
+        status,
+        requestDate,
+        reviewedAt,
+        reviewedBy,
+        rejectionReason,
+        notes,
+      ];
+}

--- a/lib/features/admin_catalog/data/repositories/admin_loan_repository_impl.dart
+++ b/lib/features/admin_catalog/data/repositories/admin_loan_repository_impl.dart
@@ -1,0 +1,132 @@
+import 'package:dio/dio.dart';
+
+import '../../../../services/storage/secure_storage_service.dart';
+import '../../domain/repositories/admin_loan_repository.dart';
+import '../models/loan.dart';
+
+class AdminLoanRepositoryImpl implements AdminLoanRepository {
+  AdminLoanRepositoryImpl({
+    required String baseUrl,
+    SecureStorageService? storage,
+    Dio? httpClient,
+  })  : _storage = storage ?? SecureStorageService(),
+        _dio = httpClient ?? _build(baseUrl) {
+    _dio.interceptors.add(InterceptorsWrapper(
+      onRequest: (options, handler) async {
+        final token = await _storage.readAdminToken();
+        if (token != null && token.isNotEmpty) {
+          options.headers['Authorization'] = 'Bearer $token';
+        }
+        return handler.next(options);
+      },
+    ));
+  }
+
+  static Dio _build(String baseUrl) => Dio(
+        BaseOptions(
+          baseUrl: baseUrl,
+          connectTimeout: const Duration(seconds: 15),
+          receiveTimeout: const Duration(seconds: 15),
+          headers: {'Content-Type': 'application/json'},
+          validateStatus: (s) => s != null && s < 500,
+        ),
+      );
+
+  final SecureStorageService _storage;
+  final Dio _dio;
+
+  @override
+  Future<List<AdminLoanRequest>> fetchPendingRequests() async {
+    final res = await _dio.get<dynamic>('/v1/loan-requests');
+    if (res.statusCode != 200 || res.data is! Map) {
+      throw LoanOperationException(
+        'fetch_failed',
+        '대출 요청 목록을 불러오지 못했습니다 (${res.statusCode}).',
+      );
+    }
+    final list = (res.data as Map<String, dynamic>)['data'] as List<dynamic>;
+    return list
+        .map((j) => AdminLoanRequest.fromJson(j as Map<String, dynamic>))
+        .toList();
+  }
+
+  @override
+  Future<List<Loan>> fetchLoans({String? status}) async {
+    final res = await _dio.get<dynamic>(
+      '/v1/loans',
+      queryParameters: {
+        if (status != null) 'status': status,
+        'limit': 100,
+      },
+    );
+    if (res.statusCode != 200 || res.data is! Map) {
+      throw LoanOperationException(
+        'fetch_failed',
+        '대출 목록을 불러오지 못했습니다 (${res.statusCode}).',
+      );
+    }
+    final list = (res.data as Map<String, dynamic>)['data'] as List<dynamic>;
+    return list.map((j) => Loan.fromJson(j as Map<String, dynamic>)).toList();
+  }
+
+  @override
+  Future<Loan> approveRequest(
+    String requestId, {
+    int? dueInDays,
+    String? notes,
+  }) async {
+    final res = await _dio.put<dynamic>(
+      '/v1/loan-requests/$requestId/approve',
+      data: {
+        if (dueInDays != null) 'dueInDays': dueInDays,
+        if (notes != null && notes.isNotEmpty) 'notes': notes,
+      },
+    );
+    return _expectLoan(res, 'approve_failed');
+  }
+
+  @override
+  Future<AdminLoanRequest> rejectRequest(String requestId, String reason) async {
+    final res = await _dio.put<dynamic>(
+      '/v1/loan-requests/$requestId/reject',
+      data: {'rejectionReason': reason},
+    );
+    if (res.statusCode == 200 && res.data is Map) {
+      final body = res.data as Map<String, dynamic>;
+      return AdminLoanRequest.fromJson(body['data'] as Map<String, dynamic>);
+    }
+    throw LoanOperationException(
+      'reject_failed',
+      _readMessage(res, '반려 처리에 실패했습니다.'),
+    );
+  }
+
+  @override
+  Future<Loan> returnLoan(String loanId) async {
+    final res = await _dio.put<dynamic>('/v1/loans/$loanId/return');
+    return _expectLoan(res, 'return_failed');
+  }
+
+  Loan _expectLoan(Response<dynamic> res, String fallbackCode) {
+    if (res.statusCode == 200 && res.data is Map) {
+      final body = res.data as Map<String, dynamic>;
+      return Loan.fromJson(body['data'] as Map<String, dynamic>);
+    }
+    if (res.data is Map) {
+      final body = res.data as Map<String, dynamic>;
+      throw LoanOperationException(
+        (body['error'] as String?) ?? fallbackCode,
+        (body['message'] as String?) ?? '처리에 실패했습니다.',
+      );
+    }
+    throw LoanOperationException(fallbackCode, '처리에 실패했습니다 (${res.statusCode}).');
+  }
+
+  String _readMessage(Response<dynamic> res, String fallback) {
+    if (res.data is Map) {
+      final body = res.data as Map<String, dynamic>;
+      return (body['message'] as String?) ?? fallback;
+    }
+    return fallback;
+  }
+}

--- a/lib/features/admin_catalog/domain/repositories/admin_loan_repository.dart
+++ b/lib/features/admin_catalog/domain/repositories/admin_loan_repository.dart
@@ -1,0 +1,19 @@
+import '../../data/models/loan.dart';
+
+class LoanOperationException implements Exception {
+  final String code;
+  final String message;
+  const LoanOperationException(this.code, this.message);
+
+  @override
+  String toString() => 'LoanOperationException($code): $message';
+}
+
+abstract class AdminLoanRepository {
+  Future<List<AdminLoanRequest>> fetchPendingRequests();
+  Future<List<Loan>> fetchLoans({String? status});
+
+  Future<Loan> approveRequest(String requestId, {int? dueInDays, String? notes});
+  Future<AdminLoanRequest> rejectRequest(String requestId, String reason);
+  Future<Loan> returnLoan(String loanId);
+}

--- a/lib/features/admin_catalog/presentation/bloc/admin_loans_bloc.dart
+++ b/lib/features/admin_catalog/presentation/bloc/admin_loans_bloc.dart
@@ -1,0 +1,109 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../domain/repositories/admin_loan_repository.dart';
+import 'admin_loans_event.dart';
+import 'admin_loans_state.dart';
+
+class AdminLoansBloc extends Bloc<AdminLoansEvent, AdminLoansState> {
+  final AdminLoanRepository repository;
+
+  AdminLoansBloc({required this.repository})
+      : super(const AdminLoansInitial()) {
+    on<AdminLoansRequested>(_onLoad);
+    on<AdminLoanApproveRequested>(_onApprove);
+    on<AdminLoanRejectRequested>(_onReject);
+    on<AdminLoanReturnRequested>(_onReturn);
+  }
+
+  Future<void> _onLoad(
+    AdminLoansRequested event,
+    Emitter<AdminLoansState> emit,
+  ) async {
+    emit(const AdminLoansLoading());
+    try {
+      final requests = await repository.fetchPendingRequests();
+      // Active+overdue loans are the actionable subset for admins.
+      final loans = await repository.fetchLoans(status: 'active');
+      final overdue = await repository.fetchLoans(status: 'overdue');
+      emit(AdminLoansLoaded(
+        pendingRequests: requests,
+        activeLoans: [...overdue, ...loans],
+      ));
+    } catch (e) {
+      emit(AdminLoansError(e.toString()));
+    }
+  }
+
+  Future<void> _onApprove(
+    AdminLoanApproveRequested event,
+    Emitter<AdminLoansState> emit,
+  ) async {
+    final current = state;
+    if (current is! AdminLoansLoaded) return;
+    emit(current.copyWith(actionStatus: AdminLoanActionStatus.inProgress));
+    try {
+      final loan = await repository.approveRequest(
+        event.requestId,
+        dueInDays: event.dueInDays,
+        notes: event.notes,
+      );
+      emit(current.copyWith(
+        pendingRequests:
+            current.pendingRequests.where((r) => r.id != event.requestId).toList(),
+        activeLoans: [loan, ...current.activeLoans],
+        actionStatus: AdminLoanActionStatus.success,
+        actionMessage: '대출 승인 완료',
+      ));
+    } catch (e) {
+      emit(current.copyWith(
+        actionStatus: AdminLoanActionStatus.failure,
+        actionMessage: e is LoanOperationException ? e.message : e.toString(),
+      ));
+    }
+  }
+
+  Future<void> _onReject(
+    AdminLoanRejectRequested event,
+    Emitter<AdminLoansState> emit,
+  ) async {
+    final current = state;
+    if (current is! AdminLoansLoaded) return;
+    emit(current.copyWith(actionStatus: AdminLoanActionStatus.inProgress));
+    try {
+      await repository.rejectRequest(event.requestId, event.reason);
+      emit(current.copyWith(
+        pendingRequests:
+            current.pendingRequests.where((r) => r.id != event.requestId).toList(),
+        actionStatus: AdminLoanActionStatus.success,
+        actionMessage: '반려 완료',
+      ));
+    } catch (e) {
+      emit(current.copyWith(
+        actionStatus: AdminLoanActionStatus.failure,
+        actionMessage: e is LoanOperationException ? e.message : e.toString(),
+      ));
+    }
+  }
+
+  Future<void> _onReturn(
+    AdminLoanReturnRequested event,
+    Emitter<AdminLoansState> emit,
+  ) async {
+    final current = state;
+    if (current is! AdminLoansLoaded) return;
+    emit(current.copyWith(actionStatus: AdminLoanActionStatus.inProgress));
+    try {
+      await repository.returnLoan(event.loanId);
+      emit(current.copyWith(
+        activeLoans: current.activeLoans.where((l) => l.id != event.loanId).toList(),
+        actionStatus: AdminLoanActionStatus.success,
+        actionMessage: '반납 처리 완료',
+      ));
+    } catch (e) {
+      emit(current.copyWith(
+        actionStatus: AdminLoanActionStatus.failure,
+        actionMessage: e is LoanOperationException ? e.message : e.toString(),
+      ));
+    }
+  }
+}

--- a/lib/features/admin_catalog/presentation/bloc/admin_loans_event.dart
+++ b/lib/features/admin_catalog/presentation/bloc/admin_loans_event.dart
@@ -1,0 +1,38 @@
+import 'package:equatable/equatable.dart';
+
+abstract class AdminLoansEvent extends Equatable {
+  const AdminLoansEvent();
+  @override
+  List<Object?> get props => [];
+}
+
+class AdminLoansRequested extends AdminLoansEvent {
+  const AdminLoansRequested();
+}
+
+class AdminLoanApproveRequested extends AdminLoansEvent {
+  final String requestId;
+  final int? dueInDays;
+  final String? notes;
+  const AdminLoanApproveRequested(this.requestId, {this.dueInDays, this.notes});
+
+  @override
+  List<Object?> get props => [requestId, dueInDays, notes];
+}
+
+class AdminLoanRejectRequested extends AdminLoansEvent {
+  final String requestId;
+  final String reason;
+  const AdminLoanRejectRequested(this.requestId, this.reason);
+
+  @override
+  List<Object?> get props => [requestId, reason];
+}
+
+class AdminLoanReturnRequested extends AdminLoansEvent {
+  final String loanId;
+  const AdminLoanReturnRequested(this.loanId);
+
+  @override
+  List<Object?> get props => [loanId];
+}

--- a/lib/features/admin_catalog/presentation/bloc/admin_loans_state.dart
+++ b/lib/features/admin_catalog/presentation/bloc/admin_loans_state.dart
@@ -1,0 +1,59 @@
+import 'package:equatable/equatable.dart';
+
+import '../../data/models/loan.dart';
+
+enum AdminLoanActionStatus { idle, inProgress, success, failure }
+
+abstract class AdminLoansState extends Equatable {
+  const AdminLoansState();
+  @override
+  List<Object?> get props => [];
+}
+
+class AdminLoansInitial extends AdminLoansState {
+  const AdminLoansInitial();
+}
+
+class AdminLoansLoading extends AdminLoansState {
+  const AdminLoansLoading();
+}
+
+class AdminLoansLoaded extends AdminLoansState {
+  final List<AdminLoanRequest> pendingRequests;
+  final List<Loan> activeLoans;
+  final AdminLoanActionStatus actionStatus;
+  final String? actionMessage;
+
+  const AdminLoansLoaded({
+    required this.pendingRequests,
+    required this.activeLoans,
+    this.actionStatus = AdminLoanActionStatus.idle,
+    this.actionMessage,
+  });
+
+  AdminLoansLoaded copyWith({
+    List<AdminLoanRequest>? pendingRequests,
+    List<Loan>? activeLoans,
+    AdminLoanActionStatus? actionStatus,
+    String? actionMessage,
+  }) {
+    return AdminLoansLoaded(
+      pendingRequests: pendingRequests ?? this.pendingRequests,
+      activeLoans: activeLoans ?? this.activeLoans,
+      actionStatus: actionStatus ?? this.actionStatus,
+      actionMessage: actionMessage,
+    );
+  }
+
+  @override
+  List<Object?> get props =>
+      [pendingRequests, activeLoans, actionStatus, actionMessage];
+}
+
+class AdminLoansError extends AdminLoansState {
+  final String message;
+  const AdminLoansError(this.message);
+
+  @override
+  List<Object?> get props => [message];
+}

--- a/lib/features/admin_catalog/presentation/screens/admin_dashboard_screen.dart
+++ b/lib/features/admin_catalog/presentation/screens/admin_dashboard_screen.dart
@@ -47,6 +47,16 @@ class AdminDashboardScreen extends StatelessWidget {
                         onTap: () => context.go('/admin/catalog'),
                       ),
                     ),
+                    const SizedBox(height: 8),
+                    Card(
+                      child: ListTile(
+                        leading: const Icon(Icons.assignment),
+                        title: const Text('대출 관리'),
+                        subtitle: const Text('대출 요청 승인, 반납 처리, 연체 추적'),
+                        trailing: const Icon(Icons.chevron_right),
+                        onTap: () => context.go('/admin/loans'),
+                      ),
+                    ),
                   ],
                 ),
               ),

--- a/lib/features/admin_catalog/presentation/screens/loans_management_screen.dart
+++ b/lib/features/admin_catalog/presentation/screens/loans_management_screen.dart
@@ -1,0 +1,323 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../../app/config.dart';
+import '../../data/models/loan.dart';
+import '../../data/repositories/admin_loan_repository_impl.dart';
+import '../../domain/repositories/admin_loan_repository.dart';
+import '../bloc/admin_loans_bloc.dart';
+import '../bloc/admin_loans_event.dart';
+import '../bloc/admin_loans_state.dart';
+import '../widgets/admin_sidebar.dart';
+
+class LoansManagementScreen extends StatelessWidget {
+  const LoansManagementScreen({super.key, this.repository});
+
+  final AdminLoanRepository? repository;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider<AdminLoansBloc>(
+      create: (_) => AdminLoansBloc(
+        repository: repository ??
+            AdminLoanRepositoryImpl(baseUrl: AppConfig.apiBaseUrl),
+      )..add(const AdminLoansRequested()),
+      child: const _LoansView(),
+    );
+  }
+}
+
+class _LoansView extends StatelessWidget {
+  const _LoansView();
+
+  @override
+  Widget build(BuildContext context) {
+    return DefaultTabController(
+      length: 2,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('대출 관리'),
+          actions: [
+            IconButton(
+              icon: const Icon(Icons.refresh),
+              tooltip: '새로고침',
+              onPressed: () => context
+                  .read<AdminLoansBloc>()
+                  .add(const AdminLoansRequested()),
+            ),
+          ],
+          bottom: const TabBar(
+            tabs: [
+              Tab(text: '대기 요청'),
+              Tab(text: '진행 중인 대출'),
+            ],
+          ),
+        ),
+        drawer: const AdminSidebar(currentRoute: '/admin/loans'),
+        body: BlocConsumer<AdminLoansBloc, AdminLoansState>(
+          listenWhen: (prev, next) =>
+              next is AdminLoansLoaded &&
+              next.actionMessage != null &&
+              next.actionStatus != AdminLoanActionStatus.idle &&
+              next.actionStatus != AdminLoanActionStatus.inProgress,
+          listener: (context, state) {
+            if (state is AdminLoansLoaded && state.actionMessage != null) {
+              ScaffoldMessenger.of(context)
+                ..hideCurrentSnackBar()
+                ..showSnackBar(SnackBar(content: Text(state.actionMessage!)));
+            }
+          },
+          builder: (context, state) {
+            if (state is AdminLoansInitial || state is AdminLoansLoading) {
+              return const Center(child: CircularProgressIndicator());
+            }
+            if (state is AdminLoansError) {
+              return _ErrorView(message: state.message);
+            }
+            final loaded = state as AdminLoansLoaded;
+            return TabBarView(
+              children: [
+                _PendingTab(requests: loaded.pendingRequests),
+                _ActiveTab(loans: loaded.activeLoans),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _ErrorView extends StatelessWidget {
+  const _ErrorView({required this.message});
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.error_outline,
+              size: 48, color: Theme.of(context).colorScheme.error),
+          const SizedBox(height: 12),
+          Text(message, textAlign: TextAlign.center),
+          const SizedBox(height: 12),
+          FilledButton(
+            onPressed: () => context
+                .read<AdminLoansBloc>()
+                .add(const AdminLoansRequested()),
+            child: const Text('다시 시도'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PendingTab extends StatelessWidget {
+  const _PendingTab({required this.requests});
+  final List<AdminLoanRequest> requests;
+
+  @override
+  Widget build(BuildContext context) {
+    if (requests.isEmpty) {
+      return const Center(child: Text('대기 중인 대출 요청이 없습니다.'));
+    }
+    return ListView.separated(
+      padding: const EdgeInsets.all(16),
+      itemCount: requests.length,
+      separatorBuilder: (_, __) => const Divider(height: 1),
+      itemBuilder: (context, i) => _LoanRequestRow(request: requests[i]),
+    );
+  }
+}
+
+class _ActiveTab extends StatelessWidget {
+  const _ActiveTab({required this.loans});
+  final List<Loan> loans;
+
+  @override
+  Widget build(BuildContext context) {
+    if (loans.isEmpty) {
+      return const Center(child: Text('진행 중인 대출이 없습니다.'));
+    }
+    return ListView.separated(
+      padding: const EdgeInsets.all(16),
+      itemCount: loans.length,
+      separatorBuilder: (_, __) => const Divider(height: 1),
+      itemBuilder: (context, i) => _LoanRow(loan: loans[i]),
+    );
+  }
+}
+
+class _LoanRequestRow extends StatelessWidget {
+  const _LoanRequestRow({required this.request});
+  final AdminLoanRequest request;
+
+  @override
+  Widget build(BuildContext context) {
+    final bookTitle = request.book?.title ?? request.bookId;
+    final studentName = request.student?.fullName ??
+        request.student?.username ??
+        request.studentId;
+    return ListTile(
+      title: Text(bookTitle),
+      subtitle: Text('$studentName · ${_formatDate(request.requestDate)}'),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          IconButton(
+            tooltip: '승인',
+            icon: const Icon(Icons.check_circle_outline, color: Colors.green),
+            onPressed: () => _confirmApprove(context, request),
+          ),
+          IconButton(
+            tooltip: '반려',
+            icon: const Icon(Icons.cancel_outlined, color: Colors.red),
+            onPressed: () => _confirmReject(context, request),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _confirmApprove(
+    BuildContext context,
+    AdminLoanRequest request,
+  ) async {
+    final bloc = context.read<AdminLoansBloc>();
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('대출 승인'),
+        content: Text('"${request.book?.title ?? request.bookId}" 대출을 승인하시겠습니까?\n\n반납 기한: 14일 후'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: const Text('취소'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: const Text('승인'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed == true) {
+      bloc.add(AdminLoanApproveRequested(request.id));
+    }
+  }
+
+  Future<void> _confirmReject(
+    BuildContext context,
+    AdminLoanRequest request,
+  ) async {
+    final bloc = context.read<AdminLoansBloc>();
+    final controller = TextEditingController();
+    final reason = await showDialog<String>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('대출 반려'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text('"${request.book?.title ?? request.bookId}" 반려 사유를 입력하세요.'),
+            const SizedBox(height: 12),
+            TextField(
+              controller: controller,
+              maxLines: 3,
+              decoration: const InputDecoration(
+                border: OutlineInputBorder(),
+                hintText: '예: 동일 도서 미반납',
+              ),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: const Text('취소'),
+          ),
+          FilledButton.tonal(
+            style: FilledButton.styleFrom(
+              backgroundColor: Theme.of(context).colorScheme.errorContainer,
+              foregroundColor: Theme.of(context).colorScheme.onErrorContainer,
+            ),
+            onPressed: () {
+              final value = controller.text.trim();
+              if (value.isEmpty) return;
+              Navigator.of(dialogContext).pop(value);
+            },
+            child: const Text('반려'),
+          ),
+        ],
+      ),
+    );
+    controller.dispose();
+    if (reason != null && reason.isNotEmpty) {
+      bloc.add(AdminLoanRejectRequested(request.id, reason));
+    }
+  }
+}
+
+class _LoanRow extends StatelessWidget {
+  const _LoanRow({required this.loan});
+  final Loan loan;
+
+  @override
+  Widget build(BuildContext context) {
+    final bookTitle = loan.book?.title ?? loan.bookId;
+    final studentName =
+        loan.student?.fullName ?? loan.student?.username ?? loan.studentId;
+    final daysLeft = loan.daysUntilDue(DateTime.now());
+    final overdue = loan.isOverdue || daysLeft < 0;
+    return ListTile(
+      title: Text(bookTitle),
+      subtitle: Text(
+        '$studentName · 만기 ${_formatDate(loan.dueDate)} '
+        '(${overdue ? '연체 ${-daysLeft}일' : 'D-$daysLeft'})',
+        style: TextStyle(
+          color: overdue ? Theme.of(context).colorScheme.error : null,
+          fontWeight: overdue ? FontWeight.bold : null,
+        ),
+      ),
+      trailing: IconButton(
+        tooltip: '반납 처리',
+        icon: const Icon(Icons.assignment_returned_outlined),
+        onPressed: () => _confirmReturn(context, loan),
+      ),
+    );
+  }
+
+  Future<void> _confirmReturn(BuildContext context, Loan loan) async {
+    final bloc = context.read<AdminLoansBloc>();
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('반납 처리'),
+        content: Text('"${loan.book?.title ?? loan.bookId}" 반납으로 처리하시겠습니까?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: const Text('취소'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: const Text('반납'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed == true) {
+      bloc.add(AdminLoanReturnRequested(loan.id));
+    }
+  }
+}
+
+String _formatDate(DateTime dt) {
+  final y = dt.year.toString().padLeft(4, '0');
+  final m = dt.month.toString().padLeft(2, '0');
+  final d = dt.day.toString().padLeft(2, '0');
+  return '$y-$m-$d';
+}

--- a/lib/features/admin_catalog/presentation/widgets/admin_sidebar.dart
+++ b/lib/features/admin_catalog/presentation/widgets/admin_sidebar.dart
@@ -51,6 +51,11 @@ class AdminSidebar extends StatelessWidget {
               selectedIcon: Icon(Icons.book),
               label: Text('도서 관리'),
             ),
+            const NavigationDrawerDestination(
+              icon: Icon(Icons.assignment_outlined),
+              selectedIcon: Icon(Icons.assignment),
+              label: Text('대출 관리'),
+            ),
             const Padding(
               padding: EdgeInsets.fromLTRB(28, 16, 28, 8),
               child: Divider(),
@@ -70,6 +75,7 @@ class AdminSidebar extends StatelessWidget {
 
   int get _selectedIndex {
     if (currentRoute.startsWith('/admin/catalog')) return 1;
+    if (currentRoute.startsWith('/admin/loans')) return 2;
     return 0;
   }
 
@@ -81,6 +87,9 @@ class AdminSidebar extends StatelessWidget {
         break;
       case 1:
         context.go('/admin/catalog');
+        break;
+      case 2:
+        context.go('/admin/loans');
         break;
     }
   }

--- a/specs/001-library-management/tasks.md
+++ b/specs/001-library-management/tasks.md
@@ -280,7 +280,7 @@
 
 ### Tests for User Story 5
 
-- [ ] T132 [P] [US5] Create unit test for Loan model in test/unit_test/models/loan_test.dart
+- [X] T132 [P] [US5] Create unit test for Loan model in test/features/admin_catalog/data/models/loan_test.dart
 - [ ] T133 [P] [US5] Create widget test for loan management screen in test/widget_test/screens/web/loans/loans_screen_test.dart
 - [ ] T134 [P] [US5] Create integration test for loan approval flow in test/integration_test/admin_loan_management_test.dart
 - [X] T135 [P] [US5] Create backend unit test for PUT /loan-requests/:id/approve in backend/tests/unit/loan_requests.test.ts
@@ -291,8 +291,8 @@
 
 **Models & Data Layer**
 
-- [ ] T138 [P] [US5] Create Loan model in lib/models/loan.dart
-- [ ] T139 [US5] Create LoanRepository in lib/repositories/loan_repository.dart
+- [X] T138 [P] [US5] Create Loan model in lib/features/admin_catalog/data/models/loan.dart
+- [X] T139 [US5] Create LoanRepository in lib/features/admin_catalog/{domain,data}/repositories/admin_loan_repository*.dart
 
 **Backend API - Loan Management**
 
@@ -308,19 +308,19 @@
 
 **State Management**
 
-- [ ] T149 [US5] Update LoanBloc to support admin loan management operations
+- [X] T149 [US5] Update LoanBloc to support admin loan management operations *(별도 AdminLoansBloc 신설)*
 
 **UI Components - Web Dashboard**
 
-- [ ] T150 [P] [US5] Create LoanRequestCard widget in lib/widgets/admin/loan_request_card.dart
-- [ ] T151 [P] [US5] Create ActiveLoanCard widget in lib/widgets/admin/active_loan_card.dart
+- [X] T150 [P] [US5] Create LoanRequestCard widget in lib/widgets/admin/loan_request_card.dart *(LoansManagementScreen 내 _LoanRequestRow)*
+- [X] T151 [P] [US5] Create ActiveLoanCard widget in lib/widgets/admin/active_loan_card.dart *(LoansManagementScreen 내 _LoanRow)*
 - [ ] T152 [P] [US5] Create OverdueIndicator widget in lib/widgets/admin/overdue_indicator.dart
 
 **Screens - Web Dashboard**
 
-- [ ] T153 [US5] Create LoanManagementScreen in lib/screens/web/loans/loans_screen.dart
+- [X] T153 [US5] Create LoanManagementScreen in lib/screens/web/loans/loans_screen.dart *(features/admin_catalog/presentation/screens/loans_management_screen.dart)*
 - [ ] T154 [US5] Create LoanHistoryScreen with filters in lib/screens/web/loans/loan_history_screen.dart
-- [ ] T155 [US5] Add loan management routes to admin navigation
+- [X] T155 [US5] Add loan management routes to admin navigation *(/admin/loans + AdminSidebar 메뉴)*
 
 **Integration & Polish**
 

--- a/test/features/admin_catalog/data/models/loan_test.dart
+++ b/test/features/admin_catalog/data/models/loan_test.dart
@@ -1,0 +1,96 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lib_42_flutter/features/admin_catalog/data/models/loan.dart';
+
+void main() {
+  group('Loan model (T132)', () {
+    test('parses loan JSON with nested book/student', () {
+      final loan = Loan.fromJson(const {
+        'id': 'l1',
+        'studentId': 's1',
+        'bookId': 'b1',
+        'status': 'active',
+        'checkoutDate': '2024-01-01T00:00:00.000Z',
+        'dueDate': '2024-01-15T00:00:00.000Z',
+        'approvedBy': 'admin-1',
+        'book': {'id': 'b1', 'title': 'Clean Code', 'author': 'Martin'},
+        'student': {'id': 's1', 'username': 'alice', 'fullName': '앨리스'},
+      });
+
+      expect(loan.id, 'l1');
+      expect(loan.status, LoanStatus.active);
+      expect(loan.book?.title, 'Clean Code');
+      expect(loan.student?.fullName, '앨리스');
+      expect(loan.isActive, isTrue);
+      expect(loan.canBeReturned, isTrue);
+    });
+
+    test('parses overdue and returned status', () {
+      final overdue = Loan.fromJson(const {
+        'id': 'l2',
+        'studentId': 's1',
+        'bookId': 'b1',
+        'status': 'overdue',
+        'checkoutDate': '2024-01-01T00:00:00.000Z',
+        'dueDate': '2024-01-15T00:00:00.000Z',
+        'approvedBy': 'admin-1',
+      });
+      expect(overdue.isOverdue, isTrue);
+      expect(overdue.canBeReturned, isTrue);
+
+      final returned = Loan.fromJson(const {
+        'id': 'l3',
+        'studentId': 's1',
+        'bookId': 'b1',
+        'status': 'returned',
+        'checkoutDate': '2024-01-01T00:00:00.000Z',
+        'dueDate': '2024-01-15T00:00:00.000Z',
+        'returnedDate': '2024-01-10T00:00:00.000Z',
+        'approvedBy': 'admin-1',
+      });
+      expect(returned.isReturned, isTrue);
+      expect(returned.canBeReturned, isFalse);
+      expect(returned.returnedDate, isNotNull);
+    });
+
+    test('throws on unknown status', () {
+      expect(
+        () => Loan.fromJson(const {
+          'id': 'l1',
+          'studentId': 's1',
+          'bookId': 'b1',
+          'status': 'pirate',
+          'checkoutDate': '2024-01-01T00:00:00.000Z',
+          'dueDate': '2024-01-15T00:00:00.000Z',
+          'approvedBy': 'admin-1',
+        }),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('daysUntilDue is positive before due, negative after', () {
+      final loan = Loan.fromJson(const {
+        'id': 'l1',
+        'studentId': 's1',
+        'bookId': 'b1',
+        'status': 'active',
+        'checkoutDate': '2024-01-01T00:00:00.000Z',
+        'dueDate': '2024-01-15T00:00:00.000Z',
+        'approvedBy': 'admin-1',
+      });
+      expect(loan.daysUntilDue(DateTime(2024, 1, 10)), 5);
+      expect(loan.daysUntilDue(DateTime(2024, 1, 20)), -5);
+    });
+
+    test('AdminLoanRequest parses status correctly', () {
+      final req = AdminLoanRequest.fromJson(const {
+        'id': 'r1',
+        'studentId': 's1',
+        'bookId': 'b1',
+        'status': 'pending',
+        'requestDate': '2024-01-01T00:00:00.000Z',
+      });
+      expect(req.isPending, isTrue);
+      expect(req.reviewedAt, isNull);
+    });
+  });
+}

--- a/test/features/admin_catalog/presentation/bloc/admin_loans_bloc_test.dart
+++ b/test/features/admin_catalog/presentation/bloc/admin_loans_bloc_test.dart
@@ -1,0 +1,138 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lib_42_flutter/features/admin_catalog/data/models/loan.dart';
+import 'package:lib_42_flutter/features/admin_catalog/domain/repositories/admin_loan_repository.dart';
+import 'package:lib_42_flutter/features/admin_catalog/presentation/bloc/admin_loans_bloc.dart';
+import 'package:lib_42_flutter/features/admin_catalog/presentation/bloc/admin_loans_event.dart';
+import 'package:lib_42_flutter/features/admin_catalog/presentation/bloc/admin_loans_state.dart';
+
+import '../../../../support/fake_admin_loan_repository.dart';
+
+void main() {
+  group('AdminLoansBloc', () {
+    blocTest<AdminLoansBloc, AdminLoansState>(
+      'load: emits [Loading, Loaded] with pending + active+overdue loans',
+      build: () {
+        final repo = FakeAdminLoanRepository()
+          ..pendingRequests = [makeAdminLoanRequest(id: 'r1')]
+          ..loansByStatus = [makeLoan(id: 'l1')];
+        return AdminLoansBloc(repository: repo);
+      },
+      act: (bloc) => bloc.add(const AdminLoansRequested()),
+      expect: () => [
+        isA<AdminLoansLoading>(),
+        // Bloc fetches active and overdue separately via fake; both queries
+        // return the same single mock loan, so we end up with 2 entries.
+        isA<AdminLoansLoaded>()
+            .having((s) => s.pendingRequests.length, 'pending', 1)
+            .having((s) => s.activeLoans.length, 'active', 2),
+      ],
+    );
+
+    blocTest<AdminLoansBloc, AdminLoansState>(
+      'load: emits [Loading, Error] on repository failure',
+      build: () {
+        final repo = FakeAdminLoanRepository()..error = Exception('boom');
+        return AdminLoansBloc(repository: repo);
+      },
+      act: (bloc) => bloc.add(const AdminLoansRequested()),
+      expect: () => [isA<AdminLoansLoading>(), isA<AdminLoansError>()],
+    );
+
+    blocTest<AdminLoansBloc, AdminLoansState>(
+      'approve: removes request and prepends new loan',
+      build: () {
+        final repo = FakeAdminLoanRepository()
+          ..approveResult = makeLoan(id: 'new-loan');
+        return AdminLoansBloc(repository: repo);
+      },
+      seed: () => AdminLoansLoaded(
+        pendingRequests: [
+          makeAdminLoanRequest(id: 'r1'),
+          makeAdminLoanRequest(id: 'r2'),
+        ],
+        activeLoans: [makeLoan(id: 'existing')],
+      ),
+      act: (bloc) => bloc.add(const AdminLoanApproveRequested('r1')),
+      expect: () => [
+        isA<AdminLoansLoaded>().having(
+          (s) => s.actionStatus,
+          'inProgress',
+          AdminLoanActionStatus.inProgress,
+        ),
+        isA<AdminLoansLoaded>()
+            .having((s) => s.pendingRequests.length, 'pending', 1)
+            .having((s) => s.pendingRequests.first.id, 'first.id', 'r2')
+            .having((s) => s.activeLoans.first.id, 'new active first', 'new-loan')
+            .having((s) => s.actionStatus, 'success', AdminLoanActionStatus.success),
+      ],
+    );
+
+    blocTest<AdminLoansBloc, AdminLoansState>(
+      'approve: surfaces failure message via LoanOperationException',
+      build: () {
+        final repo = FakeAdminLoanRepository()
+          ..error = const LoanOperationException('book_unavailable', '도서 가용량 0');
+        return AdminLoansBloc(repository: repo);
+      },
+      seed: () => AdminLoansLoaded(
+        pendingRequests: [makeAdminLoanRequest(id: 'r1')],
+        activeLoans: const [],
+      ),
+      act: (bloc) => bloc.add(const AdminLoanApproveRequested('r1')),
+      expect: () => [
+        isA<AdminLoansLoaded>().having(
+          (s) => s.actionStatus,
+          'inProgress',
+          AdminLoanActionStatus.inProgress,
+        ),
+        isA<AdminLoansLoaded>()
+            .having((s) => s.actionStatus, 'failure',
+                AdminLoanActionStatus.failure)
+            .having((s) => s.actionMessage, 'message', '도서 가용량 0')
+            .having((s) => s.pendingRequests.length, 'pending preserved', 1),
+      ],
+    );
+
+    blocTest<AdminLoansBloc, AdminLoansState>(
+      'reject: removes request from pending list',
+      build: () => AdminLoansBloc(repository: FakeAdminLoanRepository()),
+      seed: () => AdminLoansLoaded(
+        pendingRequests: [makeAdminLoanRequest(id: 'r1'), makeAdminLoanRequest(id: 'r2')],
+        activeLoans: const [],
+      ),
+      act: (bloc) =>
+          bloc.add(const AdminLoanRejectRequested('r1', '동일 도서 미반납')),
+      expect: () => [
+        isA<AdminLoansLoaded>().having(
+          (s) => s.actionStatus,
+          'inProgress',
+          AdminLoanActionStatus.inProgress,
+        ),
+        isA<AdminLoansLoaded>()
+            .having((s) => s.pendingRequests.length, 'pending', 1)
+            .having((s) => s.pendingRequests.first.id, 'first.id', 'r2')
+            .having((s) => s.actionStatus, 'success', AdminLoanActionStatus.success),
+      ],
+    );
+
+    blocTest<AdminLoansBloc, AdminLoansState>(
+      'return: removes loan from active list',
+      build: () => AdminLoansBloc(repository: FakeAdminLoanRepository()),
+      seed: () => AdminLoansLoaded(
+        pendingRequests: const [],
+        activeLoans: [makeLoan(id: 'l1'), makeLoan(id: 'l2')],
+      ),
+      act: (bloc) => bloc.add(const AdminLoanReturnRequested('l1')),
+      expect: () => [
+        isA<AdminLoansLoaded>().having((s) => s.actionStatus, 'inProgress',
+            AdminLoanActionStatus.inProgress),
+        isA<AdminLoansLoaded>()
+            .having((s) => s.activeLoans.length, 'active', 1)
+            .having((s) => s.activeLoans.first.id, 'first.id', 'l2')
+            .having((s) => s.actionStatus, 'success',
+                AdminLoanActionStatus.success),
+      ],
+    );
+  });
+}

--- a/test/support/fake_admin_loan_repository.dart
+++ b/test/support/fake_admin_loan_repository.dart
@@ -1,0 +1,112 @@
+import 'package:lib_42_flutter/features/admin_catalog/data/models/loan.dart';
+import 'package:lib_42_flutter/features/admin_catalog/domain/repositories/admin_loan_repository.dart';
+
+class FakeAdminLoanRepository implements AdminLoanRepository {
+  List<AdminLoanRequest> pendingRequests = [];
+  List<Loan> loansByStatus = [];
+  Loan? approveResult;
+  AdminLoanRequest? rejectResult;
+  Loan? returnResult;
+  Exception? error;
+
+  int approveCalls = 0;
+  int rejectCalls = 0;
+  int returnCalls = 0;
+
+  @override
+  Future<List<AdminLoanRequest>> fetchPendingRequests() async {
+    if (error != null) throw error!;
+    return pendingRequests;
+  }
+
+  @override
+  Future<List<Loan>> fetchLoans({String? status}) async {
+    if (error != null) throw error!;
+    return loansByStatus;
+  }
+
+  @override
+  Future<Loan> approveRequest(
+    String requestId, {
+    int? dueInDays,
+    String? notes,
+  }) async {
+    approveCalls++;
+    if (error != null) throw error!;
+    return approveResult ?? makeLoan(id: 'loan-$requestId');
+  }
+
+  @override
+  Future<AdminLoanRequest> rejectRequest(String requestId, String reason) async {
+    rejectCalls++;
+    if (error != null) throw error!;
+    return rejectResult ??
+        makeAdminLoanRequest(
+          id: requestId,
+          status: LoanRequestStatusFront.rejected,
+          rejectionReason: reason,
+        );
+  }
+
+  @override
+  Future<Loan> returnLoan(String loanId) async {
+    returnCalls++;
+    if (error != null) throw error!;
+    return returnResult ??
+        makeLoan(
+          id: loanId,
+          status: LoanStatus.returned,
+          returnedDate: DateTime(2024, 6, 1),
+        );
+  }
+}
+
+Loan makeLoan({
+  String id = 'loan-1',
+  String studentId = 'stu-1',
+  String bookId = 'book-1',
+  LoanStatus status = LoanStatus.active,
+  DateTime? checkoutDate,
+  DateTime? dueDate,
+  DateTime? returnedDate,
+  String approvedBy = 'admin-1',
+  LoanBookSummary? book,
+  LoanStudentSummary? student,
+}) {
+  return Loan(
+    id: id,
+    studentId: studentId,
+    bookId: bookId,
+    status: status,
+    checkoutDate: checkoutDate ?? DateTime(2024, 1, 1),
+    dueDate: dueDate ?? DateTime(2024, 1, 15),
+    returnedDate: returnedDate,
+    approvedBy: approvedBy,
+    book: book,
+    student: student,
+  );
+}
+
+AdminLoanRequest makeAdminLoanRequest({
+  String id = 'req-1',
+  String studentId = 'stu-1',
+  String bookId = 'book-1',
+  LoanRequestStatusFront status = LoanRequestStatusFront.pending,
+  DateTime? requestDate,
+  DateTime? reviewedAt,
+  String? rejectionReason,
+  LoanBookSummary? book,
+  LoanStudentSummary? student,
+}) {
+  return AdminLoanRequest(
+    id: id,
+    studentId: studentId,
+    bookId: bookId,
+    status: status,
+    requestDate: requestDate ?? DateTime(2024, 1, 1),
+    reviewedAt: reviewedAt,
+    rejectionReason: rejectionReason,
+    book: book,
+    student: student,
+  );
+}


### PR DESCRIPTION
Closes #89

## 변경 (+1289 / -8)

### 신규 (lib/features/admin_catalog/)
- `data/models/loan.dart` (T138) — Loan + AdminLoanRequest + 중첩 summary 모델
- `domain/repositories/admin_loan_repository.dart` — 인터페이스 + `LoanOperationException`
- `data/repositories/admin_loan_repository_impl.dart` (T139) — Dio + admin 토큰 인터셉터
- `presentation/bloc/admin_loans_{bloc,event,state}.dart` (T149) — 별도 AdminLoansBloc
- `presentation/screens/loans_management_screen.dart` (T153) — TabBar(대기/진행 중) + 행 액션 + 확인 다이얼로그

### UI 통합
- `/admin/loans` 라우트 (T155)
- AdminSidebar 메뉴 + 대시보드 카드

### 동작
- **대기 탭**: 승인 (확인 다이얼로그) / 반려 (사유 입력)
- **진행 중 탭**: 반납 처리. 연체는 빨간색 + 'X일 연체' 표시
- 백엔드 `LoanError` 메시지가 SnackBar로 노출

### 테스트 (11/11 PASS)
- T132 Loan 모델 — 5건 (status 파싱, daysUntilDue)
- AdminLoansBloc — 6건 (load/approve/reject/return + 실패 분기)

### 잔여 (γ 외 후속)
- T133/T134 위젯·통합 테스트 (LoansManagementScreen 자체)
- T152 OverdueIndicator 별도 위젯
- T154 LoanHistoryScreen
- T156-T159 폴리시

tasks.md T132/T138/T139/T149/T150/T151/T153/T155 [X].