### PR TITLE
[#115] ✅ test(flutter): Phase 11 — admin HTTP repository impls 단위 테스트

### DIFF
--- a/test/features/admin_catalog/data/repositories/admin_book_repository_impl_test.dart
+++ b/test/features/admin_catalog/data/repositories/admin_book_repository_impl_test.dart
@@ -1,0 +1,154 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lib_42_flutter/features/admin_catalog/data/repositories/admin_book_repository_impl.dart';
+import 'package:lib_42_flutter/features/admin_catalog/domain/repositories/admin_book_repository.dart';
+
+import '../../../../support/fake_dio_adapter.dart';
+import '../../../../support/fake_secure_storage_service.dart';
+
+AdminBookRepositoryImpl _build(FakeDioAdapter adapter, {String? adminToken}) {
+  final dio = Dio(BaseOptions(
+    baseUrl: 'https://api.test',
+    validateStatus: (s) => s != null && s < 500,
+  ));
+  dio.httpClientAdapter = adapter;
+  return AdminBookRepositoryImpl(
+    baseUrl: 'https://api.test',
+    httpClient: dio,
+    storage: FakeSecureStorageService(adminToken: adminToken),
+  );
+}
+
+const _bookJson = {
+  'id': 'b1',
+  'title': '클린 아키텍처',
+  'author': 'R. Martin',
+  'category': 'Programming',
+  'isbn': '9780134494166',
+  'description': null,
+  'publicationYear': 2017,
+  'quantity': 3,
+  'availableQuantity': 2,
+  'coverImageUrl': null,
+  'createdAt': '2024-01-01T00:00:00.000Z',
+  'updatedAt': '2024-01-01T00:00:00.000Z',
+};
+
+const _validPayload = AdminBookPayload(
+  title: '클린 아키텍처',
+  author: 'R. Martin',
+  category: 'Programming',
+  quantity: 3,
+  availableQuantity: 2,
+);
+
+void main() {
+  group('AdminBookRepositoryImpl', () {
+    test('fetchBooks parses 200 response into Book list', () async {
+      final adapter = FakeDioAdapter()..enqueue(bodyList: [_bookJson]);
+      final repo = _build(adapter);
+
+      final books = await repo.fetchBooks();
+
+      expect(books, hasLength(1));
+      expect(books.first.title, '클린 아키텍처');
+      expect(books.first.quantity, 3);
+      expect(adapter.requests.single.path, '/v1/books');
+      expect(adapter.requests.single.queryParameters,
+          {'page': 1, 'limit': 200});
+    });
+
+    test('fetchBooks throws on non-200', () async {
+      // 4xx stays under the 500 threshold so the repo path (not Dio) rejects.
+      final adapter = FakeDioAdapter()
+        ..enqueue(statusCode: 401, body: {'error': 'unauthorized'});
+      final repo = _build(adapter);
+
+      await expectLater(repo.fetchBooks(), throwsA(isA<BookConflictException>()));
+    });
+
+    test('createBook posts payload and returns Book on 201', () async {
+      final adapter = FakeDioAdapter()
+        ..enqueue(statusCode: 201, body: _bookJson);
+      final repo = _build(adapter);
+
+      final book = await repo.createBook(_validPayload);
+
+      expect(book.id, 'b1');
+      expect(adapter.requests.single.method, 'POST');
+      expect(adapter.requests.single.path, '/v1/books');
+      expect(adapter.lastRequestBody['title'], '클린 아키텍처');
+    });
+
+    test('createBook surfaces 400 validation error message', () async {
+      final adapter = FakeDioAdapter()
+        ..enqueue(statusCode: 400, body: {'error': 'ISBN already exists'});
+      final repo = _build(adapter);
+
+      await expectLater(
+        repo.createBook(_validPayload),
+        throwsA(isA<BookConflictException>().having(
+            (e) => e.message, 'message', contains('ISBN'))),
+      );
+    });
+
+    test('updateBook puts to /v1/books/:id and returns Book on 200', () async {
+      final adapter = FakeDioAdapter()
+        ..enqueue(statusCode: 200, body: _bookJson);
+      final repo = _build(adapter);
+
+      final book = await repo.updateBook('b1', _validPayload);
+
+      expect(book.id, 'b1');
+      expect(adapter.requests.single.method, 'PUT');
+      expect(adapter.requests.single.path, '/v1/books/b1');
+    });
+
+    test('deleteBook returns normally on 204', () async {
+      final adapter = FakeDioAdapter()..enqueue(statusCode: 204);
+      final repo = _build(adapter);
+
+      await repo.deleteBook('b1');
+
+      expect(adapter.requests.single.method, 'DELETE');
+    });
+
+    test('deleteBook throws BookInUseException on 409 with active loans',
+        () async {
+      final adapter = FakeDioAdapter()
+        ..enqueue(
+          statusCode: 409,
+          body: {'activeLoans': 2, 'pendingRequests': 1},
+        );
+      final repo = _build(adapter);
+
+      await expectLater(
+        repo.deleteBook('b1'),
+        throwsA(isA<BookInUseException>()
+            .having((e) => e.activeLoans, 'activeLoans', 2)
+            .having((e) => e.pendingRequests, 'pendingRequests', 1)),
+      );
+    });
+
+    test('admin token is attached as Authorization header when present',
+        () async {
+      final adapter = FakeDioAdapter()..enqueue(bodyList: const []);
+      final repo = _build(adapter, adminToken: 'tok-xyz');
+
+      await repo.fetchBooks();
+
+      expect(adapter.requests.single.headers['Authorization'],
+          'Bearer tok-xyz');
+    });
+
+    test('Authorization header is omitted when admin token is null', () async {
+      final adapter = FakeDioAdapter()..enqueue(bodyList: const []);
+      final repo = _build(adapter, adminToken: null);
+
+      await repo.fetchBooks();
+
+      expect(adapter.requests.single.headers.containsKey('Authorization'),
+          isFalse);
+    });
+  });
+}

--- a/test/features/book_suggestions/data/repositories/admin_suggestion_repository_impl_test.dart
+++ b/test/features/book_suggestions/data/repositories/admin_suggestion_repository_impl_test.dart
@@ -1,0 +1,187 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lib_42_flutter/features/book_suggestions/data/models/book_suggestion.dart';
+import 'package:lib_42_flutter/features/book_suggestions/data/models/collection_period.dart';
+import 'package:lib_42_flutter/features/book_suggestions/data/repositories/admin_suggestion_repository_impl.dart';
+import 'package:lib_42_flutter/features/book_suggestions/domain/repositories/admin_suggestion_repository.dart';
+
+import '../../../../support/fake_dio_adapter.dart';
+import '../../../../support/fake_secure_storage_service.dart';
+
+AdminSuggestionRepositoryImpl _build(FakeDioAdapter adapter,
+    {String? adminToken}) {
+  final dio = Dio(BaseOptions(
+    baseUrl: 'https://api.test',
+    validateStatus: (s) => s != null && s < 500,
+  ));
+  dio.httpClientAdapter = adapter;
+  return AdminSuggestionRepositoryImpl(
+    baseUrl: 'https://api.test',
+    httpClient: dio,
+    storage: FakeSecureStorageService(adminToken: adminToken),
+  );
+}
+
+const _suggestionJson = {
+  'id': 's1',
+  'studentId': 'stu-1',
+  'suggestedTitle': '클린 아키텍처',
+  'suggestedAuthor': 'R. Martin',
+  'reason': '학습용',
+  'collectionPeriodId': 'p1',
+  'status': 'submitted',
+  'submittedAt': '2024-02-01T00:00:00.000Z',
+};
+
+const _groupedJson = {
+  'suggestedTitle': '클린 아키텍처',
+  'suggestedAuthor': 'R. Martin',
+  'collectionPeriodId': 'p1',
+  'requesterCount': 2,
+  'statuses': {'submitted': 1, 'approved': 1},
+  'latestSubmittedAt': '2024-02-01T00:00:00.000Z',
+  'items': [_suggestionJson],
+};
+
+const _periodJson = {
+  'id': 'p1',
+  'name': '2024 Q1',
+  'startDate': '2024-01-01T00:00:00.000Z',
+  'endDate': '2024-03-31T00:00:00.000Z',
+  'status': 'active',
+};
+
+void main() {
+  group('AdminSuggestionRepositoryImpl', () {
+    test('fetchGrouped parses grouped payload', () async {
+      final adapter = FakeDioAdapter()..enqueue(bodyList: [_groupedJson]);
+      final repo = _build(adapter);
+
+      final groups = await repo.fetchGrouped();
+
+      expect(groups, hasLength(1));
+      expect(groups.first.suggestedTitle, '클린 아키텍처');
+      expect(groups.first.requesterCount, 2);
+      expect(adapter.requests.single.path, '/v1/suggestions');
+    });
+
+    test('fetchGrouped passes periodId as query param', () async {
+      final adapter = FakeDioAdapter()..enqueue(bodyList: const []);
+      final repo = _build(adapter);
+
+      await repo.fetchGrouped(periodId: 'p99');
+
+      expect(adapter.requests.single.queryParameters['periodId'], 'p99');
+    });
+
+    test('fetchGrouped throws AdminSuggestionException on non-200', () async {
+      // 4xx is below the 500 threshold so it returns to user code (does not
+      // throw at Dio level), then the repository explicitly rejects non-200.
+      final adapter = FakeDioAdapter()
+        ..enqueue(statusCode: 401, body: {'error': 'unauthorized'});
+      final repo = _build(adapter);
+
+      await expectLater(
+        repo.fetchGrouped(),
+        throwsA(isA<AdminSuggestionException>()
+            .having((e) => e.code, 'code', 'fetch_failed')),
+      );
+    });
+
+    test('review returns updated suggestion with approved status', () async {
+      final adapter = FakeDioAdapter()
+        ..enqueue(statusCode: 200, body: {
+          'data': {..._suggestionJson, 'status': 'approved'},
+        });
+      final repo = _build(adapter);
+
+      final updated = await repo.review('s1',
+          status: SuggestionStatus.approved, adminNotes: '구매 예정');
+
+      expect(updated.id, 's1');
+      expect(updated.status, SuggestionStatus.approved);
+      expect(adapter.requests.single.method, 'PUT');
+      expect(adapter.requests.single.path, '/v1/suggestions/s1/status');
+      expect(adapter.lastRequestBody['status'], 'approved');
+      expect(adapter.lastRequestBody['adminNotes'], '구매 예정');
+    });
+
+    test('review converts underReview to wire form `under_review`', () async {
+      final adapter = FakeDioAdapter()
+        ..enqueue(statusCode: 200, body: {
+          'data': {..._suggestionJson, 'status': 'under_review'},
+        });
+      final repo = _build(adapter);
+
+      await repo.review('s1', status: SuggestionStatus.underReview);
+
+      expect(adapter.lastRequestBody['status'], 'under_review');
+      // adminNotes omitted when null/empty.
+      expect(adapter.lastRequestBody.containsKey('adminNotes'), isFalse);
+    });
+
+    test('review surfaces backend error message', () async {
+      final adapter = FakeDioAdapter()
+        ..enqueue(statusCode: 400, body: {
+          'error': 'invalid_status',
+          'message': '상태 전환이 허용되지 않습니다.',
+        });
+      final repo = _build(adapter);
+
+      await expectLater(
+        repo.review('s1', status: SuggestionStatus.approved),
+        throwsA(isA<AdminSuggestionException>()
+            .having((e) => e.code, 'code', 'invalid_status')
+            .having((e) => e.message, 'message', '상태 전환이 허용되지 않습니다.')),
+      );
+    });
+
+    test('createPeriod posts payload and returns CollectionPeriod', () async {
+      final adapter = FakeDioAdapter()
+        ..enqueue(statusCode: 201, body: {'data': _periodJson});
+      final repo = _build(adapter);
+
+      final period = await repo.createPeriod(
+        name: '2024 Q1',
+        startDate: DateTime.utc(2024, 1, 1),
+        endDate: DateTime.utc(2024, 3, 31),
+        status: PeriodStatus.active,
+      );
+
+      expect(period.id, 'p1');
+      expect(period.status, PeriodStatus.active);
+      expect(adapter.requests.single.path, '/v1/collection-periods');
+      expect(adapter.lastRequestBody['name'], '2024 Q1');
+      expect(adapter.lastRequestBody['status'], 'active');
+    });
+
+    test('createPeriod surfaces backend error message', () async {
+      final adapter = FakeDioAdapter()
+        ..enqueue(statusCode: 400, body: {
+          'error': 'validation_error',
+          'message': '시작일이 종료일보다 늦을 수 없습니다.',
+        });
+      final repo = _build(adapter);
+
+      await expectLater(
+        repo.createPeriod(
+          name: 'X',
+          startDate: DateTime.utc(2024, 4, 1),
+          endDate: DateTime.utc(2024, 1, 1),
+        ),
+        throwsA(isA<AdminSuggestionException>()
+            .having((e) => e.code, 'code', 'validation_error')),
+      );
+    });
+
+    test('admin token is attached as Authorization header', () async {
+      final adapter = FakeDioAdapter()..enqueue(bodyList: const []);
+      final repo = _build(adapter, adminToken: 'admin-token');
+
+      await repo.fetchGrouped();
+
+      expect(adapter.requests.single.headers['Authorization'],
+          'Bearer admin-token');
+    });
+  });
+}

--- a/test/support/fake_dio_adapter.dart
+++ b/test/support/fake_dio_adapter.dart
@@ -1,0 +1,69 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+
+/// Minimal Dio adapter for tests. Records every request and serves canned
+/// responses queued via [enqueue]. The default response when the queue is
+/// empty is 200 OK with the body `{ "data": [] }`, which keeps tests forgiving
+/// about unrelated bookkeeping calls.
+class FakeDioAdapter implements HttpClientAdapter {
+  final List<RequestOptions> requests = [];
+  final List<_FakeResponse> _queue = [];
+  bool throwTimeout = false;
+
+  void enqueue({
+    int statusCode = 200,
+    Map<String, dynamic>? body,
+    List<dynamic>? bodyList,
+    String? rawBody,
+  }) {
+    final encoded = rawBody ??
+        jsonEncode(bodyList != null ? {'data': bodyList} : (body ?? {}));
+    _queue.add(_FakeResponse(statusCode: statusCode, body: encoded));
+  }
+
+  /// Most recent request's body decoded as JSON. Throws if no requests.
+  Map<String, dynamic> get lastRequestBody {
+    final r = requests.last;
+    final raw = r.data;
+    if (raw is Map<String, dynamic>) return raw;
+    if (raw is String) return jsonDecode(raw) as Map<String, dynamic>;
+    throw StateError('Unsupported request body type: ${raw.runtimeType}');
+  }
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<dynamic>? cancelFuture,
+  ) async {
+    requests.add(options);
+    if (throwTimeout) {
+      throw DioException(
+        requestOptions: options,
+        type: DioExceptionType.connectionTimeout,
+        message: 'fake timeout',
+      );
+    }
+    final canned = _queue.isNotEmpty
+        ? _queue.removeAt(0)
+        : _FakeResponse(statusCode: 200, body: jsonEncode({'data': []}));
+    return ResponseBody.fromString(
+      canned.body,
+      canned.statusCode,
+      headers: {
+        Headers.contentTypeHeader: ['application/json; charset=utf-8'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+class _FakeResponse {
+  _FakeResponse({required this.statusCode, required this.body});
+  final int statusCode;
+  final String body;
+}

--- a/test/support/fake_secure_storage_service.dart
+++ b/test/support/fake_secure_storage_service.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_secure_storage_platform_interface/flutter_secure_storage_platform_interface.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lib_42_flutter/services/storage/secure_storage_service.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+/// Stand-in for [SecureStorageService] that doesn't touch the platform
+/// channel. Only [readAdminToken] is exposed — extend as needed.
+class FakeSecureStorageService extends SecureStorageService {
+  FakeSecureStorageService({this.adminToken = 'test-admin-token'})
+      : super(storage: const _NoopFlutterSecureStorage());
+
+  String? adminToken;
+
+  @override
+  Future<String?> readAdminToken() async => adminToken;
+}
+
+/// FlutterSecureStorage that throws if any platform call slips through.
+/// Construction requires no platform channel because we never call into it.
+class _NoopFlutterSecureStorage implements FlutterSecureStorage {
+  const _NoopFlutterSecureStorage();
+
+  @override
+  noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('Real storage call leaked into test');
+}
+
+/// Optional helper: install a no-op platform handler so any code path that
+/// instantiates a real SecureStorageService doesn't crash. Call from
+/// `setUpAll` if needed.
+void installNoopSecureStoragePlatform() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  FlutterSecureStoragePlatform.instance = _NoopPlatform();
+}
+
+class _NoopPlatform extends FlutterSecureStoragePlatform with MockPlatformInterfaceMixin {
+  @override
+  Future<bool> containsKey(
+          {required String key, required Map<String, String> options}) async =>
+      false;
+
+  @override
+  Future<void> delete(
+      {required String key, required Map<String, String> options}) async {}
+
+  @override
+  Future<void> deleteAll({required Map<String, String> options}) async {}
+
+  @override
+  Future<String?> read(
+          {required String key, required Map<String, String> options}) async =>
+      null;
+
+  @override
+  Future<Map<String, String>> readAll(
+          {required Map<String, String> options}) async =>
+      {};
+
+  @override
+  Future<void> write(
+      {required String key,
+      required String value,
+      required Map<String, String> options}) async {}
+}


### PR DESCRIPTION
Closes #115

## Summary

Phase 11 하드닝 — Flutter 두 번째 큰 커버리지 갭 (admin HTTP wrappers 0%) 해소.

## 접근

- **FakeDioAdapter** (`test/support/fake_dio_adapter.dart`) — `HttpClientAdapter` 구현체. 외부 mock 라이브러리 없이 카닐 응답 큐 + 요청 검증.
- **FakeSecureStorageService** (`test/support/fake_secure_storage_service.dart`) — `SecureStorageService` 확장으로 플랫폼 채널 우회.

두 fake 모두 향후 다른 HTTP 클라이언트 테스트에서 재사용 가능.

## 효과

| | Before | After |
|--|--|--|
| `admin_book_repository_impl.dart` | 0% | **83%** |
| `admin_suggestion_repository_impl.dart` | 0% | **83%** |
| Flutter 전체 | 61.3% | **67.1%** |
| Flutter 테스트 | 136 | **154** |

## 테스트 추가 18건

**AdminBookRepositoryImpl (8건)**
- fetchBooks: 200 파싱, 401 에러
- createBook: 201, 400 ISBN 중복
- updateBook: 200
- deleteBook: 204, 409 active loans
- 관리자 토큰 인터셉터 (있을 때/없을 때)

**AdminSuggestionRepositoryImpl (10건)**
- fetchGrouped: 200 파싱, periodId 쿼리, 401 에러
- review: 정상, under_review wire 변환, 4xx 에러 메시지
- createPeriod: 201 + 4xx
- 관리자 토큰 헤더

## Test plan

- [x] `flutter test` 136 → 154 (+18)
- [x] 누적 커버리지 61.3% → 67.1%
- [x] `flutter analyze --no-fatal-infos` (info-only, pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)