### PR TITLE
[Release #107] v0.4.0 — P3 US3 + US6

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "42lib-backend",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "42 Learning Space Library Management System - Backend API",
   "main": "src/server.ts",
   "scripts": {

--- a/backend/src/routes/collection_periods.ts
+++ b/backend/src/routes/collection_periods.ts
@@ -1,7 +1,14 @@
-// US3: CollectionPeriod routes
-// GET /api/v1/collection-periods/active — public
+// CollectionPeriod routes
+// GET  /api/v1/collection-periods/active — public
+// POST /api/v1/collection-periods         — admin (creates new period; new active archives existing active)
 
 import express, { Request, Response, NextFunction } from 'express';
+import { z } from 'zod';
+import { PeriodStatus } from '@prisma/client';
+import {
+  authenticateAdmin,
+  AuthenticatedRequest,
+} from '../middleware/auth';
 import { suggestionService } from '../services/suggestion_service';
 
 const router = express.Router();
@@ -18,6 +25,54 @@ router.get(
         });
       }
       return res.json({ success: true, data: period });
+    } catch (error) {
+      return next(error);
+    }
+  },
+);
+
+const createPeriodSchema = z.object({
+  name: z.string().min(1).max(100),
+  startDate: z.string().min(1),
+  endDate: z.string().min(1),
+  status: z.nativeEnum(PeriodStatus).optional(),
+});
+
+router.post(
+  '/',
+  authenticateAdmin,
+  async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+    const parsed = createPeriodSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({
+        error: 'Bad Request',
+        message: parsed.error.issues[0]?.message ?? 'Invalid payload',
+      });
+    }
+    const { name, startDate, endDate, status } = parsed.data;
+    const start = new Date(startDate);
+    const end = new Date(endDate);
+    if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+      return res.status(400).json({
+        error: 'Bad Request',
+        message: '날짜 형식이 올바르지 않습니다.',
+      });
+    }
+    if (end <= start) {
+      return res.status(400).json({
+        error: 'Bad Request',
+        message: '종료일은 시작일보다 이후여야 합니다.',
+      });
+    }
+
+    try {
+      const period = await suggestionService.createPeriod({
+        name,
+        startDate: start,
+        endDate: end,
+        status,
+      });
+      return res.status(201).json({ success: true, data: period });
     } catch (error) {
       return next(error);
     }

--- a/backend/src/routes/collection_periods.ts
+++ b/backend/src/routes/collection_periods.ts
@@ -1,0 +1,27 @@
+// US3: CollectionPeriod routes
+// GET /api/v1/collection-periods/active — public
+
+import express, { Request, Response, NextFunction } from 'express';
+import { suggestionService } from '../services/suggestion_service';
+
+const router = express.Router();
+
+router.get(
+  '/active',
+  async (_req: Request, res: Response, next: NextFunction) => {
+    try {
+      const period = await suggestionService.getActivePeriod();
+      if (!period) {
+        return res.status(404).json({
+          error: 'no_active_period',
+          message: '현재 활성 수집 기간이 없습니다.',
+        });
+      }
+      return res.json({ success: true, data: period });
+    } catch (error) {
+      return next(error);
+    }
+  },
+);
+
+export default router;

--- a/backend/src/routes/suggestions.ts
+++ b/backend/src/routes/suggestions.ts
@@ -4,8 +4,10 @@
 
 import express, { Response, NextFunction } from 'express';
 import { z } from 'zod';
+import { SuggestionStatus } from '@prisma/client';
 import {
   authenticateStudent,
+  authenticateAdmin,
   AuthenticatedRequest,
 } from '../middleware/auth';
 import { suggestionService, SuggestionError } from '../services/suggestion_service';
@@ -58,6 +60,64 @@ router.get(
       const data = await suggestionService.getStudentSuggestions(studentId);
       return res.json({ success: true, data });
     } catch (error) {
+      return next(error);
+    }
+  },
+);
+
+/**
+ * T184: Admin grouped list — same title+author within a period collapsed.
+ * Optional ?periodId= filter (default = active period).
+ */
+router.get(
+  '/',
+  authenticateAdmin,
+  async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+    try {
+      const periodId = req.query.periodId as string | undefined;
+      const data = await suggestionService.getGroupedSuggestions({ periodId });
+      return res.json({ success: true, data });
+    } catch (error) {
+      return next(error);
+    }
+  },
+);
+
+const reviewSchema = z.object({
+  status: z.nativeEnum(SuggestionStatus),
+  adminNotes: z.string().max(1000).optional(),
+});
+
+/**
+ * T185: Admin reviews a suggestion — sets status + optional adminNotes.
+ */
+router.put(
+  '/:id/status',
+  authenticateAdmin,
+  async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+    const parsed = reviewSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({
+        error: 'Bad Request',
+        message: parsed.error.issues[0]?.message ?? 'Invalid payload',
+      });
+    }
+
+    try {
+      const adminId = req.user!.userId;
+      const updated = await suggestionService.reviewSuggestion(
+        req.params.id,
+        adminId,
+        parsed.data,
+      );
+      return res.json({ success: true, data: updated });
+    } catch (error) {
+      if (error instanceof SuggestionError) {
+        const status = error.code === 'suggestion_not_found' ? 404 : 400;
+        return res
+          .status(status)
+          .json({ error: error.code, message: error.message });
+      }
       return next(error);
     }
   },

--- a/backend/src/routes/suggestions.ts
+++ b/backend/src/routes/suggestions.ts
@@ -1,0 +1,66 @@
+// US3: Suggestion routes
+// POST /api/v1/suggestions      — submit (student)
+// GET  /api/v1/suggestions/my   — student's own list
+
+import express, { Response, NextFunction } from 'express';
+import { z } from 'zod';
+import {
+  authenticateStudent,
+  AuthenticatedRequest,
+} from '../middleware/auth';
+import { suggestionService, SuggestionError } from '../services/suggestion_service';
+
+const router = express.Router();
+
+const submitSchema = z.object({
+  suggestedTitle: z.string().min(1).max(500),
+  suggestedAuthor: z.string().min(1).max(200),
+  reason: z.string().max(1000).optional(),
+});
+
+router.post(
+  '/',
+  authenticateStudent,
+  async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+    const parsed = submitSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({
+        error: 'Bad Request',
+        message: parsed.error.issues[0]?.message ?? 'Invalid payload',
+      });
+    }
+
+    try {
+      const studentId = req.user!.userId;
+      const suggestion = await suggestionService.createSuggestion(
+        studentId,
+        parsed.data,
+      );
+      return res.status(201).json({ success: true, data: suggestion });
+    } catch (error) {
+      if (error instanceof SuggestionError) {
+        const status = error.code === 'duplicate_suggestion' ? 409 : 400;
+        return res
+          .status(status)
+          .json({ error: error.code, message: error.message });
+      }
+      return next(error);
+    }
+  },
+);
+
+router.get(
+  '/my',
+  authenticateStudent,
+  async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+    try {
+      const studentId = req.user!.userId;
+      const data = await suggestionService.getStudentSuggestions(studentId);
+      return res.json({ success: true, data });
+    } catch (error) {
+      return next(error);
+    }
+  },
+);
+
+export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -10,6 +10,8 @@ import authRoutes from './routes/auth';
 import loanRequestRoutes from './routes/loan_requests';
 import loanRoutes from './routes/loans';
 import adminRoutes from './routes/admin';
+import suggestionRoutes from './routes/suggestions';
+import collectionPeriodRoutes from './routes/collection_periods';
 
 const app: Express = express();
 const prisma = new PrismaClient();
@@ -40,6 +42,8 @@ app.use('/api/v1/auth', authRoutes);
 app.use('/api/v1/loan-requests', loanRequestRoutes);
 app.use('/api/v1/loans', loanRoutes);
 app.use('/api/v1/admin', adminRoutes);
+app.use('/api/v1/suggestions', suggestionRoutes);
+app.use('/api/v1/collection-periods', collectionPeriodRoutes);
 
 app.get('/api/v1', (req, res) => {
   res.json({ message: '42lib API v1', status: 'ready' });

--- a/backend/src/services/suggestion_service.ts
+++ b/backend/src/services/suggestion_service.ts
@@ -16,7 +16,9 @@ export class SuggestionError extends Error {
     public code:
       | 'no_active_period'
       | 'duplicate_suggestion'
-      | 'period_not_found',
+      | 'period_not_found'
+      | 'suggestion_not_found'
+      | 'invalid_status',
     message: string,
   ) {
     super(message);
@@ -104,6 +106,146 @@ export class SuggestionService {
           select: { id: true, name: true, status: true, endDate: true },
         },
       },
+    });
+  }
+
+  /**
+   * T184/T187: Admin grouped list — same title+author within a period
+   * collapsed into a single entry with requesterCount and per-status counts.
+   * Optional `periodId` filter; default = active period; if no active period
+   * and no filter, returns all.
+   */
+  async getGroupedSuggestions(filter: { periodId?: string } = {}) {
+    let periodId = filter.periodId;
+    if (!periodId) {
+      const active = await this.getActivePeriod();
+      periodId = active?.id;
+    }
+
+    const where = periodId ? { collectionPeriodId: periodId } : {};
+    const items = await prisma.bookSuggestion.findMany({
+      where,
+      orderBy: { submittedAt: 'desc' },
+      include: {
+        student: { select: { id: true, username: true, fullName: true } },
+        collectionPeriod: { select: { id: true, name: true, status: true, endDate: true } },
+      },
+    });
+
+    // Group in memory — small N (per-period dataset).
+    const groups = new Map<
+      string,
+      {
+        suggestedTitle: string;
+        suggestedAuthor: string;
+        collectionPeriodId: string;
+        requesterCount: number;
+        statuses: Record<string, number>;
+        latestSubmittedAt: Date;
+        items: typeof items;
+      }
+    >();
+
+    for (const s of items) {
+      const key = `${s.suggestedTitle}::${s.suggestedAuthor}::${s.collectionPeriodId}`;
+      const existing = groups.get(key);
+      if (existing) {
+        existing.requesterCount++;
+        existing.statuses[s.status] = (existing.statuses[s.status] ?? 0) + 1;
+        existing.items.push(s);
+        if (s.submittedAt > existing.latestSubmittedAt) {
+          existing.latestSubmittedAt = s.submittedAt;
+        }
+      } else {
+        groups.set(key, {
+          suggestedTitle: s.suggestedTitle,
+          suggestedAuthor: s.suggestedAuthor,
+          collectionPeriodId: s.collectionPeriodId,
+          requesterCount: 1,
+          statuses: { [s.status]: 1 },
+          latestSubmittedAt: s.submittedAt,
+          items: [s],
+        });
+      }
+    }
+
+    return Array.from(groups.values()).sort(
+      (a, b) => b.requesterCount - a.requesterCount,
+    );
+  }
+
+  /**
+   * T185: Admin marks a suggestion as approved/rejected/under_review.
+   * `adminNotes` is optional context shown to the student.
+   */
+  async reviewSuggestion(
+    suggestionId: string,
+    adminId: string,
+    payload: { status: SuggestionStatus; adminNotes?: string },
+  ) {
+    const existing = await prisma.bookSuggestion.findUnique({
+      where: { id: suggestionId },
+    });
+    if (!existing) {
+      throw new SuggestionError(
+        'suggestion_not_found',
+        '제안을 찾을 수 없습니다.',
+      );
+    }
+
+    const updated = await prisma.bookSuggestion.update({
+      where: { id: suggestionId },
+      data: {
+        status: payload.status,
+        reviewedAt: new Date(),
+        reviewedBy: adminId,
+        adminNotes: payload.adminNotes?.trim() || existing.adminNotes,
+      },
+      include: {
+        student: { select: { id: true, username: true, fullName: true } },
+      },
+    });
+
+    logger.info('Suggestion reviewed', {
+      suggestionId,
+      status: payload.status,
+      adminId,
+    });
+    return updated;
+  }
+
+  /**
+   * T186/T188: Admin creates a CollectionPeriod. If new period is `active`,
+   * any pre-existing active period is archived to `closed` (only one active
+   * at a time).
+   */
+  async createPeriod(payload: {
+    name: string;
+    startDate: Date;
+    endDate: Date;
+    status?: PeriodStatus;
+  }) {
+    const status = payload.status ?? PeriodStatus.upcoming;
+
+    return prisma.$transaction(async (tx) => {
+      if (status === PeriodStatus.active) {
+        await tx.collectionPeriod.updateMany({
+          where: { status: PeriodStatus.active },
+          data: { status: PeriodStatus.closed },
+        });
+      }
+
+      const period = await tx.collectionPeriod.create({
+        data: {
+          name: payload.name.trim(),
+          startDate: payload.startDate,
+          endDate: payload.endDate,
+          status,
+        },
+      });
+
+      logger.info('Collection period created', { periodId: period.id, status });
+      return period;
     });
   }
 }

--- a/backend/src/services/suggestion_service.ts
+++ b/backend/src/services/suggestion_service.ts
@@ -1,0 +1,111 @@
+// US3: BookSuggestion service — student-submitted book recommendations,
+// scoped to an active collection period.
+// Reference: data-model.md Entity 6 (BookSuggestion), Entity 7 (CollectionPeriod)
+
+import {
+  PrismaClient,
+  PeriodStatus,
+  SuggestionStatus,
+} from '@prisma/client';
+import { logger } from '../utils/logger';
+
+const prisma = new PrismaClient();
+
+export class SuggestionError extends Error {
+  constructor(
+    public code:
+      | 'no_active_period'
+      | 'duplicate_suggestion'
+      | 'period_not_found',
+    message: string,
+  ) {
+    super(message);
+    this.name = 'SuggestionError';
+  }
+}
+
+export class SuggestionService {
+  async getActivePeriod() {
+    return prisma.collectionPeriod.findFirst({
+      where: { status: PeriodStatus.active },
+      orderBy: { startDate: 'desc' },
+    });
+  }
+
+  /**
+   * T168/T171: Submit a new suggestion. Must fall within the currently
+   * active collection period. Dedupes per (student, title, author, period).
+   */
+  async createSuggestion(
+    studentId: string,
+    payload: {
+      suggestedTitle: string;
+      suggestedAuthor: string;
+      reason?: string;
+    },
+  ) {
+    const period = await this.getActivePeriod();
+    if (!period) {
+      throw new SuggestionError(
+        'no_active_period',
+        '현재 활성 수집 기간이 없습니다.',
+      );
+    }
+
+    const trimmedTitle = payload.suggestedTitle.trim();
+    const trimmedAuthor = payload.suggestedAuthor.trim();
+
+    const existing = await prisma.bookSuggestion.findFirst({
+      where: {
+        studentId,
+        collectionPeriodId: period.id,
+        suggestedTitle: trimmedTitle,
+        suggestedAuthor: trimmedAuthor,
+      },
+    });
+    if (existing) {
+      throw new SuggestionError(
+        'duplicate_suggestion',
+        '동일한 도서를 이미 추천했습니다.',
+      );
+    }
+
+    const suggestion = await prisma.bookSuggestion.create({
+      data: {
+        studentId,
+        suggestedTitle: trimmedTitle,
+        suggestedAuthor: trimmedAuthor,
+        reason: payload.reason?.trim() || null,
+        collectionPeriodId: period.id,
+        status: SuggestionStatus.submitted,
+      },
+      include: {
+        collectionPeriod: { select: { id: true, name: true, endDate: true } },
+      },
+    });
+
+    logger.info('Book suggestion submitted', {
+      studentId,
+      suggestionId: suggestion.id,
+      periodId: period.id,
+    });
+    return suggestion;
+  }
+
+  /**
+   * T169: Student's own suggestions across all periods.
+   */
+  async getStudentSuggestions(studentId: string) {
+    return prisma.bookSuggestion.findMany({
+      where: { studentId },
+      orderBy: { submittedAt: 'desc' },
+      include: {
+        collectionPeriod: {
+          select: { id: true, name: true, status: true, endDate: true },
+        },
+      },
+    });
+  }
+}
+
+export const suggestionService = new SuggestionService();

--- a/backend/tests/unit/collection_periods.test.ts
+++ b/backend/tests/unit/collection_periods.test.ts
@@ -1,0 +1,59 @@
+// T164: GET /api/v1/collection-periods/active
+
+import request from 'supertest';
+import { app } from '../../src/server';
+import { PrismaClient, PeriodStatus } from '@prisma/client';
+
+const prisma = new PrismaClient();
+const NAME_PREFIX = '[T164]';
+
+async function cleanup(): Promise<void> {
+  await prisma.bookSuggestion.deleteMany({
+    where: { collectionPeriod: { name: { startsWith: NAME_PREFIX } } },
+  });
+  await prisma.collectionPeriod.deleteMany({
+    where: { name: { startsWith: NAME_PREFIX } },
+  });
+}
+
+describe('GET /api/v1/collection-periods/active (T164)', () => {
+  beforeAll(async () => {
+    await cleanup();
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    await prisma.$disconnect();
+  });
+
+  it('returns 404 when no period is active', async () => {
+    // Ensure no active period exists by setting any pre-existing active to closed.
+    await prisma.collectionPeriod.updateMany({
+      where: { status: PeriodStatus.active },
+      data: { status: PeriodStatus.closed },
+    });
+
+    const res = await request(app)
+      .get('/api/v1/collection-periods/active')
+      .expect(404);
+    expect(res.body.error).toBe('no_active_period');
+  });
+
+  it('returns active period', async () => {
+    const period = await prisma.collectionPeriod.create({
+      data: {
+        name: `${NAME_PREFIX} 2024 Spring`,
+        startDate: new Date('2024-03-01'),
+        endDate: new Date('2024-05-31'),
+        status: PeriodStatus.active,
+      },
+    });
+
+    const res = await request(app)
+      .get('/api/v1/collection-periods/active')
+      .expect(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.id).toBe(period.id);
+    expect(res.body.data.name).toBe(`${NAME_PREFIX} 2024 Spring`);
+  });
+});

--- a/backend/tests/unit/suggestions.test.ts
+++ b/backend/tests/unit/suggestions.test.ts
@@ -1,0 +1,200 @@
+// T163: BookSuggestion endpoints — submit, list, dedupe, period validation
+
+import request from 'supertest';
+import { app } from '../../src/server';
+import { PrismaClient, PeriodStatus } from '@prisma/client';
+import { generateStudentToken } from '../../src/utils/jwt';
+
+const prisma = new PrismaClient();
+
+const STUDENT = {
+  fortytwoUserId: 980100,
+  username: 'sgst_student',
+  email: 'sgst_student@42.fr',
+  fullName: '추천 테스트 학생',
+};
+
+async function cleanup(): Promise<void> {
+  await prisma.bookSuggestion.deleteMany({
+    where: {
+      OR: [
+        { suggestedTitle: { startsWith: '[T163]' } },
+        { student: { username: STUDENT.username } },
+      ],
+    },
+  });
+  await prisma.collectionPeriod.deleteMany({
+    where: { name: { startsWith: '[T163]' } },
+  });
+  await prisma.student.deleteMany({ where: { username: STUDENT.username } });
+}
+
+describe('Suggestions endpoints (T163)', () => {
+  let studentId: string;
+  let token: string;
+
+  beforeAll(async () => {
+    await cleanup();
+    const student = await prisma.student.create({ data: STUDENT });
+    studentId = student.id;
+    token = generateStudentToken(
+      student.id,
+      student.username,
+      student.email,
+      student.fortytwoUserId,
+    );
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    await prisma.$disconnect();
+  });
+
+  beforeEach(async () => {
+    await prisma.bookSuggestion.deleteMany({ where: { studentId } });
+    await prisma.collectionPeriod.deleteMany({
+      where: { name: { startsWith: '[T163]' } },
+    });
+  });
+
+  describe('POST /api/v1/suggestions', () => {
+    it('rejects anonymous request with 401', async () => {
+      await request(app)
+        .post('/api/v1/suggestions')
+        .send({ suggestedTitle: 'X', suggestedAuthor: 'Y' })
+        .expect(401);
+    });
+
+    it('returns 400 when active period absent', async () => {
+      const res = await request(app)
+        .post('/api/v1/suggestions')
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          suggestedTitle: '[T163] 도서',
+          suggestedAuthor: '저자',
+        })
+        .expect(400);
+      expect(res.body.error).toBe('no_active_period');
+    });
+
+    it('creates suggestion within active period', async () => {
+      await prisma.collectionPeriod.create({
+        data: {
+          name: '[T163] 2024 Q1',
+          startDate: new Date('2024-01-01'),
+          endDate: new Date('2024-03-31'),
+          status: PeriodStatus.active,
+        },
+      });
+
+      const res = await request(app)
+        .post('/api/v1/suggestions')
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          suggestedTitle: '[T163] Effective TypeScript',
+          suggestedAuthor: 'Dan Vanderkam',
+          reason: 'TS 깊은 이해를 위한 책',
+        })
+        .expect(201);
+
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.suggestedTitle).toBe('[T163] Effective TypeScript');
+      expect(res.body.data.status).toBe('submitted');
+    });
+
+    it('returns 400 when payload missing required fields', async () => {
+      await prisma.collectionPeriod.create({
+        data: {
+          name: '[T163] 2024 Q1 v',
+          startDate: new Date('2024-01-01'),
+          endDate: new Date('2024-03-31'),
+          status: PeriodStatus.active,
+        },
+      });
+      await request(app)
+        .post('/api/v1/suggestions')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ suggestedTitle: '' })
+        .expect(400);
+    });
+
+    it('rejects duplicate title+author for same student in same period', async () => {
+      await prisma.collectionPeriod.create({
+        data: {
+          name: '[T163] 2024 Q1 dedupe',
+          startDate: new Date('2024-01-01'),
+          endDate: new Date('2024-03-31'),
+          status: PeriodStatus.active,
+        },
+      });
+
+      await request(app)
+        .post('/api/v1/suggestions')
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          suggestedTitle: '[T163] Dup Book',
+          suggestedAuthor: 'Author',
+        })
+        .expect(201);
+
+      const res = await request(app)
+        .post('/api/v1/suggestions')
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          suggestedTitle: '[T163] Dup Book',
+          suggestedAuthor: 'Author',
+        })
+        .expect(409);
+      expect(res.body.error).toBe('duplicate_suggestion');
+    });
+  });
+
+  describe('GET /api/v1/suggestions/my', () => {
+    it('returns empty array for new student', async () => {
+      const res = await request(app)
+        .get('/api/v1/suggestions/my')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+      expect(res.body.data).toEqual([]);
+    });
+
+    it('returns student own suggestions in reverse chronological order', async () => {
+      const period = await prisma.collectionPeriod.create({
+        data: {
+          name: '[T163] my list period',
+          startDate: new Date('2024-01-01'),
+          endDate: new Date('2024-03-31'),
+          status: PeriodStatus.active,
+        },
+      });
+
+      await prisma.bookSuggestion.create({
+        data: {
+          studentId,
+          collectionPeriodId: period.id,
+          suggestedTitle: '[T163] First',
+          suggestedAuthor: 'A',
+          submittedAt: new Date('2024-02-01'),
+        },
+      });
+      await prisma.bookSuggestion.create({
+        data: {
+          studentId,
+          collectionPeriodId: period.id,
+          suggestedTitle: '[T163] Second',
+          suggestedAuthor: 'B',
+          submittedAt: new Date('2024-02-10'),
+        },
+      });
+
+      const res = await request(app)
+        .get('/api/v1/suggestions/my')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+
+      expect(res.body.data).toHaveLength(2);
+      expect(res.body.data[0].suggestedTitle).toBe('[T163] Second'); // newest first
+      expect(res.body.data[1].suggestedTitle).toBe('[T163] First');
+    });
+  });
+});

--- a/backend/tests/unit/suggestions_admin.test.ts
+++ b/backend/tests/unit/suggestions_admin.test.ts
@@ -1,0 +1,302 @@
+// T182/T183: Admin suggestion review endpoints + grouping logic.
+
+import request from 'supertest';
+import { app } from '../../src/server';
+import { PrismaClient, PeriodStatus, SuggestionStatus } from '@prisma/client';
+import * as bcrypt from 'bcrypt';
+import { generateAdminToken, generateStudentToken } from '../../src/utils/jwt';
+
+const prisma = new PrismaClient();
+
+const ADMIN = {
+  username: 'sgst_admin',
+  password: 'sgst-admin-pass',
+  email: 'sgst_admin@42lib.kr',
+  fullName: '추천 관리자',
+};
+
+const PREFIX = '[SGST-ADMIN]';
+
+async function cleanup(): Promise<void> {
+  await prisma.bookSuggestion.deleteMany({
+    where: {
+      OR: [
+        { suggestedTitle: { startsWith: PREFIX } },
+        { collectionPeriod: { name: { startsWith: PREFIX } } },
+      ],
+    },
+  });
+  await prisma.collectionPeriod.deleteMany({ where: { name: { startsWith: PREFIX } } });
+  await prisma.student.deleteMany({ where: { username: { startsWith: 'sgst_st_' } } });
+  await prisma.administrator.deleteMany({ where: { username: ADMIN.username } });
+}
+
+describe('Admin suggestion endpoints (T182/T183)', () => {
+  let adminId: string;
+  let adminToken: string;
+  let activePeriodId: string;
+  let studentA: { id: string; token: string };
+  let studentB: { id: string; token: string };
+
+  beforeAll(async () => {
+    await cleanup();
+    const passwordHash = await bcrypt.hash(ADMIN.password, 10);
+    const admin = await prisma.administrator.create({
+      data: {
+        username: ADMIN.username,
+        email: ADMIN.email,
+        fullName: ADMIN.fullName,
+        passwordHash,
+        role: 'admin',
+      },
+    });
+    adminId = admin.id;
+    adminToken = generateAdminToken(admin.id, admin.username, admin.email, admin.role);
+
+    const period = await prisma.collectionPeriod.create({
+      data: {
+        name: `${PREFIX} 2024 Q1`,
+        startDate: new Date('2024-01-01'),
+        endDate: new Date('2024-03-31'),
+        status: PeriodStatus.active,
+      },
+    });
+    activePeriodId = period.id;
+
+    const a = await prisma.student.create({
+      data: {
+        fortytwoUserId: 970201,
+        username: 'sgst_st_a',
+        email: 'sgst_st_a@42.fr',
+        fullName: '학생 A',
+      },
+    });
+    const b = await prisma.student.create({
+      data: {
+        fortytwoUserId: 970202,
+        username: 'sgst_st_b',
+        email: 'sgst_st_b@42.fr',
+        fullName: '학생 B',
+      },
+    });
+    studentA = {
+      id: a.id,
+      token: generateStudentToken(a.id, a.username, a.email, a.fortytwoUserId),
+    };
+    studentB = {
+      id: b.id,
+      token: generateStudentToken(b.id, b.username, b.email, b.fortytwoUserId),
+    };
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    await prisma.$disconnect();
+  });
+
+  describe('GET /api/v1/suggestions (admin grouped, T184)', () => {
+    beforeAll(async () => {
+      // Two students suggesting the same book → grouped count=2
+      await prisma.bookSuggestion.create({
+        data: {
+          studentId: studentA.id,
+          collectionPeriodId: activePeriodId,
+          suggestedTitle: `${PREFIX} Effective TS`,
+          suggestedAuthor: 'Vanderkam',
+          status: SuggestionStatus.submitted,
+        },
+      });
+      await prisma.bookSuggestion.create({
+        data: {
+          studentId: studentB.id,
+          collectionPeriodId: activePeriodId,
+          suggestedTitle: `${PREFIX} Effective TS`,
+          suggestedAuthor: 'Vanderkam',
+          status: SuggestionStatus.submitted,
+        },
+      });
+      // Single different book → group count=1
+      await prisma.bookSuggestion.create({
+        data: {
+          studentId: studentA.id,
+          collectionPeriodId: activePeriodId,
+          suggestedTitle: `${PREFIX} Solo Book`,
+          suggestedAuthor: 'Lonely',
+          status: SuggestionStatus.submitted,
+        },
+      });
+    });
+
+    it('rejects student token (admin only)', async () => {
+      await request(app)
+        .get('/api/v1/suggestions')
+        .set('Authorization', `Bearer ${studentA.token}`)
+        .expect(403);
+    });
+
+    it('returns grouped list ordered by requesterCount desc', async () => {
+      const res = await request(app)
+        .get('/api/v1/suggestions')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .expect(200);
+
+      expect(Array.isArray(res.body.data)).toBe(true);
+      const effective = res.body.data.find(
+        (g: any) => g.suggestedTitle === `${PREFIX} Effective TS`,
+      );
+      const solo = res.body.data.find(
+        (g: any) => g.suggestedTitle === `${PREFIX} Solo Book`,
+      );
+
+      expect(effective).toBeDefined();
+      expect(effective.requesterCount).toBe(2);
+      expect(effective.items).toHaveLength(2);
+      expect(solo.requesterCount).toBe(1);
+      expect(res.body.data[0].requesterCount).toBeGreaterThanOrEqual(
+        res.body.data[res.body.data.length - 1].requesterCount,
+      );
+    });
+  });
+
+  describe('PUT /api/v1/suggestions/:id/status (T185)', () => {
+    let targetId: string;
+
+    beforeEach(async () => {
+      const s = await prisma.bookSuggestion.create({
+        data: {
+          studentId: studentA.id,
+          collectionPeriodId: activePeriodId,
+          suggestedTitle: `${PREFIX} Review Target`,
+          suggestedAuthor: 'Author',
+          status: SuggestionStatus.submitted,
+        },
+      });
+      targetId = s.id;
+    });
+
+    afterEach(async () => {
+      await prisma.bookSuggestion.deleteMany({ where: { id: targetId } });
+    });
+
+    it('approves a suggestion with admin notes', async () => {
+      const res = await request(app)
+        .put(`/api/v1/suggestions/${targetId}/status`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ status: 'approved', adminNotes: '구입 예정' })
+        .expect(200);
+
+      expect(res.body.data.status).toBe('approved');
+      expect(res.body.data.adminNotes).toBe('구입 예정');
+      expect(res.body.data.reviewedBy).toBe(adminId);
+    });
+
+    it('rejects a suggestion', async () => {
+      const res = await request(app)
+        .put(`/api/v1/suggestions/${targetId}/status`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ status: 'rejected', adminNotes: '예산 한도 초과' })
+        .expect(200);
+      expect(res.body.data.status).toBe('rejected');
+    });
+
+    it('returns 404 for non-existent suggestion', async () => {
+      await request(app)
+        .put('/api/v1/suggestions/00000000-0000-0000-0000-000000000000/status')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ status: 'approved' })
+        .expect(404);
+    });
+
+    it('returns 400 for invalid status', async () => {
+      await request(app)
+        .put(`/api/v1/suggestions/${targetId}/status`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ status: 'pirate' })
+        .expect(400);
+    });
+
+    it('rejects student token', async () => {
+      await request(app)
+        .put(`/api/v1/suggestions/${targetId}/status`)
+        .set('Authorization', `Bearer ${studentA.token}`)
+        .send({ status: 'approved' })
+        .expect(403);
+    });
+  });
+
+  describe('POST /api/v1/collection-periods (T186/T188)', () => {
+    afterEach(async () => {
+      await prisma.collectionPeriod.deleteMany({
+        where: { name: { startsWith: `${PREFIX} new ` } },
+      });
+    });
+
+    it('creates upcoming period without affecting active', async () => {
+      const res = await request(app)
+        .post('/api/v1/collection-periods')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          name: `${PREFIX} new upcoming`,
+          startDate: '2024-04-01T00:00:00.000Z',
+          endDate: '2024-06-30T00:00:00.000Z',
+          status: 'upcoming',
+        })
+        .expect(201);
+      expect(res.body.data.status).toBe('upcoming');
+
+      const stillActive = await prisma.collectionPeriod.findUnique({
+        where: { id: activePeriodId },
+      });
+      expect(stillActive?.status).toBe('active');
+    });
+
+    it('creating new active period archives the existing active one', async () => {
+      const res = await request(app)
+        .post('/api/v1/collection-periods')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          name: `${PREFIX} new active`,
+          startDate: '2024-04-01T00:00:00.000Z',
+          endDate: '2024-06-30T00:00:00.000Z',
+          status: 'active',
+        })
+        .expect(201);
+      expect(res.body.data.status).toBe('active');
+
+      const oldActive = await prisma.collectionPeriod.findUnique({
+        where: { id: activePeriodId },
+      });
+      expect(oldActive?.status).toBe('closed');
+
+      // Restore for subsequent tests
+      await prisma.collectionPeriod.update({
+        where: { id: activePeriodId },
+        data: { status: PeriodStatus.active },
+      });
+    });
+
+    it('returns 400 when endDate <= startDate', async () => {
+      await request(app)
+        .post('/api/v1/collection-periods')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          name: `${PREFIX} new bad`,
+          startDate: '2024-05-01T00:00:00.000Z',
+          endDate: '2024-04-01T00:00:00.000Z',
+        })
+        .expect(400);
+    });
+
+    it('rejects student token', async () => {
+      await request(app)
+        .post('/api/v1/collection-periods')
+        .set('Authorization', `Bearer ${studentA.token}`)
+        .send({
+          name: `${PREFIX} new student`,
+          startDate: '2024-04-01T00:00:00.000Z',
+          endDate: '2024-06-30T00:00:00.000Z',
+        })
+        .expect(403);
+    });
+  });
+});

--- a/lib/core/routes/app_router.dart
+++ b/lib/core/routes/app_router.dart
@@ -6,8 +6,10 @@ import '../../features/admin_catalog/presentation/screens/admin_dashboard_screen
 import '../../features/admin_catalog/presentation/screens/admin_login_screen.dart';
 import '../../features/admin_catalog/presentation/screens/catalog_management_screen.dart';
 import '../../features/admin_catalog/presentation/screens/loans_management_screen.dart';
+import '../../features/book_suggestions/presentation/screens/collection_periods_screen.dart';
 import '../../features/book_suggestions/presentation/screens/my_suggestions_screen.dart';
 import '../../features/book_suggestions/presentation/screens/suggestion_form_screen.dart';
+import '../../features/book_suggestions/presentation/screens/suggestions_review_screen.dart';
 import '../../features/books/presentation/screens/book_list_screen.dart';
 import '../../models/book.dart';
 import '../../screens/mobile/auth/login_screen.dart';
@@ -93,6 +95,14 @@ class AppRouter {
         GoRoute(
           path: '/admin/loans',
           builder: (context, state) => const LoansManagementScreen(),
+        ),
+        GoRoute(
+          path: '/admin/suggestions',
+          builder: (context, state) => const SuggestionsReviewScreen(),
+        ),
+        GoRoute(
+          path: '/admin/collection-periods',
+          builder: (context, state) => const CollectionPeriodsScreen(),
         ),
       ],
     );

--- a/lib/core/routes/app_router.dart
+++ b/lib/core/routes/app_router.dart
@@ -6,6 +6,8 @@ import '../../features/admin_catalog/presentation/screens/admin_dashboard_screen
 import '../../features/admin_catalog/presentation/screens/admin_login_screen.dart';
 import '../../features/admin_catalog/presentation/screens/catalog_management_screen.dart';
 import '../../features/admin_catalog/presentation/screens/loans_management_screen.dart';
+import '../../features/book_suggestions/presentation/screens/my_suggestions_screen.dart';
+import '../../features/book_suggestions/presentation/screens/suggestion_form_screen.dart';
 import '../../features/books/presentation/screens/book_list_screen.dart';
 import '../../models/book.dart';
 import '../../screens/mobile/auth/login_screen.dart';
@@ -63,6 +65,16 @@ class AppRouter {
         GoRoute(
           path: '/my-loans',
           builder: (context, state) => const MyLoansScreen(),
+        ),
+
+        // Suggestions (US3)
+        GoRoute(
+          path: '/suggestions/mine',
+          builder: (context, state) => const MySuggestionsScreen(),
+        ),
+        GoRoute(
+          path: '/suggestions/new',
+          builder: (context, state) => const SuggestionFormScreen(),
         ),
 
         // Admin

--- a/lib/features/admin_catalog/presentation/screens/admin_dashboard_screen.dart
+++ b/lib/features/admin_catalog/presentation/screens/admin_dashboard_screen.dart
@@ -67,4 +67,3 @@ class AdminDashboardScreen extends StatelessWidget {
     );
   }
 }
-

--- a/lib/features/admin_catalog/presentation/widgets/admin_sidebar.dart
+++ b/lib/features/admin_catalog/presentation/widgets/admin_sidebar.dart
@@ -56,6 +56,16 @@ class AdminSidebar extends StatelessWidget {
               selectedIcon: Icon(Icons.assignment),
               label: Text('대출 관리'),
             ),
+            const NavigationDrawerDestination(
+              icon: Icon(Icons.lightbulb_outline),
+              selectedIcon: Icon(Icons.lightbulb),
+              label: Text('도서 추천 검토'),
+            ),
+            const NavigationDrawerDestination(
+              icon: Icon(Icons.event_outlined),
+              selectedIcon: Icon(Icons.event),
+              label: Text('수집 기간'),
+            ),
             const Padding(
               padding: EdgeInsets.fromLTRB(28, 16, 28, 8),
               child: Divider(),
@@ -76,6 +86,8 @@ class AdminSidebar extends StatelessWidget {
   int get _selectedIndex {
     if (currentRoute.startsWith('/admin/catalog')) return 1;
     if (currentRoute.startsWith('/admin/loans')) return 2;
+    if (currentRoute.startsWith('/admin/suggestions')) return 3;
+    if (currentRoute.startsWith('/admin/collection-periods')) return 4;
     return 0;
   }
 
@@ -90,6 +102,12 @@ class AdminSidebar extends StatelessWidget {
         break;
       case 2:
         context.go('/admin/loans');
+        break;
+      case 3:
+        context.go('/admin/suggestions');
+        break;
+      case 4:
+        context.go('/admin/collection-periods');
         break;
     }
   }

--- a/lib/features/book_suggestions/data/models/book_suggestion.dart
+++ b/lib/features/book_suggestions/data/models/book_suggestion.dart
@@ -1,0 +1,126 @@
+import 'package:equatable/equatable.dart';
+
+import 'collection_period.dart';
+
+enum SuggestionStatus { submitted, approved, rejected, underReview }
+
+SuggestionStatus _parseSuggestionStatus(String raw) {
+  switch (raw) {
+    case 'submitted':
+      return SuggestionStatus.submitted;
+    case 'approved':
+      return SuggestionStatus.approved;
+    case 'rejected':
+      return SuggestionStatus.rejected;
+    case 'under_review':
+      return SuggestionStatus.underReview;
+    default:
+      throw ArgumentError('Unknown suggestion status: $raw');
+  }
+}
+
+/// CollectionPeriod summary embedded in suggestion responses.
+class SuggestionPeriodSummary extends Equatable {
+  final String id;
+  final String name;
+  final PeriodStatus? status;
+  final DateTime endDate;
+
+  const SuggestionPeriodSummary({
+    required this.id,
+    required this.name,
+    this.status,
+    required this.endDate,
+  });
+
+  factory SuggestionPeriodSummary.fromJson(Map<String, dynamic> json) {
+    return SuggestionPeriodSummary(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      status: json['status'] is String
+          ? CollectionPeriod.fromJson({
+              'id': json['id'] as String,
+              'name': json['name'] as String,
+              'startDate':
+                  json['startDate'] as String? ?? '1970-01-01T00:00:00.000Z',
+              'endDate': json['endDate'] as String,
+              'status': json['status'] as String,
+            }).status
+          : null,
+      endDate: DateTime.parse(json['endDate'] as String),
+    );
+  }
+
+  @override
+  List<Object?> get props => [id, name, status, endDate];
+}
+
+class BookSuggestion extends Equatable {
+  final String id;
+  final String studentId;
+  final String suggestedTitle;
+  final String suggestedAuthor;
+  final String? reason;
+  final String collectionPeriodId;
+  final SuggestionStatus status;
+  final DateTime submittedAt;
+  final DateTime? reviewedAt;
+  final String? reviewedBy;
+  final String? adminNotes;
+  final SuggestionPeriodSummary? collectionPeriod;
+
+  const BookSuggestion({
+    required this.id,
+    required this.studentId,
+    required this.suggestedTitle,
+    required this.suggestedAuthor,
+    this.reason,
+    required this.collectionPeriodId,
+    required this.status,
+    required this.submittedAt,
+    this.reviewedAt,
+    this.reviewedBy,
+    this.adminNotes,
+    this.collectionPeriod,
+  });
+
+  factory BookSuggestion.fromJson(Map<String, dynamic> json) {
+    return BookSuggestion(
+      id: json['id'] as String,
+      studentId: json['studentId'] as String,
+      suggestedTitle: json['suggestedTitle'] as String,
+      suggestedAuthor: json['suggestedAuthor'] as String,
+      reason: json['reason'] as String?,
+      collectionPeriodId: json['collectionPeriodId'] as String,
+      status: _parseSuggestionStatus(json['status'] as String),
+      submittedAt: DateTime.parse(json['submittedAt'] as String),
+      reviewedAt: json['reviewedAt'] == null
+          ? null
+          : DateTime.parse(json['reviewedAt'] as String),
+      reviewedBy: json['reviewedBy'] as String?,
+      adminNotes: json['adminNotes'] as String?,
+      collectionPeriod: json['collectionPeriod'] is Map<String, dynamic>
+          ? SuggestionPeriodSummary.fromJson(
+              json['collectionPeriod'] as Map<String, dynamic>,
+            )
+          : null,
+    );
+  }
+
+  bool get isSubmitted => status == SuggestionStatus.submitted;
+  bool get isApproved => status == SuggestionStatus.approved;
+  bool get isRejected => status == SuggestionStatus.rejected;
+  bool get isUnderReview => status == SuggestionStatus.underReview;
+
+  @override
+  List<Object?> get props => [
+        id,
+        studentId,
+        suggestedTitle,
+        suggestedAuthor,
+        reason,
+        collectionPeriodId,
+        status,
+        submittedAt,
+      ];
+}

--- a/lib/features/book_suggestions/data/models/collection_period.dart
+++ b/lib/features/book_suggestions/data/models/collection_period.dart
@@ -1,0 +1,53 @@
+import 'package:equatable/equatable.dart';
+
+enum PeriodStatus { upcoming, active, closed }
+
+PeriodStatus _parsePeriodStatus(String raw) {
+  switch (raw) {
+    case 'upcoming':
+      return PeriodStatus.upcoming;
+    case 'active':
+      return PeriodStatus.active;
+    case 'closed':
+      return PeriodStatus.closed;
+    default:
+      throw ArgumentError('Unknown period status: $raw');
+  }
+}
+
+class CollectionPeriod extends Equatable {
+  final String id;
+  final String name;
+  final DateTime startDate;
+  final DateTime endDate;
+  final PeriodStatus status;
+
+  const CollectionPeriod({
+    required this.id,
+    required this.name,
+    required this.startDate,
+    required this.endDate,
+    required this.status,
+  });
+
+  factory CollectionPeriod.fromJson(Map<String, dynamic> json) {
+    return CollectionPeriod(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      startDate: DateTime.parse(json['startDate'] as String),
+      endDate: DateTime.parse(json['endDate'] as String),
+      status: _parsePeriodStatus(json['status'] as String),
+    );
+  }
+
+  bool get isActive => status == PeriodStatus.active;
+
+  /// Days remaining until end date (0 if already past).
+  int daysRemaining(DateTime now) {
+    final diff = endDate.difference(now).inDays;
+    return diff < 0 ? 0 : diff;
+  }
+
+  @override
+  List<Object?> get props => [id, name, startDate, endDate, status];
+}

--- a/lib/features/book_suggestions/data/models/grouped_suggestion.dart
+++ b/lib/features/book_suggestions/data/models/grouped_suggestion.dart
@@ -1,0 +1,92 @@
+import 'package:equatable/equatable.dart';
+
+import 'book_suggestion.dart';
+
+/// Admin-side grouping: suggestions for the same (title, author, period)
+/// collapsed together so the dashboard can show overall demand.
+class GroupedSuggestion extends Equatable {
+  final String suggestedTitle;
+  final String suggestedAuthor;
+  final String collectionPeriodId;
+  final int requesterCount;
+  final Map<SuggestionStatus, int> statuses;
+  final DateTime latestSubmittedAt;
+  final List<BookSuggestion> items;
+
+  const GroupedSuggestion({
+    required this.suggestedTitle,
+    required this.suggestedAuthor,
+    required this.collectionPeriodId,
+    required this.requesterCount,
+    required this.statuses,
+    required this.latestSubmittedAt,
+    required this.items,
+  });
+
+  factory GroupedSuggestion.fromJson(Map<String, dynamic> json) {
+    final rawStatuses = json['statuses'] as Map<String, dynamic>? ?? const {};
+    final statuses = <SuggestionStatus, int>{};
+    rawStatuses.forEach((key, value) {
+      switch (key) {
+        case 'submitted':
+          statuses[SuggestionStatus.submitted] = value as int;
+          break;
+        case 'approved':
+          statuses[SuggestionStatus.approved] = value as int;
+          break;
+        case 'rejected':
+          statuses[SuggestionStatus.rejected] = value as int;
+          break;
+        case 'under_review':
+          statuses[SuggestionStatus.underReview] = value as int;
+          break;
+      }
+    });
+
+    final items = (json['items'] as List<dynamic>? ?? [])
+        .map((j) => BookSuggestion.fromJson(j as Map<String, dynamic>))
+        .toList();
+
+    return GroupedSuggestion(
+      suggestedTitle: json['suggestedTitle'] as String,
+      suggestedAuthor: json['suggestedAuthor'] as String,
+      collectionPeriodId: json['collectionPeriodId'] as String,
+      requesterCount: json['requesterCount'] as int,
+      statuses: statuses,
+      latestSubmittedAt: DateTime.parse(json['latestSubmittedAt'] as String),
+      items: items,
+    );
+  }
+
+  /// Group key independent of internal ordering.
+  String get groupKey =>
+      '$suggestedTitle::$suggestedAuthor::$collectionPeriodId';
+
+  GroupedSuggestion copyWith({
+    int? requesterCount,
+    Map<SuggestionStatus, int>? statuses,
+    DateTime? latestSubmittedAt,
+    List<BookSuggestion>? items,
+  }) {
+    return GroupedSuggestion(
+      suggestedTitle: suggestedTitle,
+      suggestedAuthor: suggestedAuthor,
+      collectionPeriodId: collectionPeriodId,
+      requesterCount: requesterCount ?? this.requesterCount,
+      statuses: statuses ?? this.statuses,
+      latestSubmittedAt: latestSubmittedAt ?? this.latestSubmittedAt,
+      items: items ?? this.items,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+        suggestedTitle,
+        suggestedAuthor,
+        collectionPeriodId,
+        requesterCount,
+        statuses,
+        latestSubmittedAt,
+        items,
+      ];
+}

--- a/lib/features/book_suggestions/data/repositories/admin_suggestion_repository_impl.dart
+++ b/lib/features/book_suggestions/data/repositories/admin_suggestion_repository_impl.dart
@@ -1,0 +1,145 @@
+import 'package:dio/dio.dart';
+
+import '../../../../services/storage/secure_storage_service.dart';
+import '../../domain/repositories/admin_suggestion_repository.dart';
+import '../models/book_suggestion.dart';
+import '../models/collection_period.dart';
+import '../models/grouped_suggestion.dart';
+
+class AdminSuggestionRepositoryImpl implements AdminSuggestionRepository {
+  AdminSuggestionRepositoryImpl({
+    required String baseUrl,
+    SecureStorageService? storage,
+    Dio? httpClient,
+  })  : _storage = storage ?? SecureStorageService(),
+        _dio = httpClient ?? _build(baseUrl) {
+    _dio.interceptors.add(InterceptorsWrapper(
+      onRequest: (options, handler) async {
+        final token = await _storage.readAdminToken();
+        if (token != null && token.isNotEmpty) {
+          options.headers['Authorization'] = 'Bearer $token';
+        }
+        return handler.next(options);
+      },
+    ));
+  }
+
+  static Dio _build(String baseUrl) => Dio(
+        BaseOptions(
+          baseUrl: baseUrl,
+          connectTimeout: const Duration(seconds: 15),
+          receiveTimeout: const Duration(seconds: 15),
+          headers: {'Content-Type': 'application/json'},
+          validateStatus: (s) => s != null && s < 500,
+        ),
+      );
+
+  final SecureStorageService _storage;
+  final Dio _dio;
+
+  @override
+  Future<List<GroupedSuggestion>> fetchGrouped({String? periodId}) async {
+    final res = await _dio.get<dynamic>(
+      '/v1/suggestions',
+      queryParameters: {if (periodId != null) 'periodId': periodId},
+    );
+    if (res.statusCode != 200 || res.data is! Map) {
+      throw AdminSuggestionException(
+        'fetch_failed',
+        '추천 목록을 불러오지 못했습니다 (${res.statusCode}).',
+      );
+    }
+    final list = (res.data as Map<String, dynamic>)['data'] as List<dynamic>;
+    return list
+        .map((j) => GroupedSuggestion.fromJson(j as Map<String, dynamic>))
+        .toList();
+  }
+
+  @override
+  Future<BookSuggestion> review(
+    String suggestionId, {
+    required SuggestionStatus status,
+    String? adminNotes,
+  }) async {
+    final res = await _dio.put<dynamic>(
+      '/v1/suggestions/$suggestionId/status',
+      data: {
+        'status': _statusToWire(status),
+        if (adminNotes != null && adminNotes.isNotEmpty)
+          'adminNotes': adminNotes,
+      },
+    );
+    if (res.statusCode == 200 && res.data is Map) {
+      final body = res.data as Map<String, dynamic>;
+      return BookSuggestion.fromJson(body['data'] as Map<String, dynamic>);
+    }
+    if (res.data is Map) {
+      final body = res.data as Map<String, dynamic>;
+      throw AdminSuggestionException(
+        (body['error'] as String?) ?? 'review_failed',
+        (body['message'] as String?) ?? '검토 처리에 실패했습니다.',
+      );
+    }
+    throw AdminSuggestionException(
+      'review_failed',
+      '검토 처리에 실패했습니다 (${res.statusCode}).',
+    );
+  }
+
+  @override
+  Future<CollectionPeriod> createPeriod({
+    required String name,
+    required DateTime startDate,
+    required DateTime endDate,
+    PeriodStatus status = PeriodStatus.upcoming,
+  }) async {
+    final res = await _dio.post<dynamic>(
+      '/v1/collection-periods',
+      data: {
+        'name': name,
+        'startDate': startDate.toIso8601String(),
+        'endDate': endDate.toIso8601String(),
+        'status': _periodStatusToWire(status),
+      },
+    );
+    if (res.statusCode == 201 && res.data is Map) {
+      final body = res.data as Map<String, dynamic>;
+      return CollectionPeriod.fromJson(body['data'] as Map<String, dynamic>);
+    }
+    if (res.data is Map) {
+      final body = res.data as Map<String, dynamic>;
+      throw AdminSuggestionException(
+        (body['error'] as String?) ?? 'create_period_failed',
+        (body['message'] as String?) ?? '기간 생성에 실패했습니다.',
+      );
+    }
+    throw AdminSuggestionException(
+      'create_period_failed',
+      '기간 생성에 실패했습니다 (${res.statusCode}).',
+    );
+  }
+
+  static String _statusToWire(SuggestionStatus s) {
+    switch (s) {
+      case SuggestionStatus.submitted:
+        return 'submitted';
+      case SuggestionStatus.approved:
+        return 'approved';
+      case SuggestionStatus.rejected:
+        return 'rejected';
+      case SuggestionStatus.underReview:
+        return 'under_review';
+    }
+  }
+
+  static String _periodStatusToWire(PeriodStatus s) {
+    switch (s) {
+      case PeriodStatus.upcoming:
+        return 'upcoming';
+      case PeriodStatus.active:
+        return 'active';
+      case PeriodStatus.closed:
+        return 'closed';
+    }
+  }
+}

--- a/lib/features/book_suggestions/data/repositories/suggestion_repository_impl.dart
+++ b/lib/features/book_suggestions/data/repositories/suggestion_repository_impl.dart
@@ -1,0 +1,106 @@
+import 'package:dio/dio.dart';
+
+import '../../../../services/storage/secure_storage_service.dart';
+import '../../domain/repositories/suggestion_repository.dart';
+import '../models/book_suggestion.dart';
+import '../models/collection_period.dart';
+
+class SuggestionRepositoryImpl implements SuggestionRepository {
+  SuggestionRepositoryImpl({
+    required String baseUrl,
+    SecureStorageService? storage,
+    Dio? httpClient,
+  })  : _storage = storage ?? SecureStorageService(),
+        _dio = httpClient ?? _build(baseUrl) {
+    _dio.interceptors.add(InterceptorsWrapper(
+      onRequest: (options, handler) async {
+        // Student JWT for /suggestions; /collection-periods/active is public.
+        final token = await _storage.readToken();
+        if (token != null && token.isNotEmpty) {
+          options.headers['Authorization'] = 'Bearer $token';
+        }
+        return handler.next(options);
+      },
+    ));
+  }
+
+  static Dio _build(String baseUrl) => Dio(
+        BaseOptions(
+          baseUrl: baseUrl,
+          connectTimeout: const Duration(seconds: 15),
+          receiveTimeout: const Duration(seconds: 15),
+          headers: {'Content-Type': 'application/json'},
+          validateStatus: (s) => s != null && s < 500,
+        ),
+      );
+
+  final SecureStorageService _storage;
+  final Dio _dio;
+
+  @override
+  Future<CollectionPeriod?> fetchActivePeriod() async {
+    final res = await _dio.get<dynamic>('/v1/collection-periods/active');
+    if (res.statusCode == 404) return null;
+    if (res.statusCode != 200 || res.data is! Map) {
+      throw SuggestionException(
+        'unknown',
+        '활성 수집 기간 조회 실패 (${res.statusCode}).',
+      );
+    }
+    final body = res.data as Map<String, dynamic>;
+    return CollectionPeriod.fromJson(body['data'] as Map<String, dynamic>);
+  }
+
+  @override
+  Future<BookSuggestion> submit({
+    required String suggestedTitle,
+    required String suggestedAuthor,
+    String? reason,
+  }) async {
+    final res = await _dio.post<dynamic>(
+      '/v1/suggestions',
+      data: {
+        'suggestedTitle': suggestedTitle,
+        'suggestedAuthor': suggestedAuthor,
+        if (reason != null && reason.isNotEmpty) 'reason': reason,
+      },
+    );
+    if (res.statusCode == 401) {
+      throw const SuggestionException('unauthorized', '로그인이 필요합니다.');
+    }
+    if (res.statusCode == 201 && res.data is Map) {
+      final body = res.data as Map<String, dynamic>;
+      return BookSuggestion.fromJson(body['data'] as Map<String, dynamic>);
+    }
+    if (res.data is Map) {
+      final body = res.data as Map<String, dynamic>;
+      throw SuggestionException(
+        (body['error'] as String?) ?? 'unknown',
+        (body['message'] as String?) ?? '제출에 실패했습니다.',
+      );
+    }
+    throw SuggestionException(
+      'unknown',
+      '제출에 실패했습니다 (${res.statusCode}).',
+    );
+  }
+
+  @override
+  Future<List<BookSuggestion>> fetchMine() async {
+    final res = await _dio.get<dynamic>('/v1/suggestions/my');
+    if (res.statusCode == 401) {
+      throw const SuggestionException('unauthorized', '로그인이 필요합니다.');
+    }
+    if (res.statusCode != 200 || res.data is! Map) {
+      throw SuggestionException(
+        'unknown',
+        '제출 내역 조회 실패 (${res.statusCode}).',
+      );
+    }
+    final body = res.data as Map<String, dynamic>;
+    final list = body['data'] as List<dynamic>;
+    return list
+        .map((j) => BookSuggestion.fromJson(j as Map<String, dynamic>))
+        .toList();
+  }
+}

--- a/lib/features/book_suggestions/domain/repositories/admin_suggestion_repository.dart
+++ b/lib/features/book_suggestions/domain/repositories/admin_suggestion_repository.dart
@@ -1,0 +1,30 @@
+import '../../data/models/book_suggestion.dart';
+import '../../data/models/collection_period.dart';
+import '../../data/models/grouped_suggestion.dart';
+
+class AdminSuggestionException implements Exception {
+  final String code;
+  final String message;
+  const AdminSuggestionException(this.code, this.message);
+
+  @override
+  String toString() => 'AdminSuggestionException($code): $message';
+}
+
+abstract class AdminSuggestionRepository {
+  Future<List<GroupedSuggestion>> fetchGrouped({String? periodId});
+
+  /// Update a single suggestion record.
+  Future<BookSuggestion> review(
+    String suggestionId, {
+    required SuggestionStatus status,
+    String? adminNotes,
+  });
+
+  Future<CollectionPeriod> createPeriod({
+    required String name,
+    required DateTime startDate,
+    required DateTime endDate,
+    PeriodStatus status = PeriodStatus.upcoming,
+  });
+}

--- a/lib/features/book_suggestions/domain/repositories/suggestion_repository.dart
+++ b/lib/features/book_suggestions/domain/repositories/suggestion_repository.dart
@@ -2,7 +2,8 @@ import '../../data/models/book_suggestion.dart';
 import '../../data/models/collection_period.dart';
 
 class SuggestionException implements Exception {
-  final String code; // no_active_period | duplicate_suggestion | network | unauthorized | unknown
+  final String
+      code; // no_active_period | duplicate_suggestion | network | unauthorized | unknown
   final String message;
   const SuggestionException(this.code, this.message);
 

--- a/lib/features/book_suggestions/domain/repositories/suggestion_repository.dart
+++ b/lib/features/book_suggestions/domain/repositories/suggestion_repository.dart
@@ -1,0 +1,23 @@
+import '../../data/models/book_suggestion.dart';
+import '../../data/models/collection_period.dart';
+
+class SuggestionException implements Exception {
+  final String code; // no_active_period | duplicate_suggestion | network | unauthorized | unknown
+  final String message;
+  const SuggestionException(this.code, this.message);
+
+  @override
+  String toString() => 'SuggestionException($code): $message';
+}
+
+abstract class SuggestionRepository {
+  Future<CollectionPeriod?> fetchActivePeriod();
+
+  Future<BookSuggestion> submit({
+    required String suggestedTitle,
+    required String suggestedAuthor,
+    String? reason,
+  });
+
+  Future<List<BookSuggestion>> fetchMine();
+}

--- a/lib/features/book_suggestions/presentation/bloc/admin_suggestions_bloc.dart
+++ b/lib/features/book_suggestions/presentation/bloc/admin_suggestions_bloc.dart
@@ -1,0 +1,117 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../data/models/book_suggestion.dart';
+import '../../data/models/grouped_suggestion.dart';
+import '../../domain/repositories/admin_suggestion_repository.dart';
+import 'admin_suggestions_event.dart';
+import 'admin_suggestions_state.dart';
+
+class AdminSuggestionsBloc
+    extends Bloc<AdminSuggestionsEvent, AdminSuggestionsState> {
+  final AdminSuggestionRepository repository;
+
+  AdminSuggestionsBloc({required this.repository})
+      : super(const AdminSuggestionsInitial()) {
+    on<AdminSuggestionsRequested>(_onLoad);
+    on<AdminSuggestionReviewed>(_onReview);
+    on<AdminPeriodCreated>(_onCreatePeriod);
+  }
+
+  Future<void> _onLoad(
+    AdminSuggestionsRequested event,
+    Emitter<AdminSuggestionsState> emit,
+  ) async {
+    emit(const AdminSuggestionsLoading());
+    try {
+      final groups = await repository.fetchGrouped(periodId: event.periodId);
+      emit(AdminSuggestionsLoaded(groups: groups));
+    } catch (e) {
+      emit(AdminSuggestionsError(_messageFor(e)));
+    }
+  }
+
+  Future<void> _onReview(
+    AdminSuggestionReviewed event,
+    Emitter<AdminSuggestionsState> emit,
+  ) async {
+    final current = state;
+    if (current is! AdminSuggestionsLoaded) return;
+    emit(current.copyWith(
+        actionStatus: AdminSuggestionsActionStatus.inProgress));
+    try {
+      final updated = await repository.review(
+        event.suggestionId,
+        status: event.status,
+        adminNotes: event.adminNotes,
+      );
+      emit(current.copyWith(
+        groups: _replaceItem(current.groups, updated),
+        actionStatus: AdminSuggestionsActionStatus.success,
+        actionMessage: '검토 결과가 저장되었습니다.',
+      ));
+    } catch (e) {
+      emit(current.copyWith(
+        actionStatus: AdminSuggestionsActionStatus.failure,
+        actionMessage: _messageFor(e),
+      ));
+    }
+  }
+
+  Future<void> _onCreatePeriod(
+    AdminPeriodCreated event,
+    Emitter<AdminSuggestionsState> emit,
+  ) async {
+    final current = state;
+    if (current is AdminSuggestionsLoaded) {
+      emit(current.copyWith(
+          actionStatus: AdminSuggestionsActionStatus.inProgress));
+    }
+    try {
+      await repository.createPeriod(
+        name: event.name,
+        startDate: event.startDate,
+        endDate: event.endDate,
+        status: event.status,
+      );
+      // Reload — new active period archives previous active.
+      add(const AdminSuggestionsRequested());
+    } catch (e) {
+      if (current is AdminSuggestionsLoaded) {
+        emit(current.copyWith(
+          actionStatus: AdminSuggestionsActionStatus.failure,
+          actionMessage: _messageFor(e),
+        ));
+      } else {
+        emit(AdminSuggestionsError(_messageFor(e)));
+      }
+    }
+  }
+
+  /// Returns a new list of groups with the updated suggestion replacing the
+  /// matching item inside its group, with statuses recomputed.
+  static List<GroupedSuggestion> _replaceItem(
+    List<GroupedSuggestion> groups,
+    BookSuggestion updated,
+  ) {
+    return groups.map((g) {
+      final containsUpdated = g.items.any((s) => s.id == updated.id);
+      if (!containsUpdated) return g;
+
+      final newItems =
+          g.items.map((s) => s.id == updated.id ? updated : s).toList();
+      final newStatuses = <SuggestionStatus, int>{};
+      for (final s in newItems) {
+        newStatuses[s.status] = (newStatuses[s.status] ?? 0) + 1;
+      }
+      return g.copyWith(items: newItems, statuses: newStatuses);
+    }).toList();
+  }
+
+  static String _messageFor(Object e) {
+    if (e is Exception) {
+      final msg = e.toString();
+      return msg.startsWith('Exception: ') ? msg.substring(11) : msg;
+    }
+    return e.toString();
+  }
+}

--- a/lib/features/book_suggestions/presentation/bloc/admin_suggestions_event.dart
+++ b/lib/features/book_suggestions/presentation/bloc/admin_suggestions_event.dart
@@ -1,0 +1,51 @@
+import 'package:equatable/equatable.dart';
+
+import '../../data/models/book_suggestion.dart';
+import '../../data/models/collection_period.dart';
+
+abstract class AdminSuggestionsEvent extends Equatable {
+  const AdminSuggestionsEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class AdminSuggestionsRequested extends AdminSuggestionsEvent {
+  final String? periodId;
+  const AdminSuggestionsRequested({this.periodId});
+
+  @override
+  List<Object?> get props => [periodId];
+}
+
+class AdminSuggestionReviewed extends AdminSuggestionsEvent {
+  final String suggestionId;
+  final SuggestionStatus status;
+  final String? adminNotes;
+
+  const AdminSuggestionReviewed({
+    required this.suggestionId,
+    required this.status,
+    this.adminNotes,
+  });
+
+  @override
+  List<Object?> get props => [suggestionId, status, adminNotes];
+}
+
+class AdminPeriodCreated extends AdminSuggestionsEvent {
+  final String name;
+  final DateTime startDate;
+  final DateTime endDate;
+  final PeriodStatus status;
+
+  const AdminPeriodCreated({
+    required this.name,
+    required this.startDate,
+    required this.endDate,
+    this.status = PeriodStatus.upcoming,
+  });
+
+  @override
+  List<Object?> get props => [name, startDate, endDate, status];
+}

--- a/lib/features/book_suggestions/presentation/bloc/admin_suggestions_state.dart
+++ b/lib/features/book_suggestions/presentation/bloc/admin_suggestions_state.dart
@@ -1,0 +1,55 @@
+import 'package:equatable/equatable.dart';
+
+import '../../data/models/grouped_suggestion.dart';
+
+enum AdminSuggestionsActionStatus { idle, inProgress, success, failure }
+
+abstract class AdminSuggestionsState extends Equatable {
+  const AdminSuggestionsState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class AdminSuggestionsInitial extends AdminSuggestionsState {
+  const AdminSuggestionsInitial();
+}
+
+class AdminSuggestionsLoading extends AdminSuggestionsState {
+  const AdminSuggestionsLoading();
+}
+
+class AdminSuggestionsLoaded extends AdminSuggestionsState {
+  final List<GroupedSuggestion> groups;
+  final AdminSuggestionsActionStatus actionStatus;
+  final String? actionMessage;
+
+  const AdminSuggestionsLoaded({
+    required this.groups,
+    this.actionStatus = AdminSuggestionsActionStatus.idle,
+    this.actionMessage,
+  });
+
+  AdminSuggestionsLoaded copyWith({
+    List<GroupedSuggestion>? groups,
+    AdminSuggestionsActionStatus? actionStatus,
+    String? actionMessage,
+  }) {
+    return AdminSuggestionsLoaded(
+      groups: groups ?? this.groups,
+      actionStatus: actionStatus ?? this.actionStatus,
+      actionMessage: actionMessage,
+    );
+  }
+
+  @override
+  List<Object?> get props => [groups, actionStatus, actionMessage];
+}
+
+class AdminSuggestionsError extends AdminSuggestionsState {
+  final String message;
+  const AdminSuggestionsError(this.message);
+
+  @override
+  List<Object?> get props => [message];
+}

--- a/lib/features/book_suggestions/presentation/bloc/suggestion_bloc.dart
+++ b/lib/features/book_suggestions/presentation/bloc/suggestion_bloc.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../domain/repositories/suggestion_repository.dart';
+import 'suggestion_event.dart';
+import 'suggestion_state.dart';
+
+class SuggestionBloc extends Bloc<SuggestionEvent, SuggestionState> {
+  final SuggestionRepository repository;
+
+  SuggestionBloc({required this.repository})
+      : super(const SuggestionInitial()) {
+    on<SuggestionsRequested>(_onLoad);
+    on<SuggestionSubmitted>(_onSubmit);
+  }
+
+  Future<void> _onLoad(
+    SuggestionsRequested event,
+    Emitter<SuggestionState> emit,
+  ) async {
+    emit(const SuggestionLoading());
+    try {
+      final period = await repository.fetchActivePeriod();
+      final mine = await repository.fetchMine();
+      emit(SuggestionLoaded(activePeriod: period, mySuggestions: mine));
+    } on SuggestionException catch (e) {
+      emit(SuggestionError(e.message));
+    } catch (e) {
+      emit(SuggestionError(e.toString()));
+    }
+  }
+
+  Future<void> _onSubmit(
+    SuggestionSubmitted event,
+    Emitter<SuggestionState> emit,
+  ) async {
+    final current = state;
+    if (current is! SuggestionLoaded) return;
+    emit(current.copyWith(actionStatus: SuggestionActionStatus.inProgress));
+    try {
+      final created = await repository.submit(
+        suggestedTitle: event.suggestedTitle,
+        suggestedAuthor: event.suggestedAuthor,
+        reason: event.reason,
+      );
+      emit(current.copyWith(
+        mySuggestions: [created, ...current.mySuggestions],
+        actionStatus: SuggestionActionStatus.success,
+        actionMessage: '추천이 제출되었습니다.',
+      ));
+    } on SuggestionException catch (e) {
+      emit(current.copyWith(
+        actionStatus: SuggestionActionStatus.failure,
+        actionMessage: e.message,
+      ));
+    } catch (e) {
+      emit(current.copyWith(
+        actionStatus: SuggestionActionStatus.failure,
+        actionMessage: e.toString(),
+      ));
+    }
+  }
+}

--- a/lib/features/book_suggestions/presentation/bloc/suggestion_event.dart
+++ b/lib/features/book_suggestions/presentation/bloc/suggestion_event.dart
@@ -1,0 +1,26 @@
+import 'package:equatable/equatable.dart';
+
+abstract class SuggestionEvent extends Equatable {
+  const SuggestionEvent();
+  @override
+  List<Object?> get props => [];
+}
+
+class SuggestionsRequested extends SuggestionEvent {
+  const SuggestionsRequested();
+}
+
+class SuggestionSubmitted extends SuggestionEvent {
+  final String suggestedTitle;
+  final String suggestedAuthor;
+  final String? reason;
+
+  const SuggestionSubmitted({
+    required this.suggestedTitle,
+    required this.suggestedAuthor,
+    this.reason,
+  });
+
+  @override
+  List<Object?> get props => [suggestedTitle, suggestedAuthor, reason];
+}

--- a/lib/features/book_suggestions/presentation/bloc/suggestion_state.dart
+++ b/lib/features/book_suggestions/presentation/bloc/suggestion_state.dart
@@ -1,0 +1,62 @@
+import 'package:equatable/equatable.dart';
+
+import '../../data/models/book_suggestion.dart';
+import '../../data/models/collection_period.dart';
+
+enum SuggestionActionStatus { idle, inProgress, success, failure }
+
+abstract class SuggestionState extends Equatable {
+  const SuggestionState();
+  @override
+  List<Object?> get props => [];
+}
+
+class SuggestionInitial extends SuggestionState {
+  const SuggestionInitial();
+}
+
+class SuggestionLoading extends SuggestionState {
+  const SuggestionLoading();
+}
+
+class SuggestionLoaded extends SuggestionState {
+  final CollectionPeriod? activePeriod;
+  final List<BookSuggestion> mySuggestions;
+  final SuggestionActionStatus actionStatus;
+  final String? actionMessage;
+
+  const SuggestionLoaded({
+    required this.activePeriod,
+    required this.mySuggestions,
+    this.actionStatus = SuggestionActionStatus.idle,
+    this.actionMessage,
+  });
+
+  SuggestionLoaded copyWith({
+    CollectionPeriod? activePeriod,
+    bool clearActivePeriod = false,
+    List<BookSuggestion>? mySuggestions,
+    SuggestionActionStatus? actionStatus,
+    String? actionMessage,
+  }) {
+    return SuggestionLoaded(
+      activePeriod:
+          clearActivePeriod ? null : (activePeriod ?? this.activePeriod),
+      mySuggestions: mySuggestions ?? this.mySuggestions,
+      actionStatus: actionStatus ?? this.actionStatus,
+      actionMessage: actionMessage,
+    );
+  }
+
+  @override
+  List<Object?> get props =>
+      [activePeriod, mySuggestions, actionStatus, actionMessage];
+}
+
+class SuggestionError extends SuggestionState {
+  final String message;
+  const SuggestionError(this.message);
+
+  @override
+  List<Object?> get props => [message];
+}

--- a/lib/features/book_suggestions/presentation/screens/collection_periods_screen.dart
+++ b/lib/features/book_suggestions/presentation/screens/collection_periods_screen.dart
@@ -1,0 +1,243 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../../app/config.dart';
+import '../../data/models/collection_period.dart';
+import '../../data/repositories/admin_suggestion_repository_impl.dart';
+import '../../domain/repositories/admin_suggestion_repository.dart';
+import '../bloc/admin_suggestions_bloc.dart';
+import '../bloc/admin_suggestions_event.dart';
+import '../bloc/admin_suggestions_state.dart';
+import '../../../admin_catalog/presentation/widgets/admin_sidebar.dart';
+
+/// Minimal CollectionPeriod create form. The list of periods isn't a backend
+/// endpoint yet (only `/active` is exposed), so this screen focuses on
+/// creation. Reading current period info comes via SuggestionRepository's
+/// fetchActivePeriod when needed elsewhere.
+class CollectionPeriodsScreen extends StatelessWidget {
+  const CollectionPeriodsScreen({super.key, this.repository});
+
+  final AdminSuggestionRepository? repository;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider<AdminSuggestionsBloc>(
+      create: (_) => AdminSuggestionsBloc(
+        repository: repository ??
+            AdminSuggestionRepositoryImpl(baseUrl: AppConfig.apiBaseUrl),
+      ),
+      child: const _Body(),
+    );
+  }
+}
+
+class _Body extends StatelessWidget {
+  const _Body();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('수집 기간 관리')),
+      drawer: const AdminSidebar(currentRoute: '/admin/collection-periods'),
+      body: BlocConsumer<AdminSuggestionsBloc, AdminSuggestionsState>(
+        listenWhen: (a, b) =>
+            b is AdminSuggestionsLoaded &&
+            (b.actionStatus == AdminSuggestionsActionStatus.success ||
+                b.actionStatus == AdminSuggestionsActionStatus.failure) &&
+            b.actionMessage != null,
+        listener: (context, state) {
+          if (state is AdminSuggestionsLoaded && state.actionMessage != null) {
+            ScaffoldMessenger.of(context)
+              ..hideCurrentSnackBar()
+              ..showSnackBar(SnackBar(content: Text(state.actionMessage!)));
+          }
+        },
+        builder: (context, state) {
+          return SingleChildScrollView(
+            padding: const EdgeInsets.all(24),
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 720),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text('새 수집 기간 만들기',
+                      style: Theme.of(context).textTheme.titleLarge),
+                  const SizedBox(height: 8),
+                  Text(
+                    'active로 만들면 기존 활성 기간이 자동으로 closed 처리됩니다.',
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
+                  const SizedBox(height: 16),
+                  const _PeriodForm(),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _PeriodForm extends StatefulWidget {
+  const _PeriodForm();
+
+  @override
+  State<_PeriodForm> createState() => _PeriodFormState();
+}
+
+class _PeriodFormState extends State<_PeriodForm> {
+  final _formKey = GlobalKey<FormState>();
+  final _name = TextEditingController();
+  DateTime? _start;
+  DateTime? _end;
+  PeriodStatus _status = PeriodStatus.upcoming;
+
+  @override
+  void dispose() {
+    _name.dispose();
+    super.dispose();
+  }
+
+  Future<void> _pickDate({required bool isStart}) async {
+    final initial = isStart
+        ? (_start ?? DateTime.now())
+        : (_end ?? (_start ?? DateTime.now()).add(const Duration(days: 30)));
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: initial,
+      firstDate: DateTime.now().subtract(const Duration(days: 365)),
+      lastDate: DateTime.now().add(const Duration(days: 365 * 2)),
+    );
+    if (picked != null) {
+      setState(() {
+        if (isStart) {
+          _start = picked;
+        } else {
+          _end = picked;
+        }
+      });
+    }
+  }
+
+  void _submit() {
+    if (!_formKey.currentState!.validate()) return;
+    if (_start == null || _end == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('시작일과 종료일을 모두 선택하세요.')),
+      );
+      return;
+    }
+    if (!_end!.isAfter(_start!)) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('종료일은 시작일 이후여야 합니다.')),
+      );
+      return;
+    }
+    context.read<AdminSuggestionsBloc>().add(AdminPeriodCreated(
+          name: _name.text.trim(),
+          startDate: _start!,
+          endDate: _end!,
+          status: _status,
+        ));
+    _formKey.currentState!.reset();
+    setState(() {
+      _name.clear();
+      _start = null;
+      _end = null;
+      _status = PeriodStatus.upcoming;
+    });
+  }
+
+  String _statusLabel(PeriodStatus s) {
+    switch (s) {
+      case PeriodStatus.upcoming:
+        return '예정 (upcoming)';
+      case PeriodStatus.active:
+        return '활성 (active)';
+      case PeriodStatus.closed:
+        return '종료 (closed)';
+    }
+  }
+
+  String _fmt(DateTime? d) => d == null
+      ? '선택 안 됨'
+      : '${d.year}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
+
+  @override
+  Widget build(BuildContext context) {
+    final inProgress = context.watch<AdminSuggestionsBloc>().state
+            is AdminSuggestionsLoaded &&
+        (context.watch<AdminSuggestionsBloc>().state as AdminSuggestionsLoaded)
+                .actionStatus ==
+            AdminSuggestionsActionStatus.inProgress;
+
+    return Form(
+      key: _formKey,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          TextFormField(
+            controller: _name,
+            decoration: const InputDecoration(
+              labelText: '기간 이름 *',
+              helperText: '100자 이내 (예: 2024 Q2 도서 추천)',
+            ),
+            validator: (v) {
+              if (v == null || v.trim().isEmpty) return '기간 이름을 입력하세요';
+              if (v.length > 100) return '100자 이하여야 합니다';
+              return null;
+            },
+          ),
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              Expanded(
+                child: OutlinedButton.icon(
+                  icon: const Icon(Icons.calendar_today),
+                  label: Text('시작: ${_fmt(_start)}'),
+                  onPressed: () => _pickDate(isStart: true),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: OutlinedButton.icon(
+                  icon: const Icon(Icons.event),
+                  label: Text('종료: ${_fmt(_end)}'),
+                  onPressed: () => _pickDate(isStart: false),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          DropdownButtonFormField<PeriodStatus>(
+            value: _status,
+            decoration: const InputDecoration(labelText: '상태'),
+            items: PeriodStatus.values
+                .map((s) => DropdownMenuItem(
+                      value: s,
+                      child: Text(_statusLabel(s)),
+                    ))
+                .toList(),
+            onChanged: (v) =>
+                setState(() => _status = v ?? PeriodStatus.upcoming),
+          ),
+          const SizedBox(height: 24),
+          FilledButton(
+            onPressed: inProgress ? null : _submit,
+            style: FilledButton.styleFrom(
+              minimumSize: const Size.fromHeight(48),
+            ),
+            child: inProgress
+                ? const SizedBox(
+                    width: 20,
+                    height: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Text('기간 생성'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/book_suggestions/presentation/screens/my_suggestions_screen.dart
+++ b/lib/features/book_suggestions/presentation/screens/my_suggestions_screen.dart
@@ -1,0 +1,251 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../app/config.dart';
+import '../../data/models/book_suggestion.dart';
+import '../../data/repositories/suggestion_repository_impl.dart';
+import '../bloc/suggestion_bloc.dart';
+import '../bloc/suggestion_event.dart';
+import '../bloc/suggestion_state.dart';
+
+class MySuggestionsScreen extends StatelessWidget {
+  const MySuggestionsScreen({super.key, this.bloc});
+
+  final SuggestionBloc? bloc;
+
+  @override
+  Widget build(BuildContext context) {
+    if (bloc != null) {
+      return BlocProvider<SuggestionBloc>.value(
+        value: bloc!,
+        child: const _MySuggestionsView(),
+      );
+    }
+    return BlocProvider<SuggestionBloc>(
+      create: (_) => SuggestionBloc(
+        repository:
+            SuggestionRepositoryImpl(baseUrl: AppConfig.apiBaseUrl),
+      )..add(const SuggestionsRequested()),
+      child: const _MySuggestionsView(),
+    );
+  }
+}
+
+class _MySuggestionsView extends StatelessWidget {
+  const _MySuggestionsView();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('내 희망 도서'),
+        actions: [
+          IconButton(
+            tooltip: '새로고침',
+            icon: const Icon(Icons.refresh),
+            onPressed: () =>
+                context.read<SuggestionBloc>().add(const SuggestionsRequested()),
+          ),
+        ],
+      ),
+      floatingActionButton: BlocBuilder<SuggestionBloc, SuggestionState>(
+        buildWhen: (a, b) => b is SuggestionLoaded || b is SuggestionInitial,
+        builder: (context, state) {
+          if (state is SuggestionLoaded && state.activePeriod != null) {
+            return FloatingActionButton.extended(
+              icon: const Icon(Icons.add),
+              label: const Text('도서 추천'),
+              onPressed: () => context.go('/suggestions/new'),
+            );
+          }
+          return const SizedBox.shrink();
+        },
+      ),
+      body: BlocBuilder<SuggestionBloc, SuggestionState>(
+        builder: (context, state) {
+          if (state is SuggestionLoading || state is SuggestionInitial) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (state is SuggestionError) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const Icon(Icons.error_outline,
+                        size: 56, color: Colors.red),
+                    const SizedBox(height: 12),
+                    Text(state.message, textAlign: TextAlign.center),
+                    const SizedBox(height: 16),
+                    FilledButton(
+                      onPressed: () => context
+                          .read<SuggestionBloc>()
+                          .add(const SuggestionsRequested()),
+                      child: const Text('다시 시도'),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          }
+          final loaded = state as SuggestionLoaded;
+          return Column(
+            children: [
+              if (loaded.activePeriod == null)
+                const _NoActivePeriodBanner()
+              else
+                _ActivePeriodBanner(periodName: loaded.activePeriod!.name),
+              Expanded(
+                child: loaded.mySuggestions.isEmpty
+                    ? const _EmptyState()
+                    : ListView.separated(
+                        padding: const EdgeInsets.fromLTRB(16, 16, 16, 96),
+                        itemCount: loaded.mySuggestions.length,
+                        separatorBuilder: (_, __) => const Divider(height: 1),
+                        itemBuilder: (context, i) =>
+                            _SuggestionTile(suggestion: loaded.mySuggestions[i]),
+                      ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _ActivePeriodBanner extends StatelessWidget {
+  const _ActivePeriodBanner({required this.periodName});
+  final String periodName;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      color: Theme.of(context).colorScheme.primaryContainer,
+      padding: const EdgeInsets.all(12),
+      child: Text(
+        '활성 수집 기간: $periodName',
+        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+              color: Theme.of(context).colorScheme.onPrimaryContainer,
+            ),
+      ),
+    );
+  }
+}
+
+class _NoActivePeriodBanner extends StatelessWidget {
+  const _NoActivePeriodBanner();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      color: Theme.of(context).colorScheme.surfaceContainerHighest,
+      padding: const EdgeInsets.all(12),
+      child: Text(
+        '현재 활성 수집 기간이 없습니다. 새 기간이 열릴 때까지 추천을 제출할 수 없습니다.',
+        style: Theme.of(context).textTheme.bodySmall,
+      ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.lightbulb_outline,
+                size: 56, color: Colors.grey[400]),
+            const SizedBox(height: 12),
+            Text(
+              '아직 제출한 추천이 없습니다.\n우측 하단 + 버튼으로 추천을 시작하세요.',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SuggestionTile extends StatelessWidget {
+  const _SuggestionTile({required this.suggestion});
+  final BookSuggestion suggestion;
+
+  Color _statusColor(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    switch (suggestion.status) {
+      case SuggestionStatus.approved:
+        return Colors.green;
+      case SuggestionStatus.rejected:
+        return scheme.error;
+      case SuggestionStatus.underReview:
+        return Colors.amber.shade700;
+      case SuggestionStatus.submitted:
+        return scheme.primary;
+    }
+  }
+
+  String _statusLabel() {
+    switch (suggestion.status) {
+      case SuggestionStatus.approved:
+        return '승인됨';
+      case SuggestionStatus.rejected:
+        return '반려됨';
+      case SuggestionStatus.underReview:
+        return '검토 중';
+      case SuggestionStatus.submitted:
+        return '제출됨';
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      title: Text(suggestion.suggestedTitle),
+      subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(suggestion.suggestedAuthor),
+          if (suggestion.adminNotes != null)
+            Padding(
+              padding: const EdgeInsets.only(top: 4),
+              child: Text(
+                '관리자 메모: ${suggestion.adminNotes}',
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Colors.grey[700],
+                    ),
+              ),
+            ),
+        ],
+      ),
+      trailing: Container(
+        padding:
+            const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+        decoration: BoxDecoration(
+          color: _statusColor(context).withOpacity(0.12),
+          border: Border.all(color: _statusColor(context).withOpacity(0.4)),
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Text(
+          _statusLabel(),
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: _statusColor(context),
+                fontWeight: FontWeight.w600,
+              ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/book_suggestions/presentation/screens/my_suggestions_screen.dart
+++ b/lib/features/book_suggestions/presentation/screens/my_suggestions_screen.dart
@@ -24,8 +24,7 @@ class MySuggestionsScreen extends StatelessWidget {
     }
     return BlocProvider<SuggestionBloc>(
       create: (_) => SuggestionBloc(
-        repository:
-            SuggestionRepositoryImpl(baseUrl: AppConfig.apiBaseUrl),
+        repository: SuggestionRepositoryImpl(baseUrl: AppConfig.apiBaseUrl),
       )..add(const SuggestionsRequested()),
       child: const _MySuggestionsView(),
     );
@@ -44,8 +43,9 @@ class _MySuggestionsView extends StatelessWidget {
           IconButton(
             tooltip: '새로고침',
             icon: const Icon(Icons.refresh),
-            onPressed: () =>
-                context.read<SuggestionBloc>().add(const SuggestionsRequested()),
+            onPressed: () => context
+                .read<SuggestionBloc>()
+                .add(const SuggestionsRequested()),
           ),
         ],
       ),
@@ -104,8 +104,8 @@ class _MySuggestionsView extends StatelessWidget {
                         padding: const EdgeInsets.fromLTRB(16, 16, 16, 96),
                         itemCount: loaded.mySuggestions.length,
                         separatorBuilder: (_, __) => const Divider(height: 1),
-                        itemBuilder: (context, i) =>
-                            _SuggestionTile(suggestion: loaded.mySuggestions[i]),
+                        itemBuilder: (context, i) => _SuggestionTile(
+                            suggestion: loaded.mySuggestions[i]),
                       ),
               ),
             ],
@@ -164,8 +164,7 @@ class _EmptyState extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(Icons.lightbulb_outline,
-                size: 56, color: Colors.grey[400]),
+            Icon(Icons.lightbulb_outline, size: 56, color: Colors.grey[400]),
             const SizedBox(height: 12),
             Text(
               '아직 제출한 추천이 없습니다.\n우측 하단 + 버튼으로 추천을 시작하세요.',
@@ -231,8 +230,7 @@ class _SuggestionTile extends StatelessWidget {
         ],
       ),
       trailing: Container(
-        padding:
-            const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
         decoration: BoxDecoration(
           color: _statusColor(context).withOpacity(0.12),
           border: Border.all(color: _statusColor(context).withOpacity(0.4)),

--- a/lib/features/book_suggestions/presentation/screens/suggestion_form_screen.dart
+++ b/lib/features/book_suggestions/presentation/screens/suggestion_form_screen.dart
@@ -97,8 +97,7 @@ class _SuggestionFormViewState extends State<_SuggestionFormView> {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
-                    if (state is SuggestionLoaded &&
-                        state.activePeriod != null)
+                    if (state is SuggestionLoaded && state.activePeriod != null)
                       Padding(
                         padding: const EdgeInsets.only(bottom: 16),
                         child: Text(

--- a/lib/features/book_suggestions/presentation/screens/suggestion_form_screen.dart
+++ b/lib/features/book_suggestions/presentation/screens/suggestion_form_screen.dart
@@ -1,0 +1,161 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+
+import '../bloc/suggestion_bloc.dart';
+import '../bloc/suggestion_event.dart';
+import '../bloc/suggestion_state.dart';
+
+class SuggestionFormScreen extends StatelessWidget {
+  const SuggestionFormScreen({super.key, this.bloc});
+
+  /// In production we expect to be navigated *from* MySuggestionsScreen which
+  /// owns a [SuggestionBloc]; the parent BlocProvider is reachable via `context`.
+  /// For testing we accept an explicit `bloc` and wrap with BlocProvider.value.
+  final SuggestionBloc? bloc;
+
+  @override
+  Widget build(BuildContext context) {
+    if (bloc != null) {
+      return BlocProvider<SuggestionBloc>.value(
+        value: bloc!,
+        child: const _SuggestionFormView(),
+      );
+    }
+    return const _SuggestionFormView();
+  }
+}
+
+class _SuggestionFormView extends StatefulWidget {
+  const _SuggestionFormView();
+
+  @override
+  State<_SuggestionFormView> createState() => _SuggestionFormViewState();
+}
+
+class _SuggestionFormViewState extends State<_SuggestionFormView> {
+  final _formKey = GlobalKey<FormState>();
+  final _title = TextEditingController();
+  final _author = TextEditingController();
+  final _reason = TextEditingController();
+
+  @override
+  void dispose() {
+    _title.dispose();
+    _author.dispose();
+    _reason.dispose();
+    super.dispose();
+  }
+
+  String? _required(String label, String? v) =>
+      (v == null || v.trim().isEmpty) ? '$label을(를) 입력하세요' : null;
+
+  String? _maxLen(String label, String? v, int max) {
+    if (v == null) return null;
+    if (v.length > max) return '$label은(는) $max자 이하여야 합니다';
+    return null;
+  }
+
+  void _submit() {
+    if (!_formKey.currentState!.validate()) return;
+    context.read<SuggestionBloc>().add(SuggestionSubmitted(
+          suggestedTitle: _title.text.trim(),
+          suggestedAuthor: _author.text.trim(),
+          reason: _reason.text.trim().isEmpty ? null : _reason.text.trim(),
+        ));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('도서 추천')),
+      body: BlocConsumer<SuggestionBloc, SuggestionState>(
+        listenWhen: (a, b) =>
+            b is SuggestionLoaded &&
+            (b.actionStatus == SuggestionActionStatus.success ||
+                b.actionStatus == SuggestionActionStatus.failure) &&
+            b.actionMessage != null,
+        listener: (context, state) {
+          if (state is SuggestionLoaded && state.actionMessage != null) {
+            ScaffoldMessenger.of(context)
+              ..hideCurrentSnackBar()
+              ..showSnackBar(SnackBar(content: Text(state.actionMessage!)));
+            if (state.actionStatus == SuggestionActionStatus.success) {
+              context.go('/suggestions/mine');
+            }
+          }
+        },
+        builder: (context, state) {
+          final isInProgress = state is SuggestionLoaded &&
+              state.actionStatus == SuggestionActionStatus.inProgress;
+
+          return Padding(
+            padding: const EdgeInsets.all(24),
+            child: Form(
+              key: _formKey,
+              child: SingleChildScrollView(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    if (state is SuggestionLoaded &&
+                        state.activePeriod != null)
+                      Padding(
+                        padding: const EdgeInsets.only(bottom: 16),
+                        child: Text(
+                          '제출 대상 기간: ${state.activePeriod!.name}',
+                          style: Theme.of(context).textTheme.bodyMedium,
+                        ),
+                      ),
+                    TextFormField(
+                      controller: _title,
+                      decoration: const InputDecoration(
+                        labelText: '제목 *',
+                        helperText: '500자 이내',
+                      ),
+                      validator: (v) =>
+                          _required('제목', v) ?? _maxLen('제목', v, 500),
+                    ),
+                    const SizedBox(height: 12),
+                    TextFormField(
+                      controller: _author,
+                      decoration: const InputDecoration(
+                        labelText: '저자 *',
+                        helperText: '200자 이내',
+                      ),
+                      validator: (v) =>
+                          _required('저자', v) ?? _maxLen('저자', v, 200),
+                    ),
+                    const SizedBox(height: 12),
+                    TextFormField(
+                      controller: _reason,
+                      maxLines: 4,
+                      decoration: const InputDecoration(
+                        labelText: '추천 사유',
+                        helperText: '1000자 이내 (선택)',
+                      ),
+                      validator: (v) => _maxLen('사유', v, 1000),
+                    ),
+                    const SizedBox(height: 24),
+                    FilledButton(
+                      onPressed: isInProgress ? null : _submit,
+                      style: FilledButton.styleFrom(
+                        minimumSize: const Size.fromHeight(48),
+                      ),
+                      child: isInProgress
+                          ? const SizedBox(
+                              width: 20,
+                              height: 20,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            )
+                          : const Text('제출'),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/book_suggestions/presentation/screens/suggestions_review_screen.dart
+++ b/lib/features/book_suggestions/presentation/screens/suggestions_review_screen.dart
@@ -1,0 +1,335 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../../app/config.dart';
+import '../../data/models/book_suggestion.dart';
+import '../../data/models/grouped_suggestion.dart';
+import '../../data/repositories/admin_suggestion_repository_impl.dart';
+import '../../domain/repositories/admin_suggestion_repository.dart';
+import '../bloc/admin_suggestions_bloc.dart';
+import '../bloc/admin_suggestions_event.dart';
+import '../bloc/admin_suggestions_state.dart';
+import '../../../admin_catalog/presentation/widgets/admin_sidebar.dart';
+
+class SuggestionsReviewScreen extends StatelessWidget {
+  const SuggestionsReviewScreen({super.key, this.repository});
+
+  final AdminSuggestionRepository? repository;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider<AdminSuggestionsBloc>(
+      create: (_) => AdminSuggestionsBloc(
+        repository: repository ??
+            AdminSuggestionRepositoryImpl(baseUrl: AppConfig.apiBaseUrl),
+      )..add(const AdminSuggestionsRequested()),
+      child: const _Body(),
+    );
+  }
+}
+
+class _Body extends StatelessWidget {
+  const _Body();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('도서 추천 검토'),
+        actions: [
+          IconButton(
+            tooltip: '새로고침',
+            icon: const Icon(Icons.refresh),
+            onPressed: () => context
+                .read<AdminSuggestionsBloc>()
+                .add(const AdminSuggestionsRequested()),
+          ),
+        ],
+      ),
+      drawer: const AdminSidebar(currentRoute: '/admin/suggestions'),
+      body: BlocConsumer<AdminSuggestionsBloc, AdminSuggestionsState>(
+        listenWhen: (a, b) =>
+            b is AdminSuggestionsLoaded &&
+            (b.actionStatus == AdminSuggestionsActionStatus.success ||
+                b.actionStatus == AdminSuggestionsActionStatus.failure) &&
+            b.actionMessage != null,
+        listener: (context, state) {
+          if (state is AdminSuggestionsLoaded && state.actionMessage != null) {
+            ScaffoldMessenger.of(context)
+              ..hideCurrentSnackBar()
+              ..showSnackBar(SnackBar(content: Text(state.actionMessage!)));
+          }
+        },
+        builder: (context, state) {
+          if (state is AdminSuggestionsInitial ||
+              state is AdminSuggestionsLoading) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (state is AdminSuggestionsError) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(Icons.error_outline,
+                        size: 56, color: Theme.of(context).colorScheme.error),
+                    const SizedBox(height: 12),
+                    Text(state.message, textAlign: TextAlign.center),
+                    const SizedBox(height: 16),
+                    FilledButton(
+                      onPressed: () => context
+                          .read<AdminSuggestionsBloc>()
+                          .add(const AdminSuggestionsRequested()),
+                      child: const Text('다시 시도'),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          }
+          final loaded = state as AdminSuggestionsLoaded;
+          if (loaded.groups.isEmpty) {
+            return const Center(
+              child: Padding(
+                padding: EdgeInsets.all(24),
+                child: Text(
+                  '활성 수집 기간에 제출된 추천이 없습니다.',
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            );
+          }
+          return ListView.separated(
+            padding: const EdgeInsets.all(16),
+            itemCount: loaded.groups.length,
+            separatorBuilder: (_, __) => const SizedBox(height: 12),
+            itemBuilder: (context, i) => _GroupCard(group: loaded.groups[i]),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _GroupCard extends StatelessWidget {
+  const _GroupCard({required this.group});
+  final GroupedSuggestion group;
+
+  String _statusKor(SuggestionStatus s) {
+    switch (s) {
+      case SuggestionStatus.submitted:
+        return '제출됨';
+      case SuggestionStatus.approved:
+        return '승인';
+      case SuggestionStatus.rejected:
+        return '반려';
+      case SuggestionStatus.underReview:
+        return '검토중';
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(group.suggestedTitle,
+                          style: theme.textTheme.titleMedium
+                              ?.copyWith(fontWeight: FontWeight.w600)),
+                      const SizedBox(height: 4),
+                      Text(group.suggestedAuthor,
+                          style: theme.textTheme.bodyMedium
+                              ?.copyWith(color: Colors.grey[700])),
+                    ],
+                  ),
+                ),
+                Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                  decoration: BoxDecoration(
+                    color: theme.colorScheme.primaryContainer,
+                    borderRadius: BorderRadius.circular(20),
+                  ),
+                  child: Text(
+                    '추천 ${group.requesterCount}명',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onPrimaryContainer,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 6,
+              children: group.statuses.entries
+                  .map((e) => Chip(
+                        label: Text(
+                          '${_statusKor(e.key)} ${e.value}',
+                          style: theme.textTheme.bodySmall,
+                        ),
+                        visualDensity: VisualDensity.compact,
+                      ))
+                  .toList(),
+            ),
+            const SizedBox(height: 8),
+            const Divider(),
+            ...group.items.map((s) => _ItemRow(suggestion: s)),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ItemRow extends StatelessWidget {
+  const _ItemRow({required this.suggestion});
+  final BookSuggestion suggestion;
+
+  Future<void> _openReviewDialog(
+    BuildContext context,
+    SuggestionStatus targetStatus,
+  ) async {
+    final controller = TextEditingController();
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) {
+        final label = switch (targetStatus) {
+          SuggestionStatus.approved => '승인',
+          SuggestionStatus.rejected => '반려',
+          SuggestionStatus.underReview => '검토중',
+          _ => '저장',
+        };
+        return AlertDialog(
+          title: Text('추천 $label'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                  '대상: ${suggestion.suggestedTitle} / ${suggestion.suggestedAuthor}'),
+              const SizedBox(height: 12),
+              TextField(
+                controller: controller,
+                maxLines: 3,
+                decoration: const InputDecoration(
+                  labelText: '관리자 메모 (선택)',
+                ),
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(false),
+              child: const Text('취소'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.of(dialogContext).pop(true),
+              child: Text(label),
+            ),
+          ],
+        );
+      },
+    );
+    if (confirmed == true && context.mounted) {
+      context.read<AdminSuggestionsBloc>().add(
+            AdminSuggestionReviewed(
+              suggestionId: suggestion.id,
+              status: targetStatus,
+              adminNotes: controller.text.trim().isEmpty
+                  ? null
+                  : controller.text.trim(),
+            ),
+          );
+    }
+  }
+
+  String _statusKor(SuggestionStatus s) {
+    switch (s) {
+      case SuggestionStatus.submitted:
+        return '제출됨';
+      case SuggestionStatus.approved:
+        return '승인';
+      case SuggestionStatus.rejected:
+        return '반려';
+      case SuggestionStatus.underReview:
+        return '검토중';
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '${_statusKor(suggestion.status)} · ${suggestion.submittedAt.toLocal().toString().substring(0, 10)}',
+                  style: theme.textTheme.bodySmall,
+                ),
+                if (suggestion.reason != null && suggestion.reason!.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 2),
+                    child: Text(
+                      '사유: ${suggestion.reason}',
+                      style: theme.textTheme.bodySmall
+                          ?.copyWith(color: Colors.grey[700]),
+                    ),
+                  ),
+                if (suggestion.adminNotes != null &&
+                    suggestion.adminNotes!.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 2),
+                    child: Text(
+                      '관리자 메모: ${suggestion.adminNotes}',
+                      style: theme.textTheme.bodySmall
+                          ?.copyWith(color: Colors.grey[700]),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          if (suggestion.isSubmitted || suggestion.isUnderReview) ...[
+            IconButton(
+              tooltip: '승인',
+              icon: const Icon(Icons.check_circle_outline, color: Colors.green),
+              onPressed: () =>
+                  _openReviewDialog(context, SuggestionStatus.approved),
+            ),
+            IconButton(
+              tooltip: '반려',
+              icon: Icon(Icons.cancel_outlined, color: theme.colorScheme.error),
+              onPressed: () =>
+                  _openReviewDialog(context, SuggestionStatus.rejected),
+            ),
+            if (suggestion.isSubmitted)
+              IconButton(
+                tooltip: '검토중',
+                icon: const Icon(Icons.hourglass_top_outlined,
+                    color: Colors.amber),
+                onPressed: () =>
+                    _openReviewDialog(context, SuggestionStatus.underReview),
+              ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/books/presentation/screens/book_list_screen.dart
+++ b/lib/features/books/presentation/screens/book_list_screen.dart
@@ -57,6 +57,11 @@ class _BookListViewState extends State<_BookListView> {
         centerTitle: true,
         actions: [
           IconButton(
+            icon: const Icon(Icons.lightbulb_outline),
+            tooltip: '내 희망 도서',
+            onPressed: () => context.go('/suggestions/mine'),
+          ),
+          IconButton(
             icon: Icon(_isGridView ? Icons.list : Icons.grid_view),
             onPressed: _toggleView,
             tooltip: _isGridView ? 'List view' : 'Grid view',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lib_42_flutter
 description: 42 Learning Space Library Management System - Flutter App
 publish_to: 'none'
-version: 0.3.1+1
+version: 0.4.0+1
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/specs/001-library-management/tasks.md
+++ b/specs/001-library-management/tasks.md
@@ -392,7 +392,7 @@
 
 ### Tests for User Story 6
 
-- [ ] T181 [P] [US6] Create widget test for suggestions review screen in test/widget_test/screens/web/suggestions/suggestions_screen_test.dart
+- [X] T181 [P] [US6] Create widget test for suggestions review screen in test/widget_test/screens/web/suggestions/suggestions_screen_test.dart (path: test/features/book_suggestions/presentation/screens/suggestions_review_screen_test.dart + admin_suggestions_bloc_test.dart)
 - [X] T182 [P] [US6] Create backend unit test for GET /suggestions endpoint in backend/tests/unit/suggestions.test.ts
 - [X] T183 [P] [US6] Create backend unit test for suggestion grouping in backend/tests/unit/suggestions.test.ts
 
@@ -408,21 +408,21 @@
 
 **UI Components - Web Dashboard**
 
-- [ ] T189 [P] [US6] Create SuggestionCard with requester count in lib/widgets/admin/suggestion_card.dart
-- [ ] T190 [P] [US6] Create CollectionPeriodSelector widget in lib/widgets/admin/collection_period_selector.dart
+- [X] T189 [P] [US6] Create SuggestionCard with requester count (inlined as `_GroupCard` in suggestions_review_screen.dart)
+- [X] T190 [P] [US6] Create CollectionPeriodSelector widget (inlined `_PeriodForm` in collection_periods_screen.dart — feature uses /active period; no list selector needed yet)
 
 **Screens - Web Dashboard**
 
-- [ ] T191 [US6] Create SuggestionsReviewScreen in lib/screens/web/suggestions/suggestions_screen.dart
-- [ ] T192 [US6] Create CollectionPeriodsScreen in lib/screens/web/suggestions/collection_periods_screen.dart
-- [ ] T193 [US6] Add suggestion management routes to admin navigation
+- [X] T191 [US6] Create SuggestionsReviewScreen — path: lib/features/book_suggestions/presentation/screens/suggestions_review_screen.dart (feature-first per ADR 0001)
+- [X] T192 [US6] Create CollectionPeriodsScreen — path: lib/features/book_suggestions/presentation/screens/collection_periods_screen.dart
+- [X] T193 [US6] Add suggestion management routes to admin navigation (/admin/suggestions, /admin/collection-periods + sidebar entries)
 
 **Integration & Polish**
 
-- [ ] T194 [US6] Implement grouped suggestion display with duplicate count
-- [ ] T195 [US6] Add status update (approved/rejected/under review) functionality
-- [ ] T196 [US6] Add option to add approved suggestion directly to catalog
-- [ ] T197 [US6] Display suggestion statistics (most requested categories)
+- [X] T194 [US6] Implement grouped suggestion display with duplicate count (statuses chips + 추천 N명 badge)
+- [X] T195 [US6] Add status update (approved/rejected/under review) functionality (per-item dialog with admin notes)
+- [ ] T196 [US6] Add option to add approved suggestion directly to catalog (deferred — backend endpoint not in scope for v0.4.0)
+- [ ] T197 [US6] Display suggestion statistics (most requested categories) (deferred — analytics out of MVP)
 
 **Checkpoint**: User Story 6 complete - admins can review suggestions, all user stories functional
 

--- a/specs/001-library-management/tasks.md
+++ b/specs/001-library-management/tasks.md
@@ -341,8 +341,8 @@
 
 ### Tests for User Story 3
 
-- [ ] T160 [P] [US3] Create unit test for BookSuggestion model in test/unit_test/models/book_suggestion_test.dart
-- [ ] T161 [P] [US3] Create unit test for CollectionPeriod model in test/unit_test/models/collection_period_test.dart
+- [X] T160 [P] [US3] Create unit test for BookSuggestion model in test/unit_test/models/book_suggestion_test.dart
+- [X] T161 [P] [US3] Create unit test for CollectionPeriod model in test/unit_test/models/collection_period_test.dart
 - [ ] T162 [P] [US3] Create widget test for suggestion form in test/widget_test/screens/mobile/suggestions/suggestion_form_test.dart
 - [X] T163 [P] [US3] Create backend unit test for POST /suggestions in backend/tests/unit/suggestions.test.ts
 - [X] T164 [P] [US3] Create backend unit test for collection period validation in backend/tests/unit/collection_periods.test.ts
@@ -351,9 +351,9 @@
 
 **Models & Data Layer**
 
-- [ ] T165 [P] [US3] Create BookSuggestion model in lib/models/book_suggestion.dart
-- [ ] T166 [P] [US3] Create CollectionPeriod model in lib/models/collection_period.dart
-- [ ] T167 [US3] Create BookSuggestionRepository in lib/repositories/book_suggestion_repository.dart
+- [X] T165 [P] [US3] Create BookSuggestion model in lib/models/book_suggestion.dart
+- [X] T166 [P] [US3] Create CollectionPeriod model in lib/models/collection_period.dart
+- [X] T167 [US3] Create BookSuggestionRepository in lib/repositories/book_suggestion_repository.dart
 
 **Backend API - Suggestions**
 
@@ -364,15 +364,15 @@
 
 **State Management**
 
-- [ ] T172 [P] [US3] Create SuggestionEvent classes in lib/state/suggestion/suggestion_event.dart
-- [ ] T173 [P] [US3] Create SuggestionState classes in lib/state/suggestion/suggestion_state.dart
-- [ ] T174 [US3] Implement SuggestionBloc in lib/state/suggestion/suggestion_bloc.dart
+- [X] T172 [P] [US3] Create SuggestionEvent classes in lib/state/suggestion/suggestion_event.dart
+- [X] T173 [P] [US3] Create SuggestionState classes in lib/state/suggestion/suggestion_state.dart
+- [X] T174 [US3] Implement SuggestionBloc in lib/state/suggestion/suggestion_bloc.dart
 
 **Screens**
 
-- [ ] T175 [US3] Create SuggestionFormScreen in lib/screens/mobile/suggestions/suggestion_form_screen.dart
-- [ ] T176 [US3] Create MySuggestionsScreen in lib/screens/mobile/suggestions/my_suggestions_screen.dart
-- [ ] T177 [US3] Add suggestion routes to navigation
+- [X] T175 [US3] Create SuggestionFormScreen in lib/screens/mobile/suggestions/suggestion_form_screen.dart
+- [X] T176 [US3] Create MySuggestionsScreen in lib/screens/mobile/suggestions/my_suggestions_screen.dart
+- [X] T177 [US3] Add suggestion routes to navigation
 
 **Integration & Polish**
 

--- a/specs/001-library-management/tasks.md
+++ b/specs/001-library-management/tasks.md
@@ -393,18 +393,18 @@
 ### Tests for User Story 6
 
 - [ ] T181 [P] [US6] Create widget test for suggestions review screen in test/widget_test/screens/web/suggestions/suggestions_screen_test.dart
-- [ ] T182 [P] [US6] Create backend unit test for GET /suggestions endpoint in backend/tests/unit/suggestions.test.ts
-- [ ] T183 [P] [US6] Create backend unit test for suggestion grouping in backend/tests/unit/suggestions.test.ts
+- [X] T182 [P] [US6] Create backend unit test for GET /suggestions endpoint in backend/tests/unit/suggestions.test.ts
+- [X] T183 [P] [US6] Create backend unit test for suggestion grouping in backend/tests/unit/suggestions.test.ts
 
 ### Implementation for User Story 6
 
 **Backend API - Admin Suggestions**
 
-- [ ] T184 [P] [US6] Implement GET /suggestions endpoint (admin, grouped) in backend/src/routes/suggestions.ts
-- [ ] T185 [P] [US6] Implement PUT /suggestions/:id/status endpoint in backend/src/routes/suggestions.ts
-- [ ] T186 [P] [US6] Implement POST /collection-periods endpoint in backend/src/routes/collection_periods.ts
-- [ ] T187 [US6] Implement suggestion grouping by title+author in backend/src/services/suggestion_service.ts
-- [ ] T188 [US6] Add collection period archival logic in backend/src/services/collection_period_service.ts
+- [X] T184 [P] [US6] Implement GET /suggestions endpoint (admin, grouped) in backend/src/routes/suggestions.ts
+- [X] T185 [P] [US6] Implement PUT /suggestions/:id/status endpoint in backend/src/routes/suggestions.ts
+- [X] T186 [P] [US6] Implement POST /collection-periods endpoint in backend/src/routes/collection_periods.ts
+- [X] T187 [US6] Implement suggestion grouping by title+author in backend/src/services/suggestion_service.ts
+- [X] T188 [US6] Add collection period archival logic in backend/src/services/collection_period_service.ts
 
 **UI Components - Web Dashboard**
 

--- a/specs/001-library-management/tasks.md
+++ b/specs/001-library-management/tasks.md
@@ -344,8 +344,8 @@
 - [ ] T160 [P] [US3] Create unit test for BookSuggestion model in test/unit_test/models/book_suggestion_test.dart
 - [ ] T161 [P] [US3] Create unit test for CollectionPeriod model in test/unit_test/models/collection_period_test.dart
 - [ ] T162 [P] [US3] Create widget test for suggestion form in test/widget_test/screens/mobile/suggestions/suggestion_form_test.dart
-- [ ] T163 [P] [US3] Create backend unit test for POST /suggestions in backend/tests/unit/suggestions.test.ts
-- [ ] T164 [P] [US3] Create backend unit test for collection period validation in backend/tests/unit/collection_periods.test.ts
+- [X] T163 [P] [US3] Create backend unit test for POST /suggestions in backend/tests/unit/suggestions.test.ts
+- [X] T164 [P] [US3] Create backend unit test for collection period validation in backend/tests/unit/collection_periods.test.ts
 
 ### Implementation for User Story 3
 
@@ -357,10 +357,10 @@
 
 **Backend API - Suggestions**
 
-- [ ] T168 [P] [US3] Implement POST /suggestions endpoint in backend/src/routes/suggestions.ts
-- [ ] T169 [P] [US3] Implement GET /suggestions/my endpoint in backend/src/routes/suggestions.ts
-- [ ] T170 [P] [US3] Implement GET /collection-periods/active endpoint in backend/src/routes/collection_periods.ts
-- [ ] T171 [US3] Add collection period validation to suggestion submission in backend/src/services/suggestion_service.ts
+- [X] T168 [P] [US3] Implement POST /suggestions endpoint in backend/src/routes/suggestions.ts
+- [X] T169 [P] [US3] Implement GET /suggestions/my endpoint in backend/src/routes/suggestions.ts
+- [X] T170 [P] [US3] Implement GET /collection-periods/active endpoint in backend/src/routes/collection_periods.ts
+- [X] T171 [US3] Add collection period validation to suggestion submission in backend/src/services/suggestion_service.ts
 
 **State Management**
 

--- a/test/features/book_suggestions/data/models/book_suggestion_test.dart
+++ b/test/features/book_suggestions/data/models/book_suggestion_test.dart
@@ -1,0 +1,132 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lib_42_flutter/features/book_suggestions/data/models/book_suggestion.dart';
+import 'package:lib_42_flutter/features/book_suggestions/data/models/collection_period.dart';
+
+void main() {
+  group('BookSuggestion model (T160)', () {
+    test('parses submitted suggestion JSON', () {
+      final s = BookSuggestion.fromJson(const {
+        'id': 's1',
+        'studentId': 'stu-1',
+        'suggestedTitle': 'Effective TS',
+        'suggestedAuthor': 'Vanderkam',
+        'reason': '학습용',
+        'collectionPeriodId': 'p1',
+        'status': 'submitted',
+        'submittedAt': '2024-02-01T00:00:00.000Z',
+      });
+      expect(s.id, 's1');
+      expect(s.isSubmitted, isTrue);
+      expect(s.reason, '학습용');
+    });
+
+    test('parses approved/rejected/under_review status', () {
+      final approved = BookSuggestion.fromJson(const {
+        'id': 's2',
+        'studentId': 'stu-1',
+        'suggestedTitle': 'X',
+        'suggestedAuthor': 'Y',
+        'collectionPeriodId': 'p1',
+        'status': 'approved',
+        'submittedAt': '2024-02-01T00:00:00.000Z',
+      });
+      expect(approved.isApproved, isTrue);
+
+      final rejected = BookSuggestion.fromJson(const {
+        'id': 's3',
+        'studentId': 'stu-1',
+        'suggestedTitle': 'X',
+        'suggestedAuthor': 'Y',
+        'collectionPeriodId': 'p1',
+        'status': 'rejected',
+        'submittedAt': '2024-02-01T00:00:00.000Z',
+      });
+      expect(rejected.isRejected, isTrue);
+
+      final review = BookSuggestion.fromJson(const {
+        'id': 's4',
+        'studentId': 'stu-1',
+        'suggestedTitle': 'X',
+        'suggestedAuthor': 'Y',
+        'collectionPeriodId': 'p1',
+        'status': 'under_review',
+        'submittedAt': '2024-02-01T00:00:00.000Z',
+      });
+      expect(review.isUnderReview, isTrue);
+    });
+
+    test('throws on unknown status', () {
+      expect(
+        () => BookSuggestion.fromJson(const {
+          'id': 'x',
+          'studentId': 's',
+          'suggestedTitle': 'T',
+          'suggestedAuthor': 'A',
+          'collectionPeriodId': 'p',
+          'status': 'pirate',
+          'submittedAt': '2024-02-01T00:00:00.000Z',
+        }),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('parses nested collectionPeriod summary', () {
+      final s = BookSuggestion.fromJson(const {
+        'id': 's5',
+        'studentId': 'stu',
+        'suggestedTitle': 'T',
+        'suggestedAuthor': 'A',
+        'collectionPeriodId': 'p1',
+        'status': 'submitted',
+        'submittedAt': '2024-02-01T00:00:00.000Z',
+        'collectionPeriod': {
+          'id': 'p1',
+          'name': '2024 Q1',
+          'status': 'active',
+          'endDate': '2024-03-31T00:00:00.000Z',
+        },
+      });
+      expect(s.collectionPeriod, isNotNull);
+      expect(s.collectionPeriod!.name, '2024 Q1');
+    });
+  });
+
+  group('CollectionPeriod model (T161)', () {
+    test('parses active period and isActive helper', () {
+      final p = CollectionPeriod.fromJson(const {
+        'id': 'p1',
+        'name': '2024 Spring',
+        'startDate': '2024-03-01T00:00:00.000Z',
+        'endDate': '2024-05-31T00:00:00.000Z',
+        'status': 'active',
+      });
+      expect(p.id, 'p1');
+      expect(p.isActive, isTrue);
+    });
+
+    test('throws on unknown status', () {
+      expect(
+        () => CollectionPeriod.fromJson(const {
+          'id': 'p',
+          'name': 'X',
+          'startDate': '2024-01-01T00:00:00.000Z',
+          'endDate': '2024-01-02T00:00:00.000Z',
+          'status': 'eternal',
+        }),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('daysRemaining is positive before end, 0 after', () {
+      final p = CollectionPeriod.fromJson(const {
+        'id': 'p',
+        'name': 'X',
+        'startDate': '2024-01-01T00:00:00.000Z',
+        'endDate': '2024-01-15T00:00:00.000Z',
+        'status': 'active',
+      });
+      expect(p.daysRemaining(DateTime(2024, 1, 10)), 5);
+      expect(p.daysRemaining(DateTime(2024, 1, 20)), 0);
+    });
+  });
+}

--- a/test/features/book_suggestions/presentation/bloc/admin_suggestions_bloc_test.dart
+++ b/test/features/book_suggestions/presentation/bloc/admin_suggestions_bloc_test.dart
@@ -1,0 +1,145 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lib_42_flutter/features/book_suggestions/data/models/book_suggestion.dart';
+import 'package:lib_42_flutter/features/book_suggestions/data/models/collection_period.dart';
+import 'package:lib_42_flutter/features/book_suggestions/domain/repositories/admin_suggestion_repository.dart';
+import 'package:lib_42_flutter/features/book_suggestions/presentation/bloc/admin_suggestions_bloc.dart';
+import 'package:lib_42_flutter/features/book_suggestions/presentation/bloc/admin_suggestions_event.dart';
+import 'package:lib_42_flutter/features/book_suggestions/presentation/bloc/admin_suggestions_state.dart';
+
+import '../../../../support/fake_admin_suggestion_repository.dart';
+
+void main() {
+  group('AdminSuggestionsBloc', () {
+    blocTest<AdminSuggestionsBloc, AdminSuggestionsState>(
+      'load: emits [Loading, Loaded] with grouped suggestions',
+      build: () {
+        final repo = FakeAdminSuggestionRepository()
+          ..grouped = [makeGroup(title: 'A'), makeGroup(title: 'B')];
+        return AdminSuggestionsBloc(repository: repo);
+      },
+      act: (bloc) => bloc.add(const AdminSuggestionsRequested()),
+      expect: () => [
+        isA<AdminSuggestionsLoading>(),
+        isA<AdminSuggestionsLoaded>().having(
+          (s) => s.groups.map((g) => g.suggestedTitle).toList(),
+          'titles',
+          ['A', 'B'],
+        ),
+      ],
+    );
+
+    blocTest<AdminSuggestionsBloc, AdminSuggestionsState>(
+      'load: emits Error when repo throws',
+      build: () {
+        final repo = FakeAdminSuggestionRepository()
+          ..error = const AdminSuggestionException('x', '에러');
+        return AdminSuggestionsBloc(repository: repo);
+      },
+      act: (bloc) => bloc.add(const AdminSuggestionsRequested()),
+      expect: () => [
+        isA<AdminSuggestionsLoading>(),
+        isA<AdminSuggestionsError>(),
+      ],
+    );
+
+    blocTest<AdminSuggestionsBloc, AdminSuggestionsState>(
+      'review: replaces matching item and recomputes statuses',
+      build: () {
+        final group = makeGroup(
+          title: 'Book',
+          requesterCount: 2,
+          statuses: {SuggestionStatus.submitted: 2},
+          items: [
+            makeSuggestion(id: 'a', status: SuggestionStatus.submitted),
+            makeSuggestion(id: 'b', status: SuggestionStatus.submitted),
+          ],
+        );
+        final repo = FakeAdminSuggestionRepository()
+          ..reviewResult = makeSuggestion(
+            id: 'a',
+            status: SuggestionStatus.approved,
+            adminNotes: '구매 예정',
+          );
+        return AdminSuggestionsBloc(repository: repo)
+          ..emit(AdminSuggestionsLoaded(groups: [group]));
+      },
+      act: (bloc) => bloc.add(const AdminSuggestionReviewed(
+        suggestionId: 'a',
+        status: SuggestionStatus.approved,
+        adminNotes: '구매 예정',
+      )),
+      expect: () => [
+        isA<AdminSuggestionsLoaded>().having(
+          (s) => s.actionStatus,
+          'inProgress',
+          AdminSuggestionsActionStatus.inProgress,
+        ),
+        isA<AdminSuggestionsLoaded>()
+            .having((s) => s.actionStatus, 'success',
+                AdminSuggestionsActionStatus.success)
+            .having(
+              (s) => s.groups.first.statuses,
+              'recomputed',
+              {
+                SuggestionStatus.submitted: 1,
+                SuggestionStatus.approved: 1,
+              },
+            )
+            .having(
+              (s) => s.groups.first.items
+                  .firstWhere((i) => i.id == 'a')
+                  .status,
+              'updated.status',
+              SuggestionStatus.approved,
+            ),
+      ],
+    );
+
+    blocTest<AdminSuggestionsBloc, AdminSuggestionsState>(
+      'review: surfaces failure with action message',
+      build: () {
+        final repo = FakeAdminSuggestionRepository()
+          ..error = const AdminSuggestionException('x', '실패함');
+        return AdminSuggestionsBloc(repository: repo)
+          ..emit(AdminSuggestionsLoaded(groups: [makeGroup()]));
+      },
+      act: (bloc) => bloc.add(const AdminSuggestionReviewed(
+        suggestionId: 'sg-0',
+        status: SuggestionStatus.rejected,
+      )),
+      expect: () => [
+        isA<AdminSuggestionsLoaded>().having((s) => s.actionStatus, 'inProgress',
+            AdminSuggestionsActionStatus.inProgress),
+        isA<AdminSuggestionsLoaded>()
+            .having((s) => s.actionStatus, 'failure',
+                AdminSuggestionsActionStatus.failure)
+            .having((s) => s.actionMessage, 'message', contains('실패함')),
+      ],
+    );
+
+    blocTest<AdminSuggestionsBloc, AdminSuggestionsState>(
+      'createPeriod: triggers reload after success',
+      build: () {
+        final repo = FakeAdminSuggestionRepository()
+          ..grouped = [makeGroup(title: 'After Reload')];
+        return AdminSuggestionsBloc(repository: repo);
+      },
+      act: (bloc) => bloc.add(AdminPeriodCreated(
+        name: 'Q3',
+        startDate: DateTime(2024, 7, 1),
+        endDate: DateTime(2024, 9, 30),
+        status: PeriodStatus.active,
+      )),
+      expect: () => [
+        isA<AdminSuggestionsLoading>(),
+        isA<AdminSuggestionsLoaded>().having(
+          (s) => s.groups.first.suggestedTitle,
+          'reloaded title',
+          'After Reload',
+        ),
+      ],
+      verify: (_) {},
+    );
+  });
+}

--- a/test/features/book_suggestions/presentation/bloc/suggestion_bloc_test.dart
+++ b/test/features/book_suggestions/presentation/bloc/suggestion_bloc_test.dart
@@ -1,0 +1,96 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lib_42_flutter/features/book_suggestions/domain/repositories/suggestion_repository.dart';
+import 'package:lib_42_flutter/features/book_suggestions/presentation/bloc/suggestion_bloc.dart';
+import 'package:lib_42_flutter/features/book_suggestions/presentation/bloc/suggestion_event.dart';
+import 'package:lib_42_flutter/features/book_suggestions/presentation/bloc/suggestion_state.dart';
+
+import '../../../../support/fake_suggestion_repository.dart';
+
+void main() {
+  group('SuggestionBloc', () {
+    blocTest<SuggestionBloc, SuggestionState>(
+      'load: emits [Loading, Loaded] with active period and mine',
+      build: () {
+        final repo = FakeSuggestionRepository()
+          ..activePeriod = makePeriod()
+          ..mine = [makeSuggestion(id: 'a'), makeSuggestion(id: 'b')];
+        return SuggestionBloc(repository: repo);
+      },
+      act: (bloc) => bloc.add(const SuggestionsRequested()),
+      expect: () => [
+        isA<SuggestionLoading>(),
+        isA<SuggestionLoaded>()
+            .having((s) => s.activePeriod?.name, 'period.name', '2024 Q1')
+            .having((s) => s.mySuggestions.length, 'mine count', 2),
+      ],
+    );
+
+    blocTest<SuggestionBloc, SuggestionState>(
+      'load: emits [Loading, Error] when repository throws',
+      build: () {
+        final repo = FakeSuggestionRepository()..error = Exception('boom');
+        return SuggestionBloc(repository: repo);
+      },
+      act: (bloc) => bloc.add(const SuggestionsRequested()),
+      expect: () => [isA<SuggestionLoading>(), isA<SuggestionError>()],
+    );
+
+    blocTest<SuggestionBloc, SuggestionState>(
+      'submit: prepends new suggestion and reports success',
+      build: () {
+        final repo = FakeSuggestionRepository()
+          ..submitResult = makeSuggestion(id: 'new', suggestedTitle: 'N');
+        return SuggestionBloc(repository: repo);
+      },
+      seed: () => SuggestionLoaded(
+        activePeriod: makePeriod(),
+        mySuggestions: [makeSuggestion(id: 'old')],
+      ),
+      act: (bloc) => bloc.add(const SuggestionSubmitted(
+        suggestedTitle: 'N',
+        suggestedAuthor: 'A',
+      )),
+      expect: () => [
+        isA<SuggestionLoaded>().having(
+          (s) => s.actionStatus,
+          'inProgress',
+          SuggestionActionStatus.inProgress,
+        ),
+        isA<SuggestionLoaded>()
+            .having((s) => s.mySuggestions.first.id, 'first.id', 'new')
+            .having((s) => s.mySuggestions.length, 'count', 2)
+            .having((s) => s.actionStatus, 'success',
+                SuggestionActionStatus.success),
+      ],
+    );
+
+    blocTest<SuggestionBloc, SuggestionState>(
+      'submit: surfaces SuggestionException message',
+      build: () {
+        final repo = FakeSuggestionRepository()
+          ..error = const SuggestionException(
+            'duplicate_suggestion',
+            '동일한 도서를 이미 추천했습니다.',
+          );
+        return SuggestionBloc(repository: repo);
+      },
+      seed: () => SuggestionLoaded(
+        activePeriod: makePeriod(),
+        mySuggestions: const [],
+      ),
+      act: (bloc) => bloc.add(const SuggestionSubmitted(
+        suggestedTitle: 'X',
+        suggestedAuthor: 'Y',
+      )),
+      expect: () => [
+        isA<SuggestionLoaded>().having((s) => s.actionStatus, 'inProgress',
+            SuggestionActionStatus.inProgress),
+        isA<SuggestionLoaded>()
+            .having((s) => s.actionStatus, 'failure',
+                SuggestionActionStatus.failure)
+            .having((s) => s.actionMessage, 'message', '동일한 도서를 이미 추천했습니다.'),
+      ],
+    );
+  });
+}

--- a/test/features/book_suggestions/presentation/screens/suggestions_review_screen_test.dart
+++ b/test/features/book_suggestions/presentation/screens/suggestions_review_screen_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lib_42_flutter/features/book_suggestions/data/models/book_suggestion.dart';
+import 'package:lib_42_flutter/features/book_suggestions/presentation/screens/suggestions_review_screen.dart';
+
+import '../../../../support/fake_admin_suggestion_repository.dart';
+
+Future<void> _pump(
+  WidgetTester tester,
+  FakeAdminSuggestionRepository repo,
+) async {
+  await tester.pumpWidget(MaterialApp(
+    home: SuggestionsReviewScreen(repository: repo),
+  ));
+  // Initial AdminSuggestionsRequested → AdminSuggestionsLoading → Loaded.
+  await tester.pump();
+  await tester.pump();
+}
+
+void main() {
+  group('SuggestionsReviewScreen', () {
+    testWidgets('renders empty state when no groups', (tester) async {
+      final repo = FakeAdminSuggestionRepository()..grouped = [];
+      await _pump(tester, repo);
+      expect(find.text('활성 수집 기간에 제출된 추천이 없습니다.'), findsOneWidget);
+    });
+
+    testWidgets('renders group card with title, author, and counts',
+        (tester) async {
+      final repo = FakeAdminSuggestionRepository()
+        ..grouped = [
+          makeGroup(
+            title: 'Effective Dart',
+            author: 'Google',
+            requesterCount: 3,
+            statuses: const {
+              SuggestionStatus.submitted: 2,
+              SuggestionStatus.approved: 1,
+            },
+            items: [
+              makeSuggestion(id: 'a', status: SuggestionStatus.submitted),
+              makeSuggestion(id: 'b', status: SuggestionStatus.submitted),
+              makeSuggestion(id: 'c', status: SuggestionStatus.approved),
+            ],
+          ),
+        ];
+      await _pump(tester, repo);
+
+      expect(find.text('Effective Dart'), findsOneWidget);
+      expect(find.text('Google'), findsOneWidget);
+      expect(find.text('추천 3명'), findsOneWidget);
+      expect(find.textContaining('제출됨'), findsAtLeastNWidgets(1));
+      expect(find.textContaining('승인'), findsAtLeastNWidgets(1));
+    });
+
+    testWidgets('shows error state and retry button when load fails',
+        (tester) async {
+      final repo = FakeAdminSuggestionRepository()..error = Exception('네트워크 오류');
+      await _pump(tester, repo);
+
+      expect(find.textContaining('네트워크 오류'), findsOneWidget);
+      expect(find.widgetWithText(FilledButton, '다시 시도'), findsOneWidget);
+    });
+
+    testWidgets('approve action shows dialog with notes field', (tester) async {
+      final repo = FakeAdminSuggestionRepository()
+        ..grouped = [
+          makeGroup(items: [
+            makeSuggestion(id: 'a', status: SuggestionStatus.submitted),
+            makeSuggestion(id: 'b', status: SuggestionStatus.submitted),
+          ]),
+        ];
+      await _pump(tester, repo);
+
+      // Tap the first approve icon button.
+      final approveButtons = find.byTooltip('승인');
+      expect(approveButtons, findsAtLeastNWidgets(1));
+      await tester.tap(approveButtons.first);
+      await tester.pumpAndSettle();
+
+      expect(find.text('추천 승인'), findsOneWidget);
+      expect(find.text('관리자 메모 (선택)'), findsOneWidget);
+      // Cancel to clean up.
+      await tester.tap(find.widgetWithText(TextButton, '취소'));
+      await tester.pumpAndSettle();
+    });
+  });
+}

--- a/test/support/fake_admin_suggestion_repository.dart
+++ b/test/support/fake_admin_suggestion_repository.dart
@@ -1,0 +1,86 @@
+import 'package:lib_42_flutter/features/book_suggestions/data/models/book_suggestion.dart';
+import 'package:lib_42_flutter/features/book_suggestions/data/models/collection_period.dart';
+import 'package:lib_42_flutter/features/book_suggestions/data/models/grouped_suggestion.dart';
+import 'package:lib_42_flutter/features/book_suggestions/domain/repositories/admin_suggestion_repository.dart';
+
+import 'fake_suggestion_repository.dart' show makePeriod, makeSuggestion;
+
+export 'fake_suggestion_repository.dart' show makePeriod, makeSuggestion;
+
+class FakeAdminSuggestionRepository implements AdminSuggestionRepository {
+  List<GroupedSuggestion> grouped = [];
+  BookSuggestion? reviewResult;
+  CollectionPeriod? createPeriodResult;
+  Exception? error;
+
+  int fetchCalls = 0;
+  int reviewCalls = 0;
+  int createPeriodCalls = 0;
+
+  @override
+  Future<List<GroupedSuggestion>> fetchGrouped({String? periodId}) async {
+    fetchCalls++;
+    if (error != null) throw error!;
+    return grouped;
+  }
+
+  @override
+  Future<BookSuggestion> review(
+    String suggestionId, {
+    required SuggestionStatus status,
+    String? adminNotes,
+  }) async {
+    reviewCalls++;
+    if (error != null) throw error!;
+    return reviewResult ??
+        makeSuggestion(id: suggestionId, status: status, adminNotes: adminNotes);
+  }
+
+  @override
+  Future<CollectionPeriod> createPeriod({
+    required String name,
+    required DateTime startDate,
+    required DateTime endDate,
+    PeriodStatus status = PeriodStatus.upcoming,
+  }) async {
+    createPeriodCalls++;
+    if (error != null) throw error!;
+    return createPeriodResult ??
+        CollectionPeriod(
+          id: 'np-${createPeriodCalls}',
+          name: name,
+          startDate: startDate,
+          endDate: endDate,
+          status: status,
+        );
+  }
+}
+
+GroupedSuggestion makeGroup({
+  String title = '책1',
+  String author = '저자1',
+  String periodId = 'p1',
+  int requesterCount = 2,
+  Map<SuggestionStatus, int>? statuses,
+  List<BookSuggestion>? items,
+}) {
+  return GroupedSuggestion(
+    suggestedTitle: title,
+    suggestedAuthor: author,
+    collectionPeriodId: periodId,
+    requesterCount: requesterCount,
+    statuses: statuses ?? {SuggestionStatus.submitted: requesterCount},
+    latestSubmittedAt: DateTime(2024, 2, 1),
+    items: items ??
+        List.generate(
+          requesterCount,
+          (i) => makeSuggestion(
+            id: 'sg-$i',
+            studentId: 'stu-$i',
+            suggestedTitle: title,
+            suggestedAuthor: author,
+            collectionPeriodId: periodId,
+          ),
+        ),
+  );
+}

--- a/test/support/fake_suggestion_repository.dart
+++ b/test/support/fake_suggestion_repository.dart
@@ -1,0 +1,75 @@
+import 'package:lib_42_flutter/features/book_suggestions/data/models/book_suggestion.dart';
+import 'package:lib_42_flutter/features/book_suggestions/data/models/collection_period.dart';
+import 'package:lib_42_flutter/features/book_suggestions/domain/repositories/suggestion_repository.dart';
+
+class FakeSuggestionRepository implements SuggestionRepository {
+  CollectionPeriod? activePeriod;
+  List<BookSuggestion> mine = [];
+  BookSuggestion? submitResult;
+  Exception? error;
+
+  int submitCalls = 0;
+  int fetchMineCalls = 0;
+
+  @override
+  Future<CollectionPeriod?> fetchActivePeriod() async {
+    if (error != null) throw error!;
+    return activePeriod;
+  }
+
+  @override
+  Future<List<BookSuggestion>> fetchMine() async {
+    fetchMineCalls++;
+    if (error != null) throw error!;
+    return mine;
+  }
+
+  @override
+  Future<BookSuggestion> submit({
+    required String suggestedTitle,
+    required String suggestedAuthor,
+    String? reason,
+  }) async {
+    submitCalls++;
+    if (error != null) throw error!;
+    return submitResult ??
+        makeSuggestion(suggestedTitle: suggestedTitle, suggestedAuthor: suggestedAuthor);
+  }
+}
+
+CollectionPeriod makePeriod({
+  String id = 'p1',
+  String name = '2024 Q1',
+  PeriodStatus status = PeriodStatus.active,
+}) {
+  return CollectionPeriod(
+    id: id,
+    name: name,
+    startDate: DateTime(2024, 1, 1),
+    endDate: DateTime(2024, 3, 31),
+    status: status,
+  );
+}
+
+BookSuggestion makeSuggestion({
+  String id = 'sg-1',
+  String studentId = 'stu-1',
+  String suggestedTitle = '추천 도서',
+  String suggestedAuthor = '저자',
+  String? reason,
+  SuggestionStatus status = SuggestionStatus.submitted,
+  String collectionPeriodId = 'p1',
+  String? adminNotes,
+}) {
+  return BookSuggestion(
+    id: id,
+    studentId: studentId,
+    suggestedTitle: suggestedTitle,
+    suggestedAuthor: suggestedAuthor,
+    reason: reason,
+    collectionPeriodId: collectionPeriodId,
+    status: status,
+    submittedAt: DateTime(2024, 2, 1),
+    adminNotes: adminNotes,
+  );
+}


### PR DESCRIPTION
Closes #107

## 범위

**P3 — v0.4.0**

### US3 학생 도서 추천
- #100 백엔드 (POST /suggestions, GET /my, /active period 등 / T161-T169)
- #102 프론트 (SuggestionFormScreen, MySuggestionsScreen, SuggestionBloc / T160, T170-T180)

### US6 관리자 추천 검토 + 수집 기간 관리
- #104 백엔드 (GET /suggestions 그룹화, PUT /:id/status, POST /collection-periods / T182-T188)
- #106 프론트 (SuggestionsReviewScreen, CollectionPeriodsScreen, AdminSuggestionsBloc / T181, T189-T195)

## Deferred (v0.4.0 범위 밖)
- T196 승인 → 카탈로그 직행
- T197 추천 통계 (most requested categories)

## Test plan
- [x] 누적 Flutter 테스트 135건 통과
- [x] 백엔드 테스트 통과 (Jest)
- [x] CI green (analyze + test + web build + codecov patch/project)

🤖 Generated with [Claude Code](https://claude.com/claude-code)