### PR TITLE
[δ-1 #99] US3 백엔드 — 희망 도서 제출 + 수집 기간 (T163/T164/T168-T171)

### DIFF
--- a/backend/src/routes/collection_periods.ts
+++ b/backend/src/routes/collection_periods.ts
@@ -1,0 +1,27 @@
+// US3: CollectionPeriod routes
+// GET /api/v1/collection-periods/active — public
+
+import express, { Request, Response, NextFunction } from 'express';
+import { suggestionService } from '../services/suggestion_service';
+
+const router = express.Router();
+
+router.get(
+  '/active',
+  async (_req: Request, res: Response, next: NextFunction) => {
+    try {
+      const period = await suggestionService.getActivePeriod();
+      if (!period) {
+        return res.status(404).json({
+          error: 'no_active_period',
+          message: '현재 활성 수집 기간이 없습니다.',
+        });
+      }
+      return res.json({ success: true, data: period });
+    } catch (error) {
+      return next(error);
+    }
+  },
+);
+
+export default router;

--- a/backend/src/routes/suggestions.ts
+++ b/backend/src/routes/suggestions.ts
@@ -1,0 +1,66 @@
+// US3: Suggestion routes
+// POST /api/v1/suggestions      — submit (student)
+// GET  /api/v1/suggestions/my   — student's own list
+
+import express, { Response, NextFunction } from 'express';
+import { z } from 'zod';
+import {
+  authenticateStudent,
+  AuthenticatedRequest,
+} from '../middleware/auth';
+import { suggestionService, SuggestionError } from '../services/suggestion_service';
+
+const router = express.Router();
+
+const submitSchema = z.object({
+  suggestedTitle: z.string().min(1).max(500),
+  suggestedAuthor: z.string().min(1).max(200),
+  reason: z.string().max(1000).optional(),
+});
+
+router.post(
+  '/',
+  authenticateStudent,
+  async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+    const parsed = submitSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({
+        error: 'Bad Request',
+        message: parsed.error.issues[0]?.message ?? 'Invalid payload',
+      });
+    }
+
+    try {
+      const studentId = req.user!.userId;
+      const suggestion = await suggestionService.createSuggestion(
+        studentId,
+        parsed.data,
+      );
+      return res.status(201).json({ success: true, data: suggestion });
+    } catch (error) {
+      if (error instanceof SuggestionError) {
+        const status = error.code === 'duplicate_suggestion' ? 409 : 400;
+        return res
+          .status(status)
+          .json({ error: error.code, message: error.message });
+      }
+      return next(error);
+    }
+  },
+);
+
+router.get(
+  '/my',
+  authenticateStudent,
+  async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+    try {
+      const studentId = req.user!.userId;
+      const data = await suggestionService.getStudentSuggestions(studentId);
+      return res.json({ success: true, data });
+    } catch (error) {
+      return next(error);
+    }
+  },
+);
+
+export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -10,6 +10,8 @@ import authRoutes from './routes/auth';
 import loanRequestRoutes from './routes/loan_requests';
 import loanRoutes from './routes/loans';
 import adminRoutes from './routes/admin';
+import suggestionRoutes from './routes/suggestions';
+import collectionPeriodRoutes from './routes/collection_periods';
 
 const app: Express = express();
 const prisma = new PrismaClient();
@@ -40,6 +42,8 @@ app.use('/api/v1/auth', authRoutes);
 app.use('/api/v1/loan-requests', loanRequestRoutes);
 app.use('/api/v1/loans', loanRoutes);
 app.use('/api/v1/admin', adminRoutes);
+app.use('/api/v1/suggestions', suggestionRoutes);
+app.use('/api/v1/collection-periods', collectionPeriodRoutes);
 
 app.get('/api/v1', (req, res) => {
   res.json({ message: '42lib API v1', status: 'ready' });

--- a/backend/src/services/suggestion_service.ts
+++ b/backend/src/services/suggestion_service.ts
@@ -1,0 +1,111 @@
+// US3: BookSuggestion service — student-submitted book recommendations,
+// scoped to an active collection period.
+// Reference: data-model.md Entity 6 (BookSuggestion), Entity 7 (CollectionPeriod)
+
+import {
+  PrismaClient,
+  PeriodStatus,
+  SuggestionStatus,
+} from '@prisma/client';
+import { logger } from '../utils/logger';
+
+const prisma = new PrismaClient();
+
+export class SuggestionError extends Error {
+  constructor(
+    public code:
+      | 'no_active_period'
+      | 'duplicate_suggestion'
+      | 'period_not_found',
+    message: string,
+  ) {
+    super(message);
+    this.name = 'SuggestionError';
+  }
+}
+
+export class SuggestionService {
+  async getActivePeriod() {
+    return prisma.collectionPeriod.findFirst({
+      where: { status: PeriodStatus.active },
+      orderBy: { startDate: 'desc' },
+    });
+  }
+
+  /**
+   * T168/T171: Submit a new suggestion. Must fall within the currently
+   * active collection period. Dedupes per (student, title, author, period).
+   */
+  async createSuggestion(
+    studentId: string,
+    payload: {
+      suggestedTitle: string;
+      suggestedAuthor: string;
+      reason?: string;
+    },
+  ) {
+    const period = await this.getActivePeriod();
+    if (!period) {
+      throw new SuggestionError(
+        'no_active_period',
+        '현재 활성 수집 기간이 없습니다.',
+      );
+    }
+
+    const trimmedTitle = payload.suggestedTitle.trim();
+    const trimmedAuthor = payload.suggestedAuthor.trim();
+
+    const existing = await prisma.bookSuggestion.findFirst({
+      where: {
+        studentId,
+        collectionPeriodId: period.id,
+        suggestedTitle: trimmedTitle,
+        suggestedAuthor: trimmedAuthor,
+      },
+    });
+    if (existing) {
+      throw new SuggestionError(
+        'duplicate_suggestion',
+        '동일한 도서를 이미 추천했습니다.',
+      );
+    }
+
+    const suggestion = await prisma.bookSuggestion.create({
+      data: {
+        studentId,
+        suggestedTitle: trimmedTitle,
+        suggestedAuthor: trimmedAuthor,
+        reason: payload.reason?.trim() || null,
+        collectionPeriodId: period.id,
+        status: SuggestionStatus.submitted,
+      },
+      include: {
+        collectionPeriod: { select: { id: true, name: true, endDate: true } },
+      },
+    });
+
+    logger.info('Book suggestion submitted', {
+      studentId,
+      suggestionId: suggestion.id,
+      periodId: period.id,
+    });
+    return suggestion;
+  }
+
+  /**
+   * T169: Student's own suggestions across all periods.
+   */
+  async getStudentSuggestions(studentId: string) {
+    return prisma.bookSuggestion.findMany({
+      where: { studentId },
+      orderBy: { submittedAt: 'desc' },
+      include: {
+        collectionPeriod: {
+          select: { id: true, name: true, status: true, endDate: true },
+        },
+      },
+    });
+  }
+}
+
+export const suggestionService = new SuggestionService();

--- a/backend/tests/unit/collection_periods.test.ts
+++ b/backend/tests/unit/collection_periods.test.ts
@@ -1,0 +1,59 @@
+// T164: GET /api/v1/collection-periods/active
+
+import request from 'supertest';
+import { app } from '../../src/server';
+import { PrismaClient, PeriodStatus } from '@prisma/client';
+
+const prisma = new PrismaClient();
+const NAME_PREFIX = '[T164]';
+
+async function cleanup(): Promise<void> {
+  await prisma.bookSuggestion.deleteMany({
+    where: { collectionPeriod: { name: { startsWith: NAME_PREFIX } } },
+  });
+  await prisma.collectionPeriod.deleteMany({
+    where: { name: { startsWith: NAME_PREFIX } },
+  });
+}
+
+describe('GET /api/v1/collection-periods/active (T164)', () => {
+  beforeAll(async () => {
+    await cleanup();
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    await prisma.$disconnect();
+  });
+
+  it('returns 404 when no period is active', async () => {
+    // Ensure no active period exists by setting any pre-existing active to closed.
+    await prisma.collectionPeriod.updateMany({
+      where: { status: PeriodStatus.active },
+      data: { status: PeriodStatus.closed },
+    });
+
+    const res = await request(app)
+      .get('/api/v1/collection-periods/active')
+      .expect(404);
+    expect(res.body.error).toBe('no_active_period');
+  });
+
+  it('returns active period', async () => {
+    const period = await prisma.collectionPeriod.create({
+      data: {
+        name: `${NAME_PREFIX} 2024 Spring`,
+        startDate: new Date('2024-03-01'),
+        endDate: new Date('2024-05-31'),
+        status: PeriodStatus.active,
+      },
+    });
+
+    const res = await request(app)
+      .get('/api/v1/collection-periods/active')
+      .expect(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.id).toBe(period.id);
+    expect(res.body.data.name).toBe(`${NAME_PREFIX} 2024 Spring`);
+  });
+});

--- a/backend/tests/unit/suggestions.test.ts
+++ b/backend/tests/unit/suggestions.test.ts
@@ -1,0 +1,200 @@
+// T163: BookSuggestion endpoints — submit, list, dedupe, period validation
+
+import request from 'supertest';
+import { app } from '../../src/server';
+import { PrismaClient, PeriodStatus } from '@prisma/client';
+import { generateStudentToken } from '../../src/utils/jwt';
+
+const prisma = new PrismaClient();
+
+const STUDENT = {
+  fortytwoUserId: 980100,
+  username: 'sgst_student',
+  email: 'sgst_student@42.fr',
+  fullName: '추천 테스트 학생',
+};
+
+async function cleanup(): Promise<void> {
+  await prisma.bookSuggestion.deleteMany({
+    where: {
+      OR: [
+        { suggestedTitle: { startsWith: '[T163]' } },
+        { student: { username: STUDENT.username } },
+      ],
+    },
+  });
+  await prisma.collectionPeriod.deleteMany({
+    where: { name: { startsWith: '[T163]' } },
+  });
+  await prisma.student.deleteMany({ where: { username: STUDENT.username } });
+}
+
+describe('Suggestions endpoints (T163)', () => {
+  let studentId: string;
+  let token: string;
+
+  beforeAll(async () => {
+    await cleanup();
+    const student = await prisma.student.create({ data: STUDENT });
+    studentId = student.id;
+    token = generateStudentToken(
+      student.id,
+      student.username,
+      student.email,
+      student.fortytwoUserId,
+    );
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    await prisma.$disconnect();
+  });
+
+  beforeEach(async () => {
+    await prisma.bookSuggestion.deleteMany({ where: { studentId } });
+    await prisma.collectionPeriod.deleteMany({
+      where: { name: { startsWith: '[T163]' } },
+    });
+  });
+
+  describe('POST /api/v1/suggestions', () => {
+    it('rejects anonymous request with 401', async () => {
+      await request(app)
+        .post('/api/v1/suggestions')
+        .send({ suggestedTitle: 'X', suggestedAuthor: 'Y' })
+        .expect(401);
+    });
+
+    it('returns 400 when active period absent', async () => {
+      const res = await request(app)
+        .post('/api/v1/suggestions')
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          suggestedTitle: '[T163] 도서',
+          suggestedAuthor: '저자',
+        })
+        .expect(400);
+      expect(res.body.error).toBe('no_active_period');
+    });
+
+    it('creates suggestion within active period', async () => {
+      await prisma.collectionPeriod.create({
+        data: {
+          name: '[T163] 2024 Q1',
+          startDate: new Date('2024-01-01'),
+          endDate: new Date('2024-03-31'),
+          status: PeriodStatus.active,
+        },
+      });
+
+      const res = await request(app)
+        .post('/api/v1/suggestions')
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          suggestedTitle: '[T163] Effective TypeScript',
+          suggestedAuthor: 'Dan Vanderkam',
+          reason: 'TS 깊은 이해를 위한 책',
+        })
+        .expect(201);
+
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.suggestedTitle).toBe('[T163] Effective TypeScript');
+      expect(res.body.data.status).toBe('submitted');
+    });
+
+    it('returns 400 when payload missing required fields', async () => {
+      await prisma.collectionPeriod.create({
+        data: {
+          name: '[T163] 2024 Q1 v',
+          startDate: new Date('2024-01-01'),
+          endDate: new Date('2024-03-31'),
+          status: PeriodStatus.active,
+        },
+      });
+      await request(app)
+        .post('/api/v1/suggestions')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ suggestedTitle: '' })
+        .expect(400);
+    });
+
+    it('rejects duplicate title+author for same student in same period', async () => {
+      await prisma.collectionPeriod.create({
+        data: {
+          name: '[T163] 2024 Q1 dedupe',
+          startDate: new Date('2024-01-01'),
+          endDate: new Date('2024-03-31'),
+          status: PeriodStatus.active,
+        },
+      });
+
+      await request(app)
+        .post('/api/v1/suggestions')
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          suggestedTitle: '[T163] Dup Book',
+          suggestedAuthor: 'Author',
+        })
+        .expect(201);
+
+      const res = await request(app)
+        .post('/api/v1/suggestions')
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          suggestedTitle: '[T163] Dup Book',
+          suggestedAuthor: 'Author',
+        })
+        .expect(409);
+      expect(res.body.error).toBe('duplicate_suggestion');
+    });
+  });
+
+  describe('GET /api/v1/suggestions/my', () => {
+    it('returns empty array for new student', async () => {
+      const res = await request(app)
+        .get('/api/v1/suggestions/my')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+      expect(res.body.data).toEqual([]);
+    });
+
+    it('returns student own suggestions in reverse chronological order', async () => {
+      const period = await prisma.collectionPeriod.create({
+        data: {
+          name: '[T163] my list period',
+          startDate: new Date('2024-01-01'),
+          endDate: new Date('2024-03-31'),
+          status: PeriodStatus.active,
+        },
+      });
+
+      await prisma.bookSuggestion.create({
+        data: {
+          studentId,
+          collectionPeriodId: period.id,
+          suggestedTitle: '[T163] First',
+          suggestedAuthor: 'A',
+          submittedAt: new Date('2024-02-01'),
+        },
+      });
+      await prisma.bookSuggestion.create({
+        data: {
+          studentId,
+          collectionPeriodId: period.id,
+          suggestedTitle: '[T163] Second',
+          suggestedAuthor: 'B',
+          submittedAt: new Date('2024-02-10'),
+        },
+      });
+
+      const res = await request(app)
+        .get('/api/v1/suggestions/my')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+
+      expect(res.body.data).toHaveLength(2);
+      expect(res.body.data[0].suggestedTitle).toBe('[T163] Second'); // newest first
+      expect(res.body.data[1].suggestedTitle).toBe('[T163] First');
+    });
+  });
+});

--- a/specs/001-library-management/tasks.md
+++ b/specs/001-library-management/tasks.md
@@ -344,8 +344,8 @@
 - [ ] T160 [P] [US3] Create unit test for BookSuggestion model in test/unit_test/models/book_suggestion_test.dart
 - [ ] T161 [P] [US3] Create unit test for CollectionPeriod model in test/unit_test/models/collection_period_test.dart
 - [ ] T162 [P] [US3] Create widget test for suggestion form in test/widget_test/screens/mobile/suggestions/suggestion_form_test.dart
-- [ ] T163 [P] [US3] Create backend unit test for POST /suggestions in backend/tests/unit/suggestions.test.ts
-- [ ] T164 [P] [US3] Create backend unit test for collection period validation in backend/tests/unit/collection_periods.test.ts
+- [X] T163 [P] [US3] Create backend unit test for POST /suggestions in backend/tests/unit/suggestions.test.ts
+- [X] T164 [P] [US3] Create backend unit test for collection period validation in backend/tests/unit/collection_periods.test.ts
 
 ### Implementation for User Story 3
 
@@ -357,10 +357,10 @@
 
 **Backend API - Suggestions**
 
-- [ ] T168 [P] [US3] Implement POST /suggestions endpoint in backend/src/routes/suggestions.ts
-- [ ] T169 [P] [US3] Implement GET /suggestions/my endpoint in backend/src/routes/suggestions.ts
-- [ ] T170 [P] [US3] Implement GET /collection-periods/active endpoint in backend/src/routes/collection_periods.ts
-- [ ] T171 [US3] Add collection period validation to suggestion submission in backend/src/services/suggestion_service.ts
+- [X] T168 [P] [US3] Implement POST /suggestions endpoint in backend/src/routes/suggestions.ts
+- [X] T169 [P] [US3] Implement GET /suggestions/my endpoint in backend/src/routes/suggestions.ts
+- [X] T170 [P] [US3] Implement GET /collection-periods/active endpoint in backend/src/routes/collection_periods.ts
+- [X] T171 [US3] Add collection period validation to suggestion submission in backend/src/services/suggestion_service.ts
 
 **State Management**
 


### PR DESCRIPTION
Closes #99

## 변경 (+473 / -6)

### 신규 파일
- `services/suggestion_service.ts` — getActivePeriod, createSuggestion (활성 기간 검증 + dedupe), getStudentSuggestions
- `routes/suggestions.ts` — POST / + GET /my (student 인증, zod 검증)
- `routes/collection_periods.ts` — GET /active (public)

### 핵심 로직
- 제출은 status='active'인 CollectionPeriod가 있어야 통과 (없으면 400 `no_active_period`)
- (student, title, author, period) 같은 조합 dedupe → 409 `duplicate_suggestion`
- 메시지는 한국어 `SuggestionError`로 일관

### 테스트 (9/9 PASS)
- POST: 401 / 400 (no period) / 201 / 400 (payload) / 409 (dup)
- GET /my: 빈 배열 / 최신순 정렬
- GET /collection-periods/active: 404 부재 / 200 활성

tasks.md T163/T164/T168-T171 [X]. T165-T167/T172-T177은 δ-2.