### PR TITLE
[Release #111] v0.4.1 패치 — T196 추천 → 카탈로그 직행

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "42lib-backend",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "42 Learning Space Library Management System - Backend API",
   "main": "src/server.ts",
   "scripts": {

--- a/lib/features/admin_catalog/presentation/widgets/book_form_widget.dart
+++ b/lib/features/admin_catalog/presentation/widgets/book_form_widget.dart
@@ -5,16 +5,21 @@ import '../../../books/data/models/book.dart';
 import '../../domain/repositories/admin_book_repository.dart';
 
 /// Reusable form for creating or editing a book. When [initial] is provided,
-/// the form is in edit mode and pre-populated.
+/// the form is in edit mode and pre-populated. [prefillTitle]/[prefillAuthor]
+/// seed only those two fields (used when promoting a suggestion to catalog).
 class BookFormWidget extends StatefulWidget {
   const BookFormWidget({
     super.key,
     this.initial,
+    this.prefillTitle,
+    this.prefillAuthor,
     required this.onSubmit,
     this.submitLabel = '저장',
   });
 
   final Book? initial;
+  final String? prefillTitle;
+  final String? prefillAuthor;
   final void Function(AdminBookPayload payload) onSubmit;
   final String submitLabel;
 
@@ -38,8 +43,9 @@ class _BookFormWidgetState extends State<BookFormWidget> {
   void initState() {
     super.initState();
     final b = widget.initial;
-    _title = TextEditingController(text: b?.title ?? '');
-    _author = TextEditingController(text: b?.author ?? '');
+    _title = TextEditingController(text: b?.title ?? widget.prefillTitle ?? '');
+    _author =
+        TextEditingController(text: b?.author ?? widget.prefillAuthor ?? '');
     _category = TextEditingController(text: b?.category ?? '');
     _isbn = TextEditingController(text: b?.isbn ?? '');
     _description = TextEditingController(text: b?.description ?? '');
@@ -175,8 +181,7 @@ class _BookFormWidgetState extends State<BookFormWidget> {
                     controller: _availableQuantity,
                     keyboardType: TextInputType.number,
                     inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-                    decoration:
-                        const InputDecoration(labelText: '대출 가능 수량 *'),
+                    decoration: const InputDecoration(labelText: '대출 가능 수량 *'),
                     validator: _validateAvailability,
                   ),
                 ),

--- a/lib/features/book_suggestions/presentation/screens/suggestions_review_screen.dart
+++ b/lib/features/book_suggestions/presentation/screens/suggestions_review_screen.dart
@@ -9,23 +9,50 @@ import '../../domain/repositories/admin_suggestion_repository.dart';
 import '../bloc/admin_suggestions_bloc.dart';
 import '../bloc/admin_suggestions_event.dart';
 import '../bloc/admin_suggestions_state.dart';
+import '../../../admin_catalog/data/repositories/admin_book_repository_impl.dart';
+import '../../../admin_catalog/domain/repositories/admin_book_repository.dart';
 import '../../../admin_catalog/presentation/widgets/admin_sidebar.dart';
+import '../../../admin_catalog/presentation/widgets/book_form_widget.dart';
 
 class SuggestionsReviewScreen extends StatelessWidget {
-  const SuggestionsReviewScreen({super.key, this.repository});
+  const SuggestionsReviewScreen({
+    super.key,
+    this.repository,
+    this.bookRepository,
+  });
 
   final AdminSuggestionRepository? repository;
+  final AdminBookRepository? bookRepository;
 
   @override
   Widget build(BuildContext context) {
-    return BlocProvider<AdminSuggestionsBloc>(
-      create: (_) => AdminSuggestionsBloc(
-        repository: repository ??
-            AdminSuggestionRepositoryImpl(baseUrl: AppConfig.apiBaseUrl),
-      )..add(const AdminSuggestionsRequested()),
-      child: const _Body(),
+    return _BookRepoScope(
+      repository: bookRepository ??
+          AdminBookRepositoryImpl(baseUrl: AppConfig.apiBaseUrl),
+      child: BlocProvider<AdminSuggestionsBloc>(
+        create: (_) => AdminSuggestionsBloc(
+          repository: repository ??
+              AdminSuggestionRepositoryImpl(baseUrl: AppConfig.apiBaseUrl),
+        )..add(const AdminSuggestionsRequested()),
+        child: const _Body(),
+      ),
     );
   }
+}
+
+class _BookRepoScope extends InheritedWidget {
+  const _BookRepoScope({required this.repository, required super.child});
+  final AdminBookRepository repository;
+
+  static AdminBookRepository of(BuildContext context) {
+    final scope = context.dependOnInheritedWidgetOfExactType<_BookRepoScope>();
+    assert(scope != null, '_BookRepoScope missing in tree');
+    return scope!.repository;
+  }
+
+  @override
+  bool updateShouldNotify(_BookRepoScope oldWidget) =>
+      repository != oldWidget.repository;
 }
 
 class _Body extends StatelessWidget {
@@ -328,7 +355,80 @@ class _ItemRow extends StatelessWidget {
                     _openReviewDialog(context, SuggestionStatus.underReview),
               ),
           ],
+          if (suggestion.isApproved)
+            IconButton(
+              tooltip: '카탈로그에 등록',
+              icon: const Icon(Icons.library_add_outlined,
+                  color: Colors.blueAccent),
+              onPressed: () => _openPromoteDialog(context),
+            ),
         ],
+      ),
+    );
+  }
+
+  Future<void> _openPromoteDialog(BuildContext context) async {
+    final repo = _BookRepoScope.of(context);
+    final messenger = ScaffoldMessenger.of(context);
+    await showDialog<void>(
+      context: context,
+      builder: (dialogContext) => Dialog(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 560),
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '추천 도서를 카탈로그에 등록',
+                    style: Theme.of(dialogContext).textTheme.titleLarge,
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    '제목과 저자는 추천 정보로 미리 채워졌습니다. 카테고리와 수량을 입력하세요.',
+                    style: Theme.of(dialogContext).textTheme.bodySmall,
+                  ),
+                  const SizedBox(height: 16),
+                  BookFormWidget(
+                    prefillTitle: suggestion.suggestedTitle,
+                    prefillAuthor: suggestion.suggestedAuthor,
+                    submitLabel: '카탈로그에 등록',
+                    onSubmit: (payload) async {
+                      try {
+                        await repo.createBook(payload);
+                        if (dialogContext.mounted) {
+                          Navigator.of(dialogContext).pop();
+                        }
+                        messenger
+                          ..hideCurrentSnackBar()
+                          ..showSnackBar(const SnackBar(
+                            content: Text('카탈로그에 등록되었습니다.'),
+                          ));
+                      } catch (e) {
+                        messenger
+                          ..hideCurrentSnackBar()
+                          ..showSnackBar(SnackBar(
+                            content: Text('등록 실패: $e'),
+                          ));
+                      }
+                    },
+                  ),
+                  const SizedBox(height: 8),
+                  Align(
+                    alignment: Alignment.centerRight,
+                    child: TextButton(
+                      onPressed: () => Navigator.of(dialogContext).pop(),
+                      child: const Text('닫기'),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
       ),
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lib_42_flutter
 description: 42 Learning Space Library Management System - Flutter App
 publish_to: 'none'
-version: 0.4.0+1
+version: 0.4.1+1
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/specs/001-library-management/tasks.md
+++ b/specs/001-library-management/tasks.md
@@ -421,7 +421,7 @@
 
 - [X] T194 [US6] Implement grouped suggestion display with duplicate count (statuses chips + 추천 N명 badge)
 - [X] T195 [US6] Add status update (approved/rejected/under review) functionality (per-item dialog with admin notes)
-- [ ] T196 [US6] Add option to add approved suggestion directly to catalog (deferred — backend endpoint not in scope for v0.4.0)
+- [X] T196 [US6] Add option to add approved suggestion directly to catalog — 승인된 추천 행에 "카탈로그에 등록" 액션 추가 (BookFormWidget prefill로 기존 POST /api/v1/books 재사용)
 - [ ] T197 [US6] Display suggestion statistics (most requested categories) (deferred — analytics out of MVP)
 
 **Checkpoint**: User Story 6 complete - admins can review suggestions, all user stories functional

--- a/test/features/book_suggestions/presentation/screens/suggestions_review_screen_test.dart
+++ b/test/features/book_suggestions/presentation/screens/suggestions_review_screen_test.dart
@@ -3,14 +3,19 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:lib_42_flutter/features/book_suggestions/data/models/book_suggestion.dart';
 import 'package:lib_42_flutter/features/book_suggestions/presentation/screens/suggestions_review_screen.dart';
 
+import '../../../../support/fake_admin_book_repository.dart';
 import '../../../../support/fake_admin_suggestion_repository.dart';
 
 Future<void> _pump(
   WidgetTester tester,
-  FakeAdminSuggestionRepository repo,
-) async {
+  FakeAdminSuggestionRepository repo, {
+  FakeAdminBookRepository? bookRepo,
+}) async {
   await tester.pumpWidget(MaterialApp(
-    home: SuggestionsReviewScreen(repository: repo),
+    home: SuggestionsReviewScreen(
+      repository: repo,
+      bookRepository: bookRepo ?? FakeAdminBookRepository(),
+    ),
   ));
   // Initial AdminSuggestionsRequested → AdminSuggestionsLoading → Loaded.
   await tester.pump();
@@ -60,6 +65,45 @@ void main() {
 
       expect(find.textContaining('네트워크 오류'), findsOneWidget);
       expect(find.widgetWithText(FilledButton, '다시 시도'), findsOneWidget);
+    });
+
+    testWidgets('promote action calls AdminBookRepository.createBook (T196)',
+        (tester) async {
+      final repo = FakeAdminSuggestionRepository()
+        ..grouped = [
+          makeGroup(items: [
+            makeSuggestion(
+              id: 'a',
+              suggestedTitle: '클린 아키텍처',
+              suggestedAuthor: 'R. Martin',
+              status: SuggestionStatus.approved,
+            ),
+          ]),
+        ];
+      final bookRepo = FakeAdminBookRepository();
+      await _pump(tester, repo, bookRepo: bookRepo);
+
+      await tester.tap(find.byTooltip('카탈로그에 등록'));
+      await tester.pumpAndSettle();
+
+      // Title and author should be prefilled.
+      expect(find.widgetWithText(TextFormField, '클린 아키텍처'), findsOneWidget);
+      expect(find.widgetWithText(TextFormField, 'R. Martin'), findsOneWidget);
+
+      // Fill required category (3rd TextFormField: title/author/category),
+      // then submit. The submit button sits below the viewport in the
+      // 800×600 test surface, so scroll it into view first.
+      await tester.enterText(find.byType(TextFormField).at(2), 'Programming');
+      await tester.pump();
+      final submit = find.widgetWithText(FilledButton, '카탈로그에 등록');
+      await tester.ensureVisible(submit);
+      await tester.pumpAndSettle();
+      await tester.tap(submit, warnIfMissed: false);
+      await tester.pumpAndSettle();
+      // Allow async createBook + dialog dismiss + snackbar.
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(bookRepo.createCalls, 1);
     });
 
     testWidgets('approve action shows dialog with notes field', (tester) async {


### PR DESCRIPTION
Closes #111

## 범위

**v0.4.1 패치**

#110 머지: T196 — 승인된 추천을 한 화면 안에서 카탈로그에 등록.

- `SuggestionsReviewScreen`의 승인 행에 "카탈로그에 등록" 액션
- `BookFormWidget`에 `prefillTitle`/`prefillAuthor` 옵션 추가 (재사용)
- 백엔드 변경 없음 (기존 `POST /api/v1/books` 재사용)
- 위젯 테스트 1건 추가 (전체 136건 통과)

## Test plan

- [x] 누적 Flutter 테스트 136건 통과
- [x] CI green (analyze + test + web build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)