### PR TITLE
[Release #96] v0.3.1 패치 — Phase 11 커버리지 게이트

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -15,4 +15,22 @@ module.exports = {
   testTimeout: 30000,
   // Server only opens an HTTP listener when NODE_ENV !== 'test'.
   globalSetup: '<rootDir>/tests/jest.setup.js',
+
+  // Phase 11 / T222 — coverage targets.
+  // Conservative baseline (admin, loan_service, jwt, logger 잘 커버됨).
+  // 점진 상향: 새 PR마다 코드 추가 시 함께 테스트 추가하여 spec MVP 80%로.
+  collectCoverageFrom: [
+    'src/**/*.ts',
+    '!src/server.ts',
+  ],
+  coverageDirectory: 'coverage',
+  coverageReporters: ['text', 'lcov', 'json-summary'],
+  coverageThreshold: {
+    global: {
+      lines: 35,
+      statements: 35,
+      functions: 30,
+      branches: 25,
+    },
+  },
 };

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "42lib-backend",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "42 Learning Space Library Management System - Backend API",
   "main": "src/server.ts",
   "scripts": {

--- a/backend/tests/unit/books.test.ts
+++ b/backend/tests/unit/books.test.ts
@@ -58,7 +58,7 @@ describe('GET /books', () => {
   });
 
   it('should return all books with default pagination', async () => {
-    const response = await request(app).get('/api/books').expect(200);
+    const response = await request(app).get('/api/v1/books').expect(200);
 
     expect(response.body.data).toHaveLength(3);
     expect(response.body.total).toBe(3);
@@ -68,7 +68,7 @@ describe('GET /books', () => {
 
   it('should return books with custom pagination', async () => {
     const response = await request(app)
-      .get('/api/books?page=1&limit=2')
+      .get('/api/v1/books?page=1&limit=2')
       .expect(200);
 
     expect(response.body.data).toHaveLength(2);
@@ -79,7 +79,7 @@ describe('GET /books', () => {
 
   it('should filter books by title', async () => {
     const response = await request(app)
-      .get('/api/books?title=Clean')
+      .get('/api/v1/books?title=Clean')
       .expect(200);
 
     expect(response.body.data).toHaveLength(1);
@@ -88,7 +88,7 @@ describe('GET /books', () => {
 
   it('should filter books by author', async () => {
     const response = await request(app)
-      .get('/api/books?author=Martin')
+      .get('/api/v1/books?author=Martin')
       .expect(200);
 
     expect(response.body.data).toHaveLength(1);
@@ -97,7 +97,7 @@ describe('GET /books', () => {
 
   it('should filter books by category', async () => {
     const response = await request(app)
-      .get('/api/books?category=Programming')
+      .get('/api/v1/books?category=Programming')
       .expect(200);
 
     expect(response.body.data).toHaveLength(2);
@@ -106,7 +106,7 @@ describe('GET /books', () => {
 
   it('should search books by multiple criteria', async () => {
     const response = await request(app)
-      .get('/api/books?title=Design&category=Programming')
+      .get('/api/v1/books?title=Design&category=Programming')
       .expect(200);
 
     expect(response.body.data).toHaveLength(1);
@@ -115,7 +115,7 @@ describe('GET /books', () => {
 
   it('should return empty array when no books match', async () => {
     const response = await request(app)
-      .get('/api/books?title=NonExistent')
+      .get('/api/v1/books?title=NonExistent')
       .expect(200);
 
     expect(response.body.data).toHaveLength(0);
@@ -124,7 +124,7 @@ describe('GET /books', () => {
 
   it('should sort books by title ascending', async () => {
     const response = await request(app)
-      .get('/api/books?sortBy=title&sortOrder=asc')
+      .get('/api/v1/books?sortBy=title&sortOrder=asc')
       .expect(200);
 
     expect(response.body.data[0].title).toBe('Clean Code');
@@ -132,14 +132,14 @@ describe('GET /books', () => {
 
   it('should sort books by createdAt descending', async () => {
     const response = await request(app)
-      .get('/api/books?sortBy=createdAt&sortOrder=desc')
+      .get('/api/v1/books?sortBy=createdAt&sortOrder=desc')
       .expect(200);
 
     expect(response.body.data).toHaveLength(3);
   });
 
   it('should return book with availability status', async () => {
-    const response = await request(app).get('/api/books').expect(200);
+    const response = await request(app).get('/api/v1/books').expect(200);
 
     const availableBook = response.body.data.find(
       (book: any) => book.id === '123e4567-e89b-12d3-a456-426614174000'
@@ -154,7 +154,7 @@ describe('GET /books', () => {
 
   it('should return 400 for invalid pagination parameters', async () => {
     const response = await request(app)
-      .get('/api/books?page=-1&limit=0')
+      .get('/api/v1/books?page=-1&limit=0')
       .expect(400);
 
     expect(response.body.error).toBeDefined();
@@ -162,7 +162,7 @@ describe('GET /books', () => {
 
   it('should handle case-insensitive search', async () => {
     const response = await request(app)
-      .get('/api/books?title=clean%20code')
+      .get('/api/v1/books?title=clean%20code')
       .expect(200);
 
     expect(response.body.data).toHaveLength(1);
@@ -198,7 +198,7 @@ describe('GET /books/:id', () => {
 
   it('should return a book by id', async () => {
     const response = await request(app)
-      .get(`/api/books/${testBookId}`)
+      .get(`/api/v1/books/${testBookId}`)
       .expect(200);
 
     expect(response.body.id).toBe(testBookId);
@@ -210,7 +210,7 @@ describe('GET /books/:id', () => {
   it('should return 404 for non-existent book', async () => {
     const nonExistentId = '123e4567-e89b-12d3-a456-426614174999';
     const response = await request(app)
-      .get(`/api/books/${nonExistentId}`)
+      .get(`/api/v1/books/${nonExistentId}`)
       .expect(404);
 
     expect(response.body.error).toBe('Book not found');
@@ -218,7 +218,7 @@ describe('GET /books/:id', () => {
 
   it('should return 400 for invalid UUID format', async () => {
     const response = await request(app)
-      .get('/api/books/invalid-uuid')
+      .get('/api/v1/books/invalid-uuid')
       .expect(400);
 
     expect(response.body.error).toBeDefined();
@@ -226,7 +226,7 @@ describe('GET /books/:id', () => {
 
   it('should include all book fields', async () => {
     const response = await request(app)
-      .get(`/api/books/${testBookId}`)
+      .get(`/api/v1/books/${testBookId}`)
       .expect(200);
 
     expect(response.body).toHaveProperty('id');

--- a/backend/tests/unit/books_admin.test.ts
+++ b/backend/tests/unit/books_admin.test.ts
@@ -169,8 +169,7 @@ describe('Admin book CRUD (T068/T069/T070)', () => {
         },
       });
       bookId = book.id;
-      const student = await prisma.student.findUnique({
-        where: { username: STUDENT.username },
+      const student = await prisma.student.findFirst({ where: { username: STUDENT.username },
       });
       studentId = student!.id;
     });

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,29 @@
+# Codecov 설정 (Phase 11 / T220)
+#
+# Project = 전체 커버리지 (regression 방지).
+# Patch   = PR이 추가/변경한 라인 커버리지 (새 코드 품질).
+#
+# 임계는 현재 baseline (Flutter 62.8%, Backend 50%)을 기준으로 보수적 설정.
+# 점진 상향은 PR 단위로 spec MVP 정의(80%)를 향해.
+
+coverage:
+  precision: 1
+  round: down
+  status:
+    project:
+      default:
+        # 전체 커버리지가 1% 이상 떨어지면 실패.
+        target: auto
+        threshold: 1%
+        informational: false
+    patch:
+      default:
+        # 신규/변경 라인의 50% 이상이 테스트 커버리지를 가져야 함.
+        target: 50%
+        threshold: 5%
+        informational: false
+
+comment:
+  layout: 'reach,diff,flags,files'
+  behavior: default
+  require_changes: false

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lib_42_flutter
 description: 42 Learning Space Library Management System - Flutter App
 publish_to: 'none'
-version: 0.3.0+1
+version: 0.3.1+1
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/specs/001-library-management/tasks.md
+++ b/specs/001-library-management/tasks.md
@@ -465,12 +465,12 @@
 
 **Purpose**: Achieve 80% code coverage and validate all success criteria
 
-- [ ] T217 [P] Run all unit tests and verify 60% coverage minimum in test/unit_test/
-- [ ] T218 [P] Run all widget tests and verify 30% coverage minimum in test/widget_test/
-- [ ] T219 [P] Run all integration tests and verify 10% coverage minimum in test/integration_test/
-- [ ] T220 Generate Flutter coverage report with lcov
-- [ ] T221 [P] Run backend unit tests and verify coverage in backend/tests/
-- [ ] T222 Generate backend coverage report with Jest
+- [X] T217 [P] Run all unit tests and verify 60% coverage minimum in test/unit_test/
+- [X] T218 [P] Run all widget tests and verify 30% coverage minimum in test/widget_test/
+- [X] T219 [P] Run all integration tests and verify 10% coverage minimum in test/integration_test/
+- [X] T220 Generate Flutter coverage report with lcov
+- [X] T221 [P] Run backend unit tests and verify coverage in backend/tests/
+- [X] T222 Generate backend coverage report with Jest
 - [ ] T223 [P] Test iOS build on iOS 17, 16, 15, 14 simulators
 - [ ] T224 [P] Test Android build on Android 14, 13, 12, 11 emulators
 - [ ] T225 [P] Test Web build on Chrome, Safari, Firefox, Edge (latest 2 versions)


### PR DESCRIPTION
Closes #96

PR #95 (#94 Phase 11) main 반영. codecov.yml + Jest threshold + books 테스트 정정 (10건 부활). 다음 큰 작업이 새 게이트 아래에서 검증됨.