### PR TITLE
[δ-3 #103] US6 백엔드 — 관리자 검토 + 기간 관리 (T182-T188)

### DIFF
--- a/backend/src/routes/collection_periods.ts
+++ b/backend/src/routes/collection_periods.ts
@@ -1,7 +1,14 @@
-// US3: CollectionPeriod routes
-// GET /api/v1/collection-periods/active — public
+// CollectionPeriod routes
+// GET  /api/v1/collection-periods/active — public
+// POST /api/v1/collection-periods         — admin (creates new period; new active archives existing active)
 
 import express, { Request, Response, NextFunction } from 'express';
+import { z } from 'zod';
+import { PeriodStatus } from '@prisma/client';
+import {
+  authenticateAdmin,
+  AuthenticatedRequest,
+} from '../middleware/auth';
 import { suggestionService } from '../services/suggestion_service';
 
 const router = express.Router();
@@ -18,6 +25,54 @@ router.get(
         });
       }
       return res.json({ success: true, data: period });
+    } catch (error) {
+      return next(error);
+    }
+  },
+);
+
+const createPeriodSchema = z.object({
+  name: z.string().min(1).max(100),
+  startDate: z.string().min(1),
+  endDate: z.string().min(1),
+  status: z.nativeEnum(PeriodStatus).optional(),
+});
+
+router.post(
+  '/',
+  authenticateAdmin,
+  async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+    const parsed = createPeriodSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({
+        error: 'Bad Request',
+        message: parsed.error.issues[0]?.message ?? 'Invalid payload',
+      });
+    }
+    const { name, startDate, endDate, status } = parsed.data;
+    const start = new Date(startDate);
+    const end = new Date(endDate);
+    if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+      return res.status(400).json({
+        error: 'Bad Request',
+        message: '날짜 형식이 올바르지 않습니다.',
+      });
+    }
+    if (end <= start) {
+      return res.status(400).json({
+        error: 'Bad Request',
+        message: '종료일은 시작일보다 이후여야 합니다.',
+      });
+    }
+
+    try {
+      const period = await suggestionService.createPeriod({
+        name,
+        startDate: start,
+        endDate: end,
+        status,
+      });
+      return res.status(201).json({ success: true, data: period });
     } catch (error) {
       return next(error);
     }

--- a/backend/src/routes/suggestions.ts
+++ b/backend/src/routes/suggestions.ts
@@ -4,8 +4,10 @@
 
 import express, { Response, NextFunction } from 'express';
 import { z } from 'zod';
+import { SuggestionStatus } from '@prisma/client';
 import {
   authenticateStudent,
+  authenticateAdmin,
   AuthenticatedRequest,
 } from '../middleware/auth';
 import { suggestionService, SuggestionError } from '../services/suggestion_service';
@@ -58,6 +60,64 @@ router.get(
       const data = await suggestionService.getStudentSuggestions(studentId);
       return res.json({ success: true, data });
     } catch (error) {
+      return next(error);
+    }
+  },
+);
+
+/**
+ * T184: Admin grouped list — same title+author within a period collapsed.
+ * Optional ?periodId= filter (default = active period).
+ */
+router.get(
+  '/',
+  authenticateAdmin,
+  async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+    try {
+      const periodId = req.query.periodId as string | undefined;
+      const data = await suggestionService.getGroupedSuggestions({ periodId });
+      return res.json({ success: true, data });
+    } catch (error) {
+      return next(error);
+    }
+  },
+);
+
+const reviewSchema = z.object({
+  status: z.nativeEnum(SuggestionStatus),
+  adminNotes: z.string().max(1000).optional(),
+});
+
+/**
+ * T185: Admin reviews a suggestion — sets status + optional adminNotes.
+ */
+router.put(
+  '/:id/status',
+  authenticateAdmin,
+  async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+    const parsed = reviewSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({
+        error: 'Bad Request',
+        message: parsed.error.issues[0]?.message ?? 'Invalid payload',
+      });
+    }
+
+    try {
+      const adminId = req.user!.userId;
+      const updated = await suggestionService.reviewSuggestion(
+        req.params.id,
+        adminId,
+        parsed.data,
+      );
+      return res.json({ success: true, data: updated });
+    } catch (error) {
+      if (error instanceof SuggestionError) {
+        const status = error.code === 'suggestion_not_found' ? 404 : 400;
+        return res
+          .status(status)
+          .json({ error: error.code, message: error.message });
+      }
       return next(error);
     }
   },

--- a/backend/src/services/suggestion_service.ts
+++ b/backend/src/services/suggestion_service.ts
@@ -16,7 +16,9 @@ export class SuggestionError extends Error {
     public code:
       | 'no_active_period'
       | 'duplicate_suggestion'
-      | 'period_not_found',
+      | 'period_not_found'
+      | 'suggestion_not_found'
+      | 'invalid_status',
     message: string,
   ) {
     super(message);
@@ -104,6 +106,146 @@ export class SuggestionService {
           select: { id: true, name: true, status: true, endDate: true },
         },
       },
+    });
+  }
+
+  /**
+   * T184/T187: Admin grouped list — same title+author within a period
+   * collapsed into a single entry with requesterCount and per-status counts.
+   * Optional `periodId` filter; default = active period; if no active period
+   * and no filter, returns all.
+   */
+  async getGroupedSuggestions(filter: { periodId?: string } = {}) {
+    let periodId = filter.periodId;
+    if (!periodId) {
+      const active = await this.getActivePeriod();
+      periodId = active?.id;
+    }
+
+    const where = periodId ? { collectionPeriodId: periodId } : {};
+    const items = await prisma.bookSuggestion.findMany({
+      where,
+      orderBy: { submittedAt: 'desc' },
+      include: {
+        student: { select: { id: true, username: true, fullName: true } },
+        collectionPeriod: { select: { id: true, name: true, status: true, endDate: true } },
+      },
+    });
+
+    // Group in memory — small N (per-period dataset).
+    const groups = new Map<
+      string,
+      {
+        suggestedTitle: string;
+        suggestedAuthor: string;
+        collectionPeriodId: string;
+        requesterCount: number;
+        statuses: Record<string, number>;
+        latestSubmittedAt: Date;
+        items: typeof items;
+      }
+    >();
+
+    for (const s of items) {
+      const key = `${s.suggestedTitle}::${s.suggestedAuthor}::${s.collectionPeriodId}`;
+      const existing = groups.get(key);
+      if (existing) {
+        existing.requesterCount++;
+        existing.statuses[s.status] = (existing.statuses[s.status] ?? 0) + 1;
+        existing.items.push(s);
+        if (s.submittedAt > existing.latestSubmittedAt) {
+          existing.latestSubmittedAt = s.submittedAt;
+        }
+      } else {
+        groups.set(key, {
+          suggestedTitle: s.suggestedTitle,
+          suggestedAuthor: s.suggestedAuthor,
+          collectionPeriodId: s.collectionPeriodId,
+          requesterCount: 1,
+          statuses: { [s.status]: 1 },
+          latestSubmittedAt: s.submittedAt,
+          items: [s],
+        });
+      }
+    }
+
+    return Array.from(groups.values()).sort(
+      (a, b) => b.requesterCount - a.requesterCount,
+    );
+  }
+
+  /**
+   * T185: Admin marks a suggestion as approved/rejected/under_review.
+   * `adminNotes` is optional context shown to the student.
+   */
+  async reviewSuggestion(
+    suggestionId: string,
+    adminId: string,
+    payload: { status: SuggestionStatus; adminNotes?: string },
+  ) {
+    const existing = await prisma.bookSuggestion.findUnique({
+      where: { id: suggestionId },
+    });
+    if (!existing) {
+      throw new SuggestionError(
+        'suggestion_not_found',
+        '제안을 찾을 수 없습니다.',
+      );
+    }
+
+    const updated = await prisma.bookSuggestion.update({
+      where: { id: suggestionId },
+      data: {
+        status: payload.status,
+        reviewedAt: new Date(),
+        reviewedBy: adminId,
+        adminNotes: payload.adminNotes?.trim() || existing.adminNotes,
+      },
+      include: {
+        student: { select: { id: true, username: true, fullName: true } },
+      },
+    });
+
+    logger.info('Suggestion reviewed', {
+      suggestionId,
+      status: payload.status,
+      adminId,
+    });
+    return updated;
+  }
+
+  /**
+   * T186/T188: Admin creates a CollectionPeriod. If new period is `active`,
+   * any pre-existing active period is archived to `closed` (only one active
+   * at a time).
+   */
+  async createPeriod(payload: {
+    name: string;
+    startDate: Date;
+    endDate: Date;
+    status?: PeriodStatus;
+  }) {
+    const status = payload.status ?? PeriodStatus.upcoming;
+
+    return prisma.$transaction(async (tx) => {
+      if (status === PeriodStatus.active) {
+        await tx.collectionPeriod.updateMany({
+          where: { status: PeriodStatus.active },
+          data: { status: PeriodStatus.closed },
+        });
+      }
+
+      const period = await tx.collectionPeriod.create({
+        data: {
+          name: payload.name.trim(),
+          startDate: payload.startDate,
+          endDate: payload.endDate,
+          status,
+        },
+      });
+
+      logger.info('Collection period created', { periodId: period.id, status });
+      return period;
     });
   }
 }

--- a/backend/tests/unit/suggestions_admin.test.ts
+++ b/backend/tests/unit/suggestions_admin.test.ts
@@ -1,0 +1,302 @@
+// T182/T183: Admin suggestion review endpoints + grouping logic.
+
+import request from 'supertest';
+import { app } from '../../src/server';
+import { PrismaClient, PeriodStatus, SuggestionStatus } from '@prisma/client';
+import * as bcrypt from 'bcrypt';
+import { generateAdminToken, generateStudentToken } from '../../src/utils/jwt';
+
+const prisma = new PrismaClient();
+
+const ADMIN = {
+  username: 'sgst_admin',
+  password: 'sgst-admin-pass',
+  email: 'sgst_admin@42lib.kr',
+  fullName: '추천 관리자',
+};
+
+const PREFIX = '[SGST-ADMIN]';
+
+async function cleanup(): Promise<void> {
+  await prisma.bookSuggestion.deleteMany({
+    where: {
+      OR: [
+        { suggestedTitle: { startsWith: PREFIX } },
+        { collectionPeriod: { name: { startsWith: PREFIX } } },
+      ],
+    },
+  });
+  await prisma.collectionPeriod.deleteMany({ where: { name: { startsWith: PREFIX } } });
+  await prisma.student.deleteMany({ where: { username: { startsWith: 'sgst_st_' } } });
+  await prisma.administrator.deleteMany({ where: { username: ADMIN.username } });
+}
+
+describe('Admin suggestion endpoints (T182/T183)', () => {
+  let adminId: string;
+  let adminToken: string;
+  let activePeriodId: string;
+  let studentA: { id: string; token: string };
+  let studentB: { id: string; token: string };
+
+  beforeAll(async () => {
+    await cleanup();
+    const passwordHash = await bcrypt.hash(ADMIN.password, 10);
+    const admin = await prisma.administrator.create({
+      data: {
+        username: ADMIN.username,
+        email: ADMIN.email,
+        fullName: ADMIN.fullName,
+        passwordHash,
+        role: 'admin',
+      },
+    });
+    adminId = admin.id;
+    adminToken = generateAdminToken(admin.id, admin.username, admin.email, admin.role);
+
+    const period = await prisma.collectionPeriod.create({
+      data: {
+        name: `${PREFIX} 2024 Q1`,
+        startDate: new Date('2024-01-01'),
+        endDate: new Date('2024-03-31'),
+        status: PeriodStatus.active,
+      },
+    });
+    activePeriodId = period.id;
+
+    const a = await prisma.student.create({
+      data: {
+        fortytwoUserId: 970201,
+        username: 'sgst_st_a',
+        email: 'sgst_st_a@42.fr',
+        fullName: '학생 A',
+      },
+    });
+    const b = await prisma.student.create({
+      data: {
+        fortytwoUserId: 970202,
+        username: 'sgst_st_b',
+        email: 'sgst_st_b@42.fr',
+        fullName: '학생 B',
+      },
+    });
+    studentA = {
+      id: a.id,
+      token: generateStudentToken(a.id, a.username, a.email, a.fortytwoUserId),
+    };
+    studentB = {
+      id: b.id,
+      token: generateStudentToken(b.id, b.username, b.email, b.fortytwoUserId),
+    };
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    await prisma.$disconnect();
+  });
+
+  describe('GET /api/v1/suggestions (admin grouped, T184)', () => {
+    beforeAll(async () => {
+      // Two students suggesting the same book → grouped count=2
+      await prisma.bookSuggestion.create({
+        data: {
+          studentId: studentA.id,
+          collectionPeriodId: activePeriodId,
+          suggestedTitle: `${PREFIX} Effective TS`,
+          suggestedAuthor: 'Vanderkam',
+          status: SuggestionStatus.submitted,
+        },
+      });
+      await prisma.bookSuggestion.create({
+        data: {
+          studentId: studentB.id,
+          collectionPeriodId: activePeriodId,
+          suggestedTitle: `${PREFIX} Effective TS`,
+          suggestedAuthor: 'Vanderkam',
+          status: SuggestionStatus.submitted,
+        },
+      });
+      // Single different book → group count=1
+      await prisma.bookSuggestion.create({
+        data: {
+          studentId: studentA.id,
+          collectionPeriodId: activePeriodId,
+          suggestedTitle: `${PREFIX} Solo Book`,
+          suggestedAuthor: 'Lonely',
+          status: SuggestionStatus.submitted,
+        },
+      });
+    });
+
+    it('rejects student token (admin only)', async () => {
+      await request(app)
+        .get('/api/v1/suggestions')
+        .set('Authorization', `Bearer ${studentA.token}`)
+        .expect(403);
+    });
+
+    it('returns grouped list ordered by requesterCount desc', async () => {
+      const res = await request(app)
+        .get('/api/v1/suggestions')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .expect(200);
+
+      expect(Array.isArray(res.body.data)).toBe(true);
+      const effective = res.body.data.find(
+        (g: any) => g.suggestedTitle === `${PREFIX} Effective TS`,
+      );
+      const solo = res.body.data.find(
+        (g: any) => g.suggestedTitle === `${PREFIX} Solo Book`,
+      );
+
+      expect(effective).toBeDefined();
+      expect(effective.requesterCount).toBe(2);
+      expect(effective.items).toHaveLength(2);
+      expect(solo.requesterCount).toBe(1);
+      expect(res.body.data[0].requesterCount).toBeGreaterThanOrEqual(
+        res.body.data[res.body.data.length - 1].requesterCount,
+      );
+    });
+  });
+
+  describe('PUT /api/v1/suggestions/:id/status (T185)', () => {
+    let targetId: string;
+
+    beforeEach(async () => {
+      const s = await prisma.bookSuggestion.create({
+        data: {
+          studentId: studentA.id,
+          collectionPeriodId: activePeriodId,
+          suggestedTitle: `${PREFIX} Review Target`,
+          suggestedAuthor: 'Author',
+          status: SuggestionStatus.submitted,
+        },
+      });
+      targetId = s.id;
+    });
+
+    afterEach(async () => {
+      await prisma.bookSuggestion.deleteMany({ where: { id: targetId } });
+    });
+
+    it('approves a suggestion with admin notes', async () => {
+      const res = await request(app)
+        .put(`/api/v1/suggestions/${targetId}/status`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ status: 'approved', adminNotes: '구입 예정' })
+        .expect(200);
+
+      expect(res.body.data.status).toBe('approved');
+      expect(res.body.data.adminNotes).toBe('구입 예정');
+      expect(res.body.data.reviewedBy).toBe(adminId);
+    });
+
+    it('rejects a suggestion', async () => {
+      const res = await request(app)
+        .put(`/api/v1/suggestions/${targetId}/status`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ status: 'rejected', adminNotes: '예산 한도 초과' })
+        .expect(200);
+      expect(res.body.data.status).toBe('rejected');
+    });
+
+    it('returns 404 for non-existent suggestion', async () => {
+      await request(app)
+        .put('/api/v1/suggestions/00000000-0000-0000-0000-000000000000/status')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ status: 'approved' })
+        .expect(404);
+    });
+
+    it('returns 400 for invalid status', async () => {
+      await request(app)
+        .put(`/api/v1/suggestions/${targetId}/status`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ status: 'pirate' })
+        .expect(400);
+    });
+
+    it('rejects student token', async () => {
+      await request(app)
+        .put(`/api/v1/suggestions/${targetId}/status`)
+        .set('Authorization', `Bearer ${studentA.token}`)
+        .send({ status: 'approved' })
+        .expect(403);
+    });
+  });
+
+  describe('POST /api/v1/collection-periods (T186/T188)', () => {
+    afterEach(async () => {
+      await prisma.collectionPeriod.deleteMany({
+        where: { name: { startsWith: `${PREFIX} new ` } },
+      });
+    });
+
+    it('creates upcoming period without affecting active', async () => {
+      const res = await request(app)
+        .post('/api/v1/collection-periods')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          name: `${PREFIX} new upcoming`,
+          startDate: '2024-04-01T00:00:00.000Z',
+          endDate: '2024-06-30T00:00:00.000Z',
+          status: 'upcoming',
+        })
+        .expect(201);
+      expect(res.body.data.status).toBe('upcoming');
+
+      const stillActive = await prisma.collectionPeriod.findUnique({
+        where: { id: activePeriodId },
+      });
+      expect(stillActive?.status).toBe('active');
+    });
+
+    it('creating new active period archives the existing active one', async () => {
+      const res = await request(app)
+        .post('/api/v1/collection-periods')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          name: `${PREFIX} new active`,
+          startDate: '2024-04-01T00:00:00.000Z',
+          endDate: '2024-06-30T00:00:00.000Z',
+          status: 'active',
+        })
+        .expect(201);
+      expect(res.body.data.status).toBe('active');
+
+      const oldActive = await prisma.collectionPeriod.findUnique({
+        where: { id: activePeriodId },
+      });
+      expect(oldActive?.status).toBe('closed');
+
+      // Restore for subsequent tests
+      await prisma.collectionPeriod.update({
+        where: { id: activePeriodId },
+        data: { status: PeriodStatus.active },
+      });
+    });
+
+    it('returns 400 when endDate <= startDate', async () => {
+      await request(app)
+        .post('/api/v1/collection-periods')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          name: `${PREFIX} new bad`,
+          startDate: '2024-05-01T00:00:00.000Z',
+          endDate: '2024-04-01T00:00:00.000Z',
+        })
+        .expect(400);
+    });
+
+    it('rejects student token', async () => {
+      await request(app)
+        .post('/api/v1/collection-periods')
+        .set('Authorization', `Bearer ${studentA.token}`)
+        .send({
+          name: `${PREFIX} new student`,
+          startDate: '2024-04-01T00:00:00.000Z',
+          endDate: '2024-06-30T00:00:00.000Z',
+        })
+        .expect(403);
+    });
+  });
+});

--- a/specs/001-library-management/tasks.md
+++ b/specs/001-library-management/tasks.md
@@ -393,18 +393,18 @@
 ### Tests for User Story 6
 
 - [ ] T181 [P] [US6] Create widget test for suggestions review screen in test/widget_test/screens/web/suggestions/suggestions_screen_test.dart
-- [ ] T182 [P] [US6] Create backend unit test for GET /suggestions endpoint in backend/tests/unit/suggestions.test.ts
-- [ ] T183 [P] [US6] Create backend unit test for suggestion grouping in backend/tests/unit/suggestions.test.ts
+- [X] T182 [P] [US6] Create backend unit test for GET /suggestions endpoint in backend/tests/unit/suggestions.test.ts
+- [X] T183 [P] [US6] Create backend unit test for suggestion grouping in backend/tests/unit/suggestions.test.ts
 
 ### Implementation for User Story 6
 
 **Backend API - Admin Suggestions**
 
-- [ ] T184 [P] [US6] Implement GET /suggestions endpoint (admin, grouped) in backend/src/routes/suggestions.ts
-- [ ] T185 [P] [US6] Implement PUT /suggestions/:id/status endpoint in backend/src/routes/suggestions.ts
-- [ ] T186 [P] [US6] Implement POST /collection-periods endpoint in backend/src/routes/collection_periods.ts
-- [ ] T187 [US6] Implement suggestion grouping by title+author in backend/src/services/suggestion_service.ts
-- [ ] T188 [US6] Add collection period archival logic in backend/src/services/collection_period_service.ts
+- [X] T184 [P] [US6] Implement GET /suggestions endpoint (admin, grouped) in backend/src/routes/suggestions.ts
+- [X] T185 [P] [US6] Implement PUT /suggestions/:id/status endpoint in backend/src/routes/suggestions.ts
+- [X] T186 [P] [US6] Implement POST /collection-periods endpoint in backend/src/routes/collection_periods.ts
+- [X] T187 [US6] Implement suggestion grouping by title+author in backend/src/services/suggestion_service.ts
+- [X] T188 [US6] Add collection period archival logic in backend/src/services/collection_period_service.ts
 
 **UI Components - Web Dashboard**
 


### PR DESCRIPTION
Closes #103

## 변경 (+569 / -10)

### 신규 기능
- **GET /api/v1/suggestions** (admin) — title+author+period 그룹핑, requesterCount 정렬
- **PUT /api/v1/suggestions/:id/status** (admin) — approved/rejected/under_review + adminNotes
- **POST /api/v1/collection-periods** (admin) — 새 period 생성, active로 만들면 기존 active 자동 closed

### 테스트 (11/11 PASS)
- 그룹핑: 동일 책 2명 학생 → count=2 정렬 검증
- 검토: approved/rejected/404/400 invalid/403 student
- 기간 생성: upcoming 무영향/active 시 archival/400 invalid date/403

tasks.md T182-T188 [X].