### PR TITLE
[δ-2 #101] US3 프론트 — 희망 도서 제출 UI (T160/T161/T165-T167/T172-T177)

### DIFF
--- a/lib/core/routes/app_router.dart
+++ b/lib/core/routes/app_router.dart
@@ -6,6 +6,8 @@ import '../../features/admin_catalog/presentation/screens/admin_dashboard_screen
 import '../../features/admin_catalog/presentation/screens/admin_login_screen.dart';
 import '../../features/admin_catalog/presentation/screens/catalog_management_screen.dart';
 import '../../features/admin_catalog/presentation/screens/loans_management_screen.dart';
+import '../../features/book_suggestions/presentation/screens/my_suggestions_screen.dart';
+import '../../features/book_suggestions/presentation/screens/suggestion_form_screen.dart';
 import '../../features/books/presentation/screens/book_list_screen.dart';
 import '../../models/book.dart';
 import '../../screens/mobile/auth/login_screen.dart';
@@ -63,6 +65,16 @@ class AppRouter {
         GoRoute(
           path: '/my-loans',
           builder: (context, state) => const MyLoansScreen(),
+        ),
+
+        // Suggestions (US3)
+        GoRoute(
+          path: '/suggestions/mine',
+          builder: (context, state) => const MySuggestionsScreen(),
+        ),
+        GoRoute(
+          path: '/suggestions/new',
+          builder: (context, state) => const SuggestionFormScreen(),
         ),
 
         // Admin

--- a/lib/features/book_suggestions/data/models/book_suggestion.dart
+++ b/lib/features/book_suggestions/data/models/book_suggestion.dart
@@ -1,0 +1,126 @@
+import 'package:equatable/equatable.dart';
+
+import 'collection_period.dart';
+
+enum SuggestionStatus { submitted, approved, rejected, underReview }
+
+SuggestionStatus _parseSuggestionStatus(String raw) {
+  switch (raw) {
+    case 'submitted':
+      return SuggestionStatus.submitted;
+    case 'approved':
+      return SuggestionStatus.approved;
+    case 'rejected':
+      return SuggestionStatus.rejected;
+    case 'under_review':
+      return SuggestionStatus.underReview;
+    default:
+      throw ArgumentError('Unknown suggestion status: $raw');
+  }
+}
+
+/// CollectionPeriod summary embedded in suggestion responses.
+class SuggestionPeriodSummary extends Equatable {
+  final String id;
+  final String name;
+  final PeriodStatus? status;
+  final DateTime endDate;
+
+  const SuggestionPeriodSummary({
+    required this.id,
+    required this.name,
+    this.status,
+    required this.endDate,
+  });
+
+  factory SuggestionPeriodSummary.fromJson(Map<String, dynamic> json) {
+    return SuggestionPeriodSummary(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      status: json['status'] is String
+          ? CollectionPeriod.fromJson({
+              'id': json['id'] as String,
+              'name': json['name'] as String,
+              'startDate':
+                  json['startDate'] as String? ?? '1970-01-01T00:00:00.000Z',
+              'endDate': json['endDate'] as String,
+              'status': json['status'] as String,
+            }).status
+          : null,
+      endDate: DateTime.parse(json['endDate'] as String),
+    );
+  }
+
+  @override
+  List<Object?> get props => [id, name, status, endDate];
+}
+
+class BookSuggestion extends Equatable {
+  final String id;
+  final String studentId;
+  final String suggestedTitle;
+  final String suggestedAuthor;
+  final String? reason;
+  final String collectionPeriodId;
+  final SuggestionStatus status;
+  final DateTime submittedAt;
+  final DateTime? reviewedAt;
+  final String? reviewedBy;
+  final String? adminNotes;
+  final SuggestionPeriodSummary? collectionPeriod;
+
+  const BookSuggestion({
+    required this.id,
+    required this.studentId,
+    required this.suggestedTitle,
+    required this.suggestedAuthor,
+    this.reason,
+    required this.collectionPeriodId,
+    required this.status,
+    required this.submittedAt,
+    this.reviewedAt,
+    this.reviewedBy,
+    this.adminNotes,
+    this.collectionPeriod,
+  });
+
+  factory BookSuggestion.fromJson(Map<String, dynamic> json) {
+    return BookSuggestion(
+      id: json['id'] as String,
+      studentId: json['studentId'] as String,
+      suggestedTitle: json['suggestedTitle'] as String,
+      suggestedAuthor: json['suggestedAuthor'] as String,
+      reason: json['reason'] as String?,
+      collectionPeriodId: json['collectionPeriodId'] as String,
+      status: _parseSuggestionStatus(json['status'] as String),
+      submittedAt: DateTime.parse(json['submittedAt'] as String),
+      reviewedAt: json['reviewedAt'] == null
+          ? null
+          : DateTime.parse(json['reviewedAt'] as String),
+      reviewedBy: json['reviewedBy'] as String?,
+      adminNotes: json['adminNotes'] as String?,
+      collectionPeriod: json['collectionPeriod'] is Map<String, dynamic>
+          ? SuggestionPeriodSummary.fromJson(
+              json['collectionPeriod'] as Map<String, dynamic>,
+            )
+          : null,
+    );
+  }
+
+  bool get isSubmitted => status == SuggestionStatus.submitted;
+  bool get isApproved => status == SuggestionStatus.approved;
+  bool get isRejected => status == SuggestionStatus.rejected;
+  bool get isUnderReview => status == SuggestionStatus.underReview;
+
+  @override
+  List<Object?> get props => [
+        id,
+        studentId,
+        suggestedTitle,
+        suggestedAuthor,
+        reason,
+        collectionPeriodId,
+        status,
+        submittedAt,
+      ];
+}

--- a/lib/features/book_suggestions/data/models/collection_period.dart
+++ b/lib/features/book_suggestions/data/models/collection_period.dart
@@ -1,0 +1,53 @@
+import 'package:equatable/equatable.dart';
+
+enum PeriodStatus { upcoming, active, closed }
+
+PeriodStatus _parsePeriodStatus(String raw) {
+  switch (raw) {
+    case 'upcoming':
+      return PeriodStatus.upcoming;
+    case 'active':
+      return PeriodStatus.active;
+    case 'closed':
+      return PeriodStatus.closed;
+    default:
+      throw ArgumentError('Unknown period status: $raw');
+  }
+}
+
+class CollectionPeriod extends Equatable {
+  final String id;
+  final String name;
+  final DateTime startDate;
+  final DateTime endDate;
+  final PeriodStatus status;
+
+  const CollectionPeriod({
+    required this.id,
+    required this.name,
+    required this.startDate,
+    required this.endDate,
+    required this.status,
+  });
+
+  factory CollectionPeriod.fromJson(Map<String, dynamic> json) {
+    return CollectionPeriod(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      startDate: DateTime.parse(json['startDate'] as String),
+      endDate: DateTime.parse(json['endDate'] as String),
+      status: _parsePeriodStatus(json['status'] as String),
+    );
+  }
+
+  bool get isActive => status == PeriodStatus.active;
+
+  /// Days remaining until end date (0 if already past).
+  int daysRemaining(DateTime now) {
+    final diff = endDate.difference(now).inDays;
+    return diff < 0 ? 0 : diff;
+  }
+
+  @override
+  List<Object?> get props => [id, name, startDate, endDate, status];
+}

--- a/lib/features/book_suggestions/data/repositories/suggestion_repository_impl.dart
+++ b/lib/features/book_suggestions/data/repositories/suggestion_repository_impl.dart
@@ -1,0 +1,106 @@
+import 'package:dio/dio.dart';
+
+import '../../../../services/storage/secure_storage_service.dart';
+import '../../domain/repositories/suggestion_repository.dart';
+import '../models/book_suggestion.dart';
+import '../models/collection_period.dart';
+
+class SuggestionRepositoryImpl implements SuggestionRepository {
+  SuggestionRepositoryImpl({
+    required String baseUrl,
+    SecureStorageService? storage,
+    Dio? httpClient,
+  })  : _storage = storage ?? SecureStorageService(),
+        _dio = httpClient ?? _build(baseUrl) {
+    _dio.interceptors.add(InterceptorsWrapper(
+      onRequest: (options, handler) async {
+        // Student JWT for /suggestions; /collection-periods/active is public.
+        final token = await _storage.readToken();
+        if (token != null && token.isNotEmpty) {
+          options.headers['Authorization'] = 'Bearer $token';
+        }
+        return handler.next(options);
+      },
+    ));
+  }
+
+  static Dio _build(String baseUrl) => Dio(
+        BaseOptions(
+          baseUrl: baseUrl,
+          connectTimeout: const Duration(seconds: 15),
+          receiveTimeout: const Duration(seconds: 15),
+          headers: {'Content-Type': 'application/json'},
+          validateStatus: (s) => s != null && s < 500,
+        ),
+      );
+
+  final SecureStorageService _storage;
+  final Dio _dio;
+
+  @override
+  Future<CollectionPeriod?> fetchActivePeriod() async {
+    final res = await _dio.get<dynamic>('/v1/collection-periods/active');
+    if (res.statusCode == 404) return null;
+    if (res.statusCode != 200 || res.data is! Map) {
+      throw SuggestionException(
+        'unknown',
+        '활성 수집 기간 조회 실패 (${res.statusCode}).',
+      );
+    }
+    final body = res.data as Map<String, dynamic>;
+    return CollectionPeriod.fromJson(body['data'] as Map<String, dynamic>);
+  }
+
+  @override
+  Future<BookSuggestion> submit({
+    required String suggestedTitle,
+    required String suggestedAuthor,
+    String? reason,
+  }) async {
+    final res = await _dio.post<dynamic>(
+      '/v1/suggestions',
+      data: {
+        'suggestedTitle': suggestedTitle,
+        'suggestedAuthor': suggestedAuthor,
+        if (reason != null && reason.isNotEmpty) 'reason': reason,
+      },
+    );
+    if (res.statusCode == 401) {
+      throw const SuggestionException('unauthorized', '로그인이 필요합니다.');
+    }
+    if (res.statusCode == 201 && res.data is Map) {
+      final body = res.data as Map<String, dynamic>;
+      return BookSuggestion.fromJson(body['data'] as Map<String, dynamic>);
+    }
+    if (res.data is Map) {
+      final body = res.data as Map<String, dynamic>;
+      throw SuggestionException(
+        (body['error'] as String?) ?? 'unknown',
+        (body['message'] as String?) ?? '제출에 실패했습니다.',
+      );
+    }
+    throw SuggestionException(
+      'unknown',
+      '제출에 실패했습니다 (${res.statusCode}).',
+    );
+  }
+
+  @override
+  Future<List<BookSuggestion>> fetchMine() async {
+    final res = await _dio.get<dynamic>('/v1/suggestions/my');
+    if (res.statusCode == 401) {
+      throw const SuggestionException('unauthorized', '로그인이 필요합니다.');
+    }
+    if (res.statusCode != 200 || res.data is! Map) {
+      throw SuggestionException(
+        'unknown',
+        '제출 내역 조회 실패 (${res.statusCode}).',
+      );
+    }
+    final body = res.data as Map<String, dynamic>;
+    final list = body['data'] as List<dynamic>;
+    return list
+        .map((j) => BookSuggestion.fromJson(j as Map<String, dynamic>))
+        .toList();
+  }
+}

--- a/lib/features/book_suggestions/domain/repositories/suggestion_repository.dart
+++ b/lib/features/book_suggestions/domain/repositories/suggestion_repository.dart
@@ -1,0 +1,23 @@
+import '../../data/models/book_suggestion.dart';
+import '../../data/models/collection_period.dart';
+
+class SuggestionException implements Exception {
+  final String code; // no_active_period | duplicate_suggestion | network | unauthorized | unknown
+  final String message;
+  const SuggestionException(this.code, this.message);
+
+  @override
+  String toString() => 'SuggestionException($code): $message';
+}
+
+abstract class SuggestionRepository {
+  Future<CollectionPeriod?> fetchActivePeriod();
+
+  Future<BookSuggestion> submit({
+    required String suggestedTitle,
+    required String suggestedAuthor,
+    String? reason,
+  });
+
+  Future<List<BookSuggestion>> fetchMine();
+}

--- a/lib/features/book_suggestions/presentation/bloc/suggestion_bloc.dart
+++ b/lib/features/book_suggestions/presentation/bloc/suggestion_bloc.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../domain/repositories/suggestion_repository.dart';
+import 'suggestion_event.dart';
+import 'suggestion_state.dart';
+
+class SuggestionBloc extends Bloc<SuggestionEvent, SuggestionState> {
+  final SuggestionRepository repository;
+
+  SuggestionBloc({required this.repository})
+      : super(const SuggestionInitial()) {
+    on<SuggestionsRequested>(_onLoad);
+    on<SuggestionSubmitted>(_onSubmit);
+  }
+
+  Future<void> _onLoad(
+    SuggestionsRequested event,
+    Emitter<SuggestionState> emit,
+  ) async {
+    emit(const SuggestionLoading());
+    try {
+      final period = await repository.fetchActivePeriod();
+      final mine = await repository.fetchMine();
+      emit(SuggestionLoaded(activePeriod: period, mySuggestions: mine));
+    } on SuggestionException catch (e) {
+      emit(SuggestionError(e.message));
+    } catch (e) {
+      emit(SuggestionError(e.toString()));
+    }
+  }
+
+  Future<void> _onSubmit(
+    SuggestionSubmitted event,
+    Emitter<SuggestionState> emit,
+  ) async {
+    final current = state;
+    if (current is! SuggestionLoaded) return;
+    emit(current.copyWith(actionStatus: SuggestionActionStatus.inProgress));
+    try {
+      final created = await repository.submit(
+        suggestedTitle: event.suggestedTitle,
+        suggestedAuthor: event.suggestedAuthor,
+        reason: event.reason,
+      );
+      emit(current.copyWith(
+        mySuggestions: [created, ...current.mySuggestions],
+        actionStatus: SuggestionActionStatus.success,
+        actionMessage: '추천이 제출되었습니다.',
+      ));
+    } on SuggestionException catch (e) {
+      emit(current.copyWith(
+        actionStatus: SuggestionActionStatus.failure,
+        actionMessage: e.message,
+      ));
+    } catch (e) {
+      emit(current.copyWith(
+        actionStatus: SuggestionActionStatus.failure,
+        actionMessage: e.toString(),
+      ));
+    }
+  }
+}

--- a/lib/features/book_suggestions/presentation/bloc/suggestion_event.dart
+++ b/lib/features/book_suggestions/presentation/bloc/suggestion_event.dart
@@ -1,0 +1,26 @@
+import 'package:equatable/equatable.dart';
+
+abstract class SuggestionEvent extends Equatable {
+  const SuggestionEvent();
+  @override
+  List<Object?> get props => [];
+}
+
+class SuggestionsRequested extends SuggestionEvent {
+  const SuggestionsRequested();
+}
+
+class SuggestionSubmitted extends SuggestionEvent {
+  final String suggestedTitle;
+  final String suggestedAuthor;
+  final String? reason;
+
+  const SuggestionSubmitted({
+    required this.suggestedTitle,
+    required this.suggestedAuthor,
+    this.reason,
+  });
+
+  @override
+  List<Object?> get props => [suggestedTitle, suggestedAuthor, reason];
+}

--- a/lib/features/book_suggestions/presentation/bloc/suggestion_state.dart
+++ b/lib/features/book_suggestions/presentation/bloc/suggestion_state.dart
@@ -1,0 +1,62 @@
+import 'package:equatable/equatable.dart';
+
+import '../../data/models/book_suggestion.dart';
+import '../../data/models/collection_period.dart';
+
+enum SuggestionActionStatus { idle, inProgress, success, failure }
+
+abstract class SuggestionState extends Equatable {
+  const SuggestionState();
+  @override
+  List<Object?> get props => [];
+}
+
+class SuggestionInitial extends SuggestionState {
+  const SuggestionInitial();
+}
+
+class SuggestionLoading extends SuggestionState {
+  const SuggestionLoading();
+}
+
+class SuggestionLoaded extends SuggestionState {
+  final CollectionPeriod? activePeriod;
+  final List<BookSuggestion> mySuggestions;
+  final SuggestionActionStatus actionStatus;
+  final String? actionMessage;
+
+  const SuggestionLoaded({
+    required this.activePeriod,
+    required this.mySuggestions,
+    this.actionStatus = SuggestionActionStatus.idle,
+    this.actionMessage,
+  });
+
+  SuggestionLoaded copyWith({
+    CollectionPeriod? activePeriod,
+    bool clearActivePeriod = false,
+    List<BookSuggestion>? mySuggestions,
+    SuggestionActionStatus? actionStatus,
+    String? actionMessage,
+  }) {
+    return SuggestionLoaded(
+      activePeriod:
+          clearActivePeriod ? null : (activePeriod ?? this.activePeriod),
+      mySuggestions: mySuggestions ?? this.mySuggestions,
+      actionStatus: actionStatus ?? this.actionStatus,
+      actionMessage: actionMessage,
+    );
+  }
+
+  @override
+  List<Object?> get props =>
+      [activePeriod, mySuggestions, actionStatus, actionMessage];
+}
+
+class SuggestionError extends SuggestionState {
+  final String message;
+  const SuggestionError(this.message);
+
+  @override
+  List<Object?> get props => [message];
+}

--- a/lib/features/book_suggestions/presentation/screens/my_suggestions_screen.dart
+++ b/lib/features/book_suggestions/presentation/screens/my_suggestions_screen.dart
@@ -1,0 +1,251 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../app/config.dart';
+import '../../data/models/book_suggestion.dart';
+import '../../data/repositories/suggestion_repository_impl.dart';
+import '../bloc/suggestion_bloc.dart';
+import '../bloc/suggestion_event.dart';
+import '../bloc/suggestion_state.dart';
+
+class MySuggestionsScreen extends StatelessWidget {
+  const MySuggestionsScreen({super.key, this.bloc});
+
+  final SuggestionBloc? bloc;
+
+  @override
+  Widget build(BuildContext context) {
+    if (bloc != null) {
+      return BlocProvider<SuggestionBloc>.value(
+        value: bloc!,
+        child: const _MySuggestionsView(),
+      );
+    }
+    return BlocProvider<SuggestionBloc>(
+      create: (_) => SuggestionBloc(
+        repository:
+            SuggestionRepositoryImpl(baseUrl: AppConfig.apiBaseUrl),
+      )..add(const SuggestionsRequested()),
+      child: const _MySuggestionsView(),
+    );
+  }
+}
+
+class _MySuggestionsView extends StatelessWidget {
+  const _MySuggestionsView();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('내 희망 도서'),
+        actions: [
+          IconButton(
+            tooltip: '새로고침',
+            icon: const Icon(Icons.refresh),
+            onPressed: () =>
+                context.read<SuggestionBloc>().add(const SuggestionsRequested()),
+          ),
+        ],
+      ),
+      floatingActionButton: BlocBuilder<SuggestionBloc, SuggestionState>(
+        buildWhen: (a, b) => b is SuggestionLoaded || b is SuggestionInitial,
+        builder: (context, state) {
+          if (state is SuggestionLoaded && state.activePeriod != null) {
+            return FloatingActionButton.extended(
+              icon: const Icon(Icons.add),
+              label: const Text('도서 추천'),
+              onPressed: () => context.go('/suggestions/new'),
+            );
+          }
+          return const SizedBox.shrink();
+        },
+      ),
+      body: BlocBuilder<SuggestionBloc, SuggestionState>(
+        builder: (context, state) {
+          if (state is SuggestionLoading || state is SuggestionInitial) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (state is SuggestionError) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const Icon(Icons.error_outline,
+                        size: 56, color: Colors.red),
+                    const SizedBox(height: 12),
+                    Text(state.message, textAlign: TextAlign.center),
+                    const SizedBox(height: 16),
+                    FilledButton(
+                      onPressed: () => context
+                          .read<SuggestionBloc>()
+                          .add(const SuggestionsRequested()),
+                      child: const Text('다시 시도'),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          }
+          final loaded = state as SuggestionLoaded;
+          return Column(
+            children: [
+              if (loaded.activePeriod == null)
+                const _NoActivePeriodBanner()
+              else
+                _ActivePeriodBanner(periodName: loaded.activePeriod!.name),
+              Expanded(
+                child: loaded.mySuggestions.isEmpty
+                    ? const _EmptyState()
+                    : ListView.separated(
+                        padding: const EdgeInsets.fromLTRB(16, 16, 16, 96),
+                        itemCount: loaded.mySuggestions.length,
+                        separatorBuilder: (_, __) => const Divider(height: 1),
+                        itemBuilder: (context, i) =>
+                            _SuggestionTile(suggestion: loaded.mySuggestions[i]),
+                      ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _ActivePeriodBanner extends StatelessWidget {
+  const _ActivePeriodBanner({required this.periodName});
+  final String periodName;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      color: Theme.of(context).colorScheme.primaryContainer,
+      padding: const EdgeInsets.all(12),
+      child: Text(
+        '활성 수집 기간: $periodName',
+        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+              color: Theme.of(context).colorScheme.onPrimaryContainer,
+            ),
+      ),
+    );
+  }
+}
+
+class _NoActivePeriodBanner extends StatelessWidget {
+  const _NoActivePeriodBanner();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      color: Theme.of(context).colorScheme.surfaceContainerHighest,
+      padding: const EdgeInsets.all(12),
+      child: Text(
+        '현재 활성 수집 기간이 없습니다. 새 기간이 열릴 때까지 추천을 제출할 수 없습니다.',
+        style: Theme.of(context).textTheme.bodySmall,
+      ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.lightbulb_outline,
+                size: 56, color: Colors.grey[400]),
+            const SizedBox(height: 12),
+            Text(
+              '아직 제출한 추천이 없습니다.\n우측 하단 + 버튼으로 추천을 시작하세요.',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SuggestionTile extends StatelessWidget {
+  const _SuggestionTile({required this.suggestion});
+  final BookSuggestion suggestion;
+
+  Color _statusColor(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    switch (suggestion.status) {
+      case SuggestionStatus.approved:
+        return Colors.green;
+      case SuggestionStatus.rejected:
+        return scheme.error;
+      case SuggestionStatus.underReview:
+        return Colors.amber.shade700;
+      case SuggestionStatus.submitted:
+        return scheme.primary;
+    }
+  }
+
+  String _statusLabel() {
+    switch (suggestion.status) {
+      case SuggestionStatus.approved:
+        return '승인됨';
+      case SuggestionStatus.rejected:
+        return '반려됨';
+      case SuggestionStatus.underReview:
+        return '검토 중';
+      case SuggestionStatus.submitted:
+        return '제출됨';
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      title: Text(suggestion.suggestedTitle),
+      subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(suggestion.suggestedAuthor),
+          if (suggestion.adminNotes != null)
+            Padding(
+              padding: const EdgeInsets.only(top: 4),
+              child: Text(
+                '관리자 메모: ${suggestion.adminNotes}',
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Colors.grey[700],
+                    ),
+              ),
+            ),
+        ],
+      ),
+      trailing: Container(
+        padding:
+            const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+        decoration: BoxDecoration(
+          color: _statusColor(context).withOpacity(0.12),
+          border: Border.all(color: _statusColor(context).withOpacity(0.4)),
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Text(
+          _statusLabel(),
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: _statusColor(context),
+                fontWeight: FontWeight.w600,
+              ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/book_suggestions/presentation/screens/suggestion_form_screen.dart
+++ b/lib/features/book_suggestions/presentation/screens/suggestion_form_screen.dart
@@ -1,0 +1,161 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+
+import '../bloc/suggestion_bloc.dart';
+import '../bloc/suggestion_event.dart';
+import '../bloc/suggestion_state.dart';
+
+class SuggestionFormScreen extends StatelessWidget {
+  const SuggestionFormScreen({super.key, this.bloc});
+
+  /// In production we expect to be navigated *from* MySuggestionsScreen which
+  /// owns a [SuggestionBloc]; the parent BlocProvider is reachable via `context`.
+  /// For testing we accept an explicit `bloc` and wrap with BlocProvider.value.
+  final SuggestionBloc? bloc;
+
+  @override
+  Widget build(BuildContext context) {
+    if (bloc != null) {
+      return BlocProvider<SuggestionBloc>.value(
+        value: bloc!,
+        child: const _SuggestionFormView(),
+      );
+    }
+    return const _SuggestionFormView();
+  }
+}
+
+class _SuggestionFormView extends StatefulWidget {
+  const _SuggestionFormView();
+
+  @override
+  State<_SuggestionFormView> createState() => _SuggestionFormViewState();
+}
+
+class _SuggestionFormViewState extends State<_SuggestionFormView> {
+  final _formKey = GlobalKey<FormState>();
+  final _title = TextEditingController();
+  final _author = TextEditingController();
+  final _reason = TextEditingController();
+
+  @override
+  void dispose() {
+    _title.dispose();
+    _author.dispose();
+    _reason.dispose();
+    super.dispose();
+  }
+
+  String? _required(String label, String? v) =>
+      (v == null || v.trim().isEmpty) ? '$label을(를) 입력하세요' : null;
+
+  String? _maxLen(String label, String? v, int max) {
+    if (v == null) return null;
+    if (v.length > max) return '$label은(는) $max자 이하여야 합니다';
+    return null;
+  }
+
+  void _submit() {
+    if (!_formKey.currentState!.validate()) return;
+    context.read<SuggestionBloc>().add(SuggestionSubmitted(
+          suggestedTitle: _title.text.trim(),
+          suggestedAuthor: _author.text.trim(),
+          reason: _reason.text.trim().isEmpty ? null : _reason.text.trim(),
+        ));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('도서 추천')),
+      body: BlocConsumer<SuggestionBloc, SuggestionState>(
+        listenWhen: (a, b) =>
+            b is SuggestionLoaded &&
+            (b.actionStatus == SuggestionActionStatus.success ||
+                b.actionStatus == SuggestionActionStatus.failure) &&
+            b.actionMessage != null,
+        listener: (context, state) {
+          if (state is SuggestionLoaded && state.actionMessage != null) {
+            ScaffoldMessenger.of(context)
+              ..hideCurrentSnackBar()
+              ..showSnackBar(SnackBar(content: Text(state.actionMessage!)));
+            if (state.actionStatus == SuggestionActionStatus.success) {
+              context.go('/suggestions/mine');
+            }
+          }
+        },
+        builder: (context, state) {
+          final isInProgress = state is SuggestionLoaded &&
+              state.actionStatus == SuggestionActionStatus.inProgress;
+
+          return Padding(
+            padding: const EdgeInsets.all(24),
+            child: Form(
+              key: _formKey,
+              child: SingleChildScrollView(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    if (state is SuggestionLoaded &&
+                        state.activePeriod != null)
+                      Padding(
+                        padding: const EdgeInsets.only(bottom: 16),
+                        child: Text(
+                          '제출 대상 기간: ${state.activePeriod!.name}',
+                          style: Theme.of(context).textTheme.bodyMedium,
+                        ),
+                      ),
+                    TextFormField(
+                      controller: _title,
+                      decoration: const InputDecoration(
+                        labelText: '제목 *',
+                        helperText: '500자 이내',
+                      ),
+                      validator: (v) =>
+                          _required('제목', v) ?? _maxLen('제목', v, 500),
+                    ),
+                    const SizedBox(height: 12),
+                    TextFormField(
+                      controller: _author,
+                      decoration: const InputDecoration(
+                        labelText: '저자 *',
+                        helperText: '200자 이내',
+                      ),
+                      validator: (v) =>
+                          _required('저자', v) ?? _maxLen('저자', v, 200),
+                    ),
+                    const SizedBox(height: 12),
+                    TextFormField(
+                      controller: _reason,
+                      maxLines: 4,
+                      decoration: const InputDecoration(
+                        labelText: '추천 사유',
+                        helperText: '1000자 이내 (선택)',
+                      ),
+                      validator: (v) => _maxLen('사유', v, 1000),
+                    ),
+                    const SizedBox(height: 24),
+                    FilledButton(
+                      onPressed: isInProgress ? null : _submit,
+                      style: FilledButton.styleFrom(
+                        minimumSize: const Size.fromHeight(48),
+                      ),
+                      child: isInProgress
+                          ? const SizedBox(
+                              width: 20,
+                              height: 20,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            )
+                          : const Text('제출'),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/books/presentation/screens/book_list_screen.dart
+++ b/lib/features/books/presentation/screens/book_list_screen.dart
@@ -57,6 +57,11 @@ class _BookListViewState extends State<_BookListView> {
         centerTitle: true,
         actions: [
           IconButton(
+            icon: const Icon(Icons.lightbulb_outline),
+            tooltip: '내 희망 도서',
+            onPressed: () => context.go('/suggestions/mine'),
+          ),
+          IconButton(
             icon: Icon(_isGridView ? Icons.list : Icons.grid_view),
             onPressed: _toggleView,
             tooltip: _isGridView ? 'List view' : 'Grid view',

--- a/specs/001-library-management/tasks.md
+++ b/specs/001-library-management/tasks.md
@@ -341,8 +341,8 @@
 
 ### Tests for User Story 3
 
-- [ ] T160 [P] [US3] Create unit test for BookSuggestion model in test/unit_test/models/book_suggestion_test.dart
-- [ ] T161 [P] [US3] Create unit test for CollectionPeriod model in test/unit_test/models/collection_period_test.dart
+- [X] T160 [P] [US3] Create unit test for BookSuggestion model in test/unit_test/models/book_suggestion_test.dart
+- [X] T161 [P] [US3] Create unit test for CollectionPeriod model in test/unit_test/models/collection_period_test.dart
 - [ ] T162 [P] [US3] Create widget test for suggestion form in test/widget_test/screens/mobile/suggestions/suggestion_form_test.dart
 - [X] T163 [P] [US3] Create backend unit test for POST /suggestions in backend/tests/unit/suggestions.test.ts
 - [X] T164 [P] [US3] Create backend unit test for collection period validation in backend/tests/unit/collection_periods.test.ts
@@ -351,9 +351,9 @@
 
 **Models & Data Layer**
 
-- [ ] T165 [P] [US3] Create BookSuggestion model in lib/models/book_suggestion.dart
-- [ ] T166 [P] [US3] Create CollectionPeriod model in lib/models/collection_period.dart
-- [ ] T167 [US3] Create BookSuggestionRepository in lib/repositories/book_suggestion_repository.dart
+- [X] T165 [P] [US3] Create BookSuggestion model in lib/models/book_suggestion.dart
+- [X] T166 [P] [US3] Create CollectionPeriod model in lib/models/collection_period.dart
+- [X] T167 [US3] Create BookSuggestionRepository in lib/repositories/book_suggestion_repository.dart
 
 **Backend API - Suggestions**
 
@@ -364,15 +364,15 @@
 
 **State Management**
 
-- [ ] T172 [P] [US3] Create SuggestionEvent classes in lib/state/suggestion/suggestion_event.dart
-- [ ] T173 [P] [US3] Create SuggestionState classes in lib/state/suggestion/suggestion_state.dart
-- [ ] T174 [US3] Implement SuggestionBloc in lib/state/suggestion/suggestion_bloc.dart
+- [X] T172 [P] [US3] Create SuggestionEvent classes in lib/state/suggestion/suggestion_event.dart
+- [X] T173 [P] [US3] Create SuggestionState classes in lib/state/suggestion/suggestion_state.dart
+- [X] T174 [US3] Implement SuggestionBloc in lib/state/suggestion/suggestion_bloc.dart
 
 **Screens**
 
-- [ ] T175 [US3] Create SuggestionFormScreen in lib/screens/mobile/suggestions/suggestion_form_screen.dart
-- [ ] T176 [US3] Create MySuggestionsScreen in lib/screens/mobile/suggestions/my_suggestions_screen.dart
-- [ ] T177 [US3] Add suggestion routes to navigation
+- [X] T175 [US3] Create SuggestionFormScreen in lib/screens/mobile/suggestions/suggestion_form_screen.dart
+- [X] T176 [US3] Create MySuggestionsScreen in lib/screens/mobile/suggestions/my_suggestions_screen.dart
+- [X] T177 [US3] Add suggestion routes to navigation
 
 **Integration & Polish**
 

--- a/test/features/book_suggestions/data/models/book_suggestion_test.dart
+++ b/test/features/book_suggestions/data/models/book_suggestion_test.dart
@@ -1,0 +1,132 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lib_42_flutter/features/book_suggestions/data/models/book_suggestion.dart';
+import 'package:lib_42_flutter/features/book_suggestions/data/models/collection_period.dart';
+
+void main() {
+  group('BookSuggestion model (T160)', () {
+    test('parses submitted suggestion JSON', () {
+      final s = BookSuggestion.fromJson(const {
+        'id': 's1',
+        'studentId': 'stu-1',
+        'suggestedTitle': 'Effective TS',
+        'suggestedAuthor': 'Vanderkam',
+        'reason': '학습용',
+        'collectionPeriodId': 'p1',
+        'status': 'submitted',
+        'submittedAt': '2024-02-01T00:00:00.000Z',
+      });
+      expect(s.id, 's1');
+      expect(s.isSubmitted, isTrue);
+      expect(s.reason, '학습용');
+    });
+
+    test('parses approved/rejected/under_review status', () {
+      final approved = BookSuggestion.fromJson(const {
+        'id': 's2',
+        'studentId': 'stu-1',
+        'suggestedTitle': 'X',
+        'suggestedAuthor': 'Y',
+        'collectionPeriodId': 'p1',
+        'status': 'approved',
+        'submittedAt': '2024-02-01T00:00:00.000Z',
+      });
+      expect(approved.isApproved, isTrue);
+
+      final rejected = BookSuggestion.fromJson(const {
+        'id': 's3',
+        'studentId': 'stu-1',
+        'suggestedTitle': 'X',
+        'suggestedAuthor': 'Y',
+        'collectionPeriodId': 'p1',
+        'status': 'rejected',
+        'submittedAt': '2024-02-01T00:00:00.000Z',
+      });
+      expect(rejected.isRejected, isTrue);
+
+      final review = BookSuggestion.fromJson(const {
+        'id': 's4',
+        'studentId': 'stu-1',
+        'suggestedTitle': 'X',
+        'suggestedAuthor': 'Y',
+        'collectionPeriodId': 'p1',
+        'status': 'under_review',
+        'submittedAt': '2024-02-01T00:00:00.000Z',
+      });
+      expect(review.isUnderReview, isTrue);
+    });
+
+    test('throws on unknown status', () {
+      expect(
+        () => BookSuggestion.fromJson(const {
+          'id': 'x',
+          'studentId': 's',
+          'suggestedTitle': 'T',
+          'suggestedAuthor': 'A',
+          'collectionPeriodId': 'p',
+          'status': 'pirate',
+          'submittedAt': '2024-02-01T00:00:00.000Z',
+        }),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('parses nested collectionPeriod summary', () {
+      final s = BookSuggestion.fromJson(const {
+        'id': 's5',
+        'studentId': 'stu',
+        'suggestedTitle': 'T',
+        'suggestedAuthor': 'A',
+        'collectionPeriodId': 'p1',
+        'status': 'submitted',
+        'submittedAt': '2024-02-01T00:00:00.000Z',
+        'collectionPeriod': {
+          'id': 'p1',
+          'name': '2024 Q1',
+          'status': 'active',
+          'endDate': '2024-03-31T00:00:00.000Z',
+        },
+      });
+      expect(s.collectionPeriod, isNotNull);
+      expect(s.collectionPeriod!.name, '2024 Q1');
+    });
+  });
+
+  group('CollectionPeriod model (T161)', () {
+    test('parses active period and isActive helper', () {
+      final p = CollectionPeriod.fromJson(const {
+        'id': 'p1',
+        'name': '2024 Spring',
+        'startDate': '2024-03-01T00:00:00.000Z',
+        'endDate': '2024-05-31T00:00:00.000Z',
+        'status': 'active',
+      });
+      expect(p.id, 'p1');
+      expect(p.isActive, isTrue);
+    });
+
+    test('throws on unknown status', () {
+      expect(
+        () => CollectionPeriod.fromJson(const {
+          'id': 'p',
+          'name': 'X',
+          'startDate': '2024-01-01T00:00:00.000Z',
+          'endDate': '2024-01-02T00:00:00.000Z',
+          'status': 'eternal',
+        }),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('daysRemaining is positive before end, 0 after', () {
+      final p = CollectionPeriod.fromJson(const {
+        'id': 'p',
+        'name': 'X',
+        'startDate': '2024-01-01T00:00:00.000Z',
+        'endDate': '2024-01-15T00:00:00.000Z',
+        'status': 'active',
+      });
+      expect(p.daysRemaining(DateTime(2024, 1, 10)), 5);
+      expect(p.daysRemaining(DateTime(2024, 1, 20)), 0);
+    });
+  });
+}

--- a/test/features/book_suggestions/presentation/bloc/suggestion_bloc_test.dart
+++ b/test/features/book_suggestions/presentation/bloc/suggestion_bloc_test.dart
@@ -1,0 +1,96 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lib_42_flutter/features/book_suggestions/domain/repositories/suggestion_repository.dart';
+import 'package:lib_42_flutter/features/book_suggestions/presentation/bloc/suggestion_bloc.dart';
+import 'package:lib_42_flutter/features/book_suggestions/presentation/bloc/suggestion_event.dart';
+import 'package:lib_42_flutter/features/book_suggestions/presentation/bloc/suggestion_state.dart';
+
+import '../../../../support/fake_suggestion_repository.dart';
+
+void main() {
+  group('SuggestionBloc', () {
+    blocTest<SuggestionBloc, SuggestionState>(
+      'load: emits [Loading, Loaded] with active period and mine',
+      build: () {
+        final repo = FakeSuggestionRepository()
+          ..activePeriod = makePeriod()
+          ..mine = [makeSuggestion(id: 'a'), makeSuggestion(id: 'b')];
+        return SuggestionBloc(repository: repo);
+      },
+      act: (bloc) => bloc.add(const SuggestionsRequested()),
+      expect: () => [
+        isA<SuggestionLoading>(),
+        isA<SuggestionLoaded>()
+            .having((s) => s.activePeriod?.name, 'period.name', '2024 Q1')
+            .having((s) => s.mySuggestions.length, 'mine count', 2),
+      ],
+    );
+
+    blocTest<SuggestionBloc, SuggestionState>(
+      'load: emits [Loading, Error] when repository throws',
+      build: () {
+        final repo = FakeSuggestionRepository()..error = Exception('boom');
+        return SuggestionBloc(repository: repo);
+      },
+      act: (bloc) => bloc.add(const SuggestionsRequested()),
+      expect: () => [isA<SuggestionLoading>(), isA<SuggestionError>()],
+    );
+
+    blocTest<SuggestionBloc, SuggestionState>(
+      'submit: prepends new suggestion and reports success',
+      build: () {
+        final repo = FakeSuggestionRepository()
+          ..submitResult = makeSuggestion(id: 'new', suggestedTitle: 'N');
+        return SuggestionBloc(repository: repo);
+      },
+      seed: () => SuggestionLoaded(
+        activePeriod: makePeriod(),
+        mySuggestions: [makeSuggestion(id: 'old')],
+      ),
+      act: (bloc) => bloc.add(const SuggestionSubmitted(
+        suggestedTitle: 'N',
+        suggestedAuthor: 'A',
+      )),
+      expect: () => [
+        isA<SuggestionLoaded>().having(
+          (s) => s.actionStatus,
+          'inProgress',
+          SuggestionActionStatus.inProgress,
+        ),
+        isA<SuggestionLoaded>()
+            .having((s) => s.mySuggestions.first.id, 'first.id', 'new')
+            .having((s) => s.mySuggestions.length, 'count', 2)
+            .having((s) => s.actionStatus, 'success',
+                SuggestionActionStatus.success),
+      ],
+    );
+
+    blocTest<SuggestionBloc, SuggestionState>(
+      'submit: surfaces SuggestionException message',
+      build: () {
+        final repo = FakeSuggestionRepository()
+          ..error = const SuggestionException(
+            'duplicate_suggestion',
+            '동일한 도서를 이미 추천했습니다.',
+          );
+        return SuggestionBloc(repository: repo);
+      },
+      seed: () => SuggestionLoaded(
+        activePeriod: makePeriod(),
+        mySuggestions: const [],
+      ),
+      act: (bloc) => bloc.add(const SuggestionSubmitted(
+        suggestedTitle: 'X',
+        suggestedAuthor: 'Y',
+      )),
+      expect: () => [
+        isA<SuggestionLoaded>().having((s) => s.actionStatus, 'inProgress',
+            SuggestionActionStatus.inProgress),
+        isA<SuggestionLoaded>()
+            .having((s) => s.actionStatus, 'failure',
+                SuggestionActionStatus.failure)
+            .having((s) => s.actionMessage, 'message', '동일한 도서를 이미 추천했습니다.'),
+      ],
+    );
+  });
+}

--- a/test/support/fake_suggestion_repository.dart
+++ b/test/support/fake_suggestion_repository.dart
@@ -1,0 +1,75 @@
+import 'package:lib_42_flutter/features/book_suggestions/data/models/book_suggestion.dart';
+import 'package:lib_42_flutter/features/book_suggestions/data/models/collection_period.dart';
+import 'package:lib_42_flutter/features/book_suggestions/domain/repositories/suggestion_repository.dart';
+
+class FakeSuggestionRepository implements SuggestionRepository {
+  CollectionPeriod? activePeriod;
+  List<BookSuggestion> mine = [];
+  BookSuggestion? submitResult;
+  Exception? error;
+
+  int submitCalls = 0;
+  int fetchMineCalls = 0;
+
+  @override
+  Future<CollectionPeriod?> fetchActivePeriod() async {
+    if (error != null) throw error!;
+    return activePeriod;
+  }
+
+  @override
+  Future<List<BookSuggestion>> fetchMine() async {
+    fetchMineCalls++;
+    if (error != null) throw error!;
+    return mine;
+  }
+
+  @override
+  Future<BookSuggestion> submit({
+    required String suggestedTitle,
+    required String suggestedAuthor,
+    String? reason,
+  }) async {
+    submitCalls++;
+    if (error != null) throw error!;
+    return submitResult ??
+        makeSuggestion(suggestedTitle: suggestedTitle, suggestedAuthor: suggestedAuthor);
+  }
+}
+
+CollectionPeriod makePeriod({
+  String id = 'p1',
+  String name = '2024 Q1',
+  PeriodStatus status = PeriodStatus.active,
+}) {
+  return CollectionPeriod(
+    id: id,
+    name: name,
+    startDate: DateTime(2024, 1, 1),
+    endDate: DateTime(2024, 3, 31),
+    status: status,
+  );
+}
+
+BookSuggestion makeSuggestion({
+  String id = 'sg-1',
+  String studentId = 'stu-1',
+  String suggestedTitle = '추천 도서',
+  String suggestedAuthor = '저자',
+  String? reason,
+  SuggestionStatus status = SuggestionStatus.submitted,
+  String collectionPeriodId = 'p1',
+  String? adminNotes,
+}) {
+  return BookSuggestion(
+    id: id,
+    studentId: studentId,
+    suggestedTitle: suggestedTitle,
+    suggestedAuthor: suggestedAuthor,
+    reason: reason,
+    collectionPeriodId: collectionPeriodId,
+    status: status,
+    submittedAt: DateTime(2024, 2, 1),
+    adminNotes: adminNotes,
+  );
+}


### PR DESCRIPTION
Closes #101

## 변경 (+1201 / -11)

### 신규 (lib/features/book_suggestions/)
- data/models/book_suggestion.dart, collection_period.dart
- data/repositories/suggestion_repository_impl.dart (Dio + 학생 JWT 자동)
- domain/repositories/suggestion_repository.dart + SuggestionException
- presentation/bloc/suggestion_{bloc,event,state}.dart
- presentation/screens/my_suggestions_screen.dart (활성 기간 배너 + 상태 칩)
- presentation/screens/suggestion_form_screen.dart (제목/저자/사유 검증)

### 라우팅 + 진입
- /suggestions/mine, /suggestions/new
- BookListScreen AppBar에 lightbulb 아이콘 → /suggestions/mine

### 테스트 (11/11 PASS)
- T160/T161 모델 테스트 8건
- SuggestionBloc 테스트 4건

tasks.md T160/T161/T165-T167/T172-T177 [X].