### PR TITLE
[Release #119] v0.5.0 — Phase 11 하드닝 1차 + reorderQueue 버그 수정

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "42lib-backend",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "42 Learning Space Library Management System - Backend API",
   "main": "src/server.ts",
   "scripts": {

--- a/backend/src/services/reservation_service.ts
+++ b/backend/src/services/reservation_service.ts
@@ -113,34 +113,56 @@ export class ReservationService {
   }
 
   /**
-   * BR-305: Reorder queue when reservation is cancelled or expired
+   * BR-305: Reorder queue when reservation is cancelled or expired.
+   *
+   * The schema has @@unique([bookId, queuePosition]) over ALL rows
+   * (including cancelled/expired/fulfilled), so a naive renumber-in-place
+   * may collide with a non-active reservation that still holds a positive
+   * slot. We sidestep that with a 2-phase update inside a transaction:
+   *   1. Park every reservation for this book in a unique negative slot.
+   *   2. Assign sequential positions 1..N to the active subset only.
+   * Non-active rows keep their negative slot, which is fine because every
+   * downstream read filters by status.
    */
   async reorderQueue(bookId: string) {
     try {
-      const reservations = await prisma.reservation.findMany({
-        where: {
-          bookId,
-          status: { in: [ReservationStatus.waiting, ReservationStatus.notified] },
-        },
+      const all = await prisma.reservation.findMany({
+        where: { bookId },
         orderBy: { queuePosition: 'asc' },
       });
+      if (all.length === 0) return [];
 
-      // Update queue positions to be sequential (1, 2, 3, ...)
-      for (let i = 0; i < reservations.length; i++) {
-        if (reservations[i].queuePosition !== i + 1) {
-          await prisma.reservation.update({
-            where: { id: reservations[i].id },
+      const active = all.filter(
+        (r) =>
+          r.status === ReservationStatus.waiting ||
+          r.status === ReservationStatus.notified,
+      );
+
+      await prisma.$transaction(async (tx) => {
+        // Phase 1: park every row at -(index+1)-1_000_000. Guaranteed
+        // unique (bookId, queuePosition) within this book.
+        for (let i = 0; i < all.length; i++) {
+          await tx.reservation.update({
+            where: { id: all[i].id },
+            data: { queuePosition: -(i + 1) - 1_000_000 },
+          });
+        }
+        // Phase 2: assign 1..N to active in arrival order.
+        for (let i = 0; i < active.length; i++) {
+          await tx.reservation.update({
+            where: { id: active[i].id },
             data: { queuePosition: i + 1 },
           });
         }
-      }
+      });
 
       logger.info('Reservation queue reordered', {
         bookId,
-        count: reservations.length,
+        active: active.length,
+        total: all.length,
       });
 
-      return reservations;
+      return active;
     } catch (error: any) {
       logger.error('Failed to reorder reservation queue', {
         error: error.message,

--- a/backend/tests/unit/loan_request_service.test.ts
+++ b/backend/tests/unit/loan_request_service.test.ts
@@ -1,0 +1,304 @@
+// Phase 11 hardening — service-level tests for LoanRequestService.
+// The HTTP-level tests in loan_requests.test.ts cover happy paths through
+// the route layer; this file targets the validation/error branches and the
+// reservation auto-creation behavior in createLoanRequest.
+
+import { LoanRequestStatus, PrismaClient, ReservationStatus } from '@prisma/client';
+import { loanRequestService } from '../../src/services/loan_request_service';
+
+const prisma = new PrismaClient();
+
+const PREFIX = 'lrq_svc_';
+const BOOK_AVAIL = '00000000-0000-0000-0000-000000000d00';
+const BOOK_FULL = '00000000-0000-0000-0000-000000000d01';
+
+const BOOK_AVAIL_DATA = {
+  id: BOOK_AVAIL,
+  title: '[T112-svc] 사용 가능 도서',
+  author: 'Service Test',
+  isbn: '9780000000d00',
+  category: 'Programming',
+  quantity: 2,
+  availableQuantity: 2,
+};
+
+const BOOK_FULL_DATA = {
+  id: BOOK_FULL,
+  title: '[T112-svc] 매진 도서',
+  author: 'Service Test',
+  isbn: '9780000000d01',
+  category: 'Programming',
+  quantity: 1,
+  availableQuantity: 0,
+};
+
+async function cleanup(): Promise<void> {
+  await prisma.loanRequest.deleteMany({
+    where: { book: { title: { startsWith: '[T112-svc]' } } },
+  });
+  await prisma.reservation.deleteMany({
+    where: { book: { title: { startsWith: '[T112-svc]' } } },
+  });
+  await prisma.book.deleteMany({
+    where: { title: { startsWith: '[T112-svc]' } },
+  });
+  await prisma.student.deleteMany({
+    where: { username: { startsWith: PREFIX } },
+  });
+}
+
+async function createStudent(suffix: string) {
+  const u = `${PREFIX}${suffix}`;
+  return prisma.student.create({
+    data: {
+      fortytwoUserId: 960000 + suffix.charCodeAt(0),
+      username: u,
+      email: `${u}@42.fr`,
+      fullName: `대출 학생 ${suffix}`,
+    },
+  });
+}
+
+describe('LoanRequestService (unit, service-level)', () => {
+  beforeAll(async () => {
+    await cleanup();
+    await prisma.book.create({ data: BOOK_AVAIL_DATA });
+    await prisma.book.create({ data: BOOK_FULL_DATA });
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    await prisma.$disconnect();
+  });
+
+  beforeEach(async () => {
+    // Wipe loan requests + reservations + students between tests; keep books.
+    await prisma.loanRequest.deleteMany({
+      where: { OR: [{ bookId: BOOK_AVAIL }, { bookId: BOOK_FULL }] },
+    });
+    await prisma.reservation.deleteMany({
+      where: { OR: [{ bookId: BOOK_AVAIL }, { bookId: BOOK_FULL }] },
+    });
+    await prisma.student.deleteMany({
+      where: { username: { startsWith: PREFIX } },
+    });
+  });
+
+  describe('createLoanRequest', () => {
+    it('creates a pending request when book is available — no reservation', async () => {
+      const s = await createStudent('a');
+      const req = await loanRequestService.createLoanRequest(
+        s.id,
+        BOOK_AVAIL,
+        '학기 과제용',
+      );
+
+      expect(req.status).toBe(LoanRequestStatus.pending);
+      expect(req.studentId).toBe(s.id);
+      expect(req.notes).toBe('학기 과제용');
+
+      const reservations = await prisma.reservation.findMany({
+        where: { studentId: s.id, bookId: BOOK_AVAIL },
+      });
+      expect(reservations).toHaveLength(0);
+    });
+
+    it('auto-creates a waiting reservation when book is unavailable', async () => {
+      const s = await createStudent('b');
+      const req = await loanRequestService.createLoanRequest(s.id, BOOK_FULL);
+
+      expect(req.status).toBe(LoanRequestStatus.pending);
+
+      const reservation = await prisma.reservation.findFirst({
+        where: { studentId: s.id, bookId: BOOK_FULL },
+      });
+      expect(reservation).not.toBeNull();
+      expect(reservation!.status).toBe(ReservationStatus.waiting);
+      expect(reservation!.queuePosition).toBe(1);
+    });
+
+    it('assigns sequential queue positions to multiple students for the same full book', async () => {
+      const a = await createStudent('a');
+      const b = await createStudent('b');
+      const c = await createStudent('c');
+      await loanRequestService.createLoanRequest(a.id, BOOK_FULL);
+      await loanRequestService.createLoanRequest(b.id, BOOK_FULL);
+      await loanRequestService.createLoanRequest(c.id, BOOK_FULL);
+
+      const positions = await prisma.reservation.findMany({
+        where: { bookId: BOOK_FULL },
+        orderBy: { queuePosition: 'asc' },
+        select: { studentId: true, queuePosition: true },
+      });
+      expect(positions.map((p) => p.queuePosition)).toEqual([1, 2, 3]);
+      expect(positions.map((p) => p.studentId)).toEqual([a.id, b.id, c.id]);
+    });
+
+    it('throws when student is not found', async () => {
+      await expect(
+        loanRequestService.createLoanRequest(
+          '00000000-0000-0000-0000-000000000000',
+          BOOK_AVAIL,
+        ),
+      ).rejects.toThrow('학생을 찾을 수 없습니다');
+    });
+
+    it('throws when book is not found', async () => {
+      const s = await createStudent('a');
+      await expect(
+        loanRequestService.createLoanRequest(
+          s.id,
+          '00000000-0000-0000-0000-deadbeef0000',
+        ),
+      ).rejects.toThrow('책을 찾을 수 없습니다');
+    });
+
+    it('throws when student already has a pending request for the same book', async () => {
+      const s = await createStudent('a');
+      await loanRequestService.createLoanRequest(s.id, BOOK_AVAIL);
+
+      await expect(
+        loanRequestService.createLoanRequest(s.id, BOOK_AVAIL),
+      ).rejects.toThrow('이미 해당 책에 대한 대출 신청');
+    });
+  });
+
+  describe('getStudentLoanRequests', () => {
+    it('returns requests for the student in descending requestDate order', async () => {
+      const s = await createStudent('a');
+      await loanRequestService.createLoanRequest(s.id, BOOK_AVAIL, 'first');
+      // Small delay so requestDate timestamps differ enough to sort.
+      await new Promise((r) => setTimeout(r, 10));
+      await loanRequestService.createLoanRequest(s.id, BOOK_FULL, 'second');
+
+      const list = await loanRequestService.getStudentLoanRequests(s.id);
+
+      expect(list).toHaveLength(2);
+      expect(list[0].notes).toBe('second');
+      expect(list[1].notes).toBe('first');
+    });
+
+    it('returns an empty array when student has no requests', async () => {
+      const s = await createStudent('a');
+      const list = await loanRequestService.getStudentLoanRequests(s.id);
+      expect(list).toEqual([]);
+    });
+  });
+
+  describe('getPendingLoanRequests', () => {
+    it('returns only pending requests across all students, ordered by requestDate asc', async () => {
+      const a = await createStudent('a');
+      const b = await createStudent('b');
+      await loanRequestService.createLoanRequest(a.id, BOOK_AVAIL, 'a-pending');
+      await new Promise((r) => setTimeout(r, 10));
+      const second = await loanRequestService.createLoanRequest(
+        b.id,
+        BOOK_FULL,
+        'b-pending',
+      );
+      // Manually flip the second one to cancelled so it must be excluded.
+      await prisma.loanRequest.update({
+        where: { id: second.id },
+        data: { status: LoanRequestStatus.cancelled },
+      });
+
+      const list = await loanRequestService.getPendingLoanRequests();
+      const fromTestData = list.filter((r) =>
+        [BOOK_AVAIL, BOOK_FULL].includes(r.bookId),
+      );
+
+      expect(fromTestData).toHaveLength(1);
+      expect(fromTestData[0].studentId).toBe(a.id);
+      expect(fromTestData[0].status).toBe(LoanRequestStatus.pending);
+    });
+  });
+
+  describe('getStudentReservations', () => {
+    it('returns waiting + notified reservations ordered by queuePosition', async () => {
+      const a = await createStudent('a');
+      // Two reservations on full book — both waiting at positions 1, 2.
+      await prisma.reservation.create({
+        data: {
+          studentId: a.id,
+          bookId: BOOK_FULL,
+          queuePosition: 5,
+          status: ReservationStatus.waiting,
+        },
+      });
+      await prisma.reservation.create({
+        data: {
+          studentId: a.id,
+          bookId: BOOK_AVAIL,
+          queuePosition: 1,
+          status: ReservationStatus.notified,
+          notifiedAt: new Date(),
+          expiresAt: new Date(Date.now() + 60_000),
+        },
+      });
+      // Cancelled one must not appear.
+      await prisma.reservation.create({
+        data: {
+          studentId: a.id,
+          bookId: BOOK_FULL,
+          queuePosition: 7,
+          status: ReservationStatus.cancelled,
+        },
+      });
+
+      const list = await loanRequestService.getStudentReservations(a.id);
+
+      expect(list).toHaveLength(2);
+      expect(list.map((r) => r.queuePosition)).toEqual([1, 5]);
+      expect(list.every((r) => r.status !== ReservationStatus.cancelled)).toBe(true);
+    });
+
+    it('returns empty list when student has no active reservations', async () => {
+      const a = await createStudent('a');
+      const list = await loanRequestService.getStudentReservations(a.id);
+      expect(list).toEqual([]);
+    });
+  });
+
+  describe('cancelLoanRequest', () => {
+    it('cancels a pending request owned by the student', async () => {
+      const s = await createStudent('a');
+      const req = await loanRequestService.createLoanRequest(s.id, BOOK_AVAIL);
+
+      const updated = await loanRequestService.cancelLoanRequest(req.id, s.id);
+
+      expect(updated.status).toBe(LoanRequestStatus.cancelled);
+    });
+
+    it('throws when request is not found', async () => {
+      await expect(
+        loanRequestService.cancelLoanRequest(
+          '00000000-0000-0000-0000-000000000000',
+          'nope',
+        ),
+      ).rejects.toThrow('대출 신청을 찾을 수 없습니다');
+    });
+
+    it('throws when student does not own the request', async () => {
+      const a = await createStudent('a');
+      const b = await createStudent('b');
+      const req = await loanRequestService.createLoanRequest(a.id, BOOK_AVAIL);
+
+      await expect(
+        loanRequestService.cancelLoanRequest(req.id, b.id),
+      ).rejects.toThrow('권한이 없습니다');
+    });
+
+    it('throws when request is not in pending status', async () => {
+      const s = await createStudent('a');
+      const req = await loanRequestService.createLoanRequest(s.id, BOOK_AVAIL);
+      await prisma.loanRequest.update({
+        where: { id: req.id },
+        data: { status: LoanRequestStatus.approved },
+      });
+
+      await expect(
+        loanRequestService.cancelLoanRequest(req.id, s.id),
+      ).rejects.toThrow('대기 중인 신청만');
+    });
+  });
+});

--- a/backend/tests/unit/reservation_service.test.ts
+++ b/backend/tests/unit/reservation_service.test.ts
@@ -1,0 +1,294 @@
+// Phase 11 hardening — direct service-level tests for ReservationService.
+// Complements the HTTP integration tests in reservations.test.ts by covering
+// branches not reachable via the loan-request endpoints
+// (handleExpiredReservations, reorderQueue, cancel ownership/state checks,
+// getQueuePosition).
+
+import { PrismaClient, ReservationStatus } from '@prisma/client';
+import { reservationService } from '../../src/services/reservation_service';
+
+const prisma = new PrismaClient();
+
+const PREFIX = 'rsv_svc_';
+const BOOK_ID = '00000000-0000-0000-0000-000000000c00';
+const BOOK_DATA = {
+  id: BOOK_ID,
+  title: '[T101-svc] 서비스 테스트 도서',
+  author: 'Service Test',
+  isbn: '9780000000c00',
+  category: 'Programming',
+  quantity: 1,
+  availableQuantity: 0,
+};
+
+async function cleanup(): Promise<void> {
+  await prisma.loanRequest.deleteMany({
+    where: { book: { title: { startsWith: '[T101-svc]' } } },
+  });
+  await prisma.reservation.deleteMany({
+    where: { book: { title: { startsWith: '[T101-svc]' } } },
+  });
+  await prisma.book.deleteMany({ where: { title: { startsWith: '[T101-svc]' } } });
+  await prisma.student.deleteMany({ where: { username: { startsWith: PREFIX } } });
+}
+
+async function createStudent(suffix: string) {
+  const u = `${PREFIX}${suffix}`;
+  return prisma.student.create({
+    data: {
+      fortytwoUserId: 970000 + suffix.charCodeAt(0),
+      username: u,
+      email: `${u}@42.fr`,
+      fullName: `예약 학생 ${suffix}`,
+    },
+  });
+}
+
+async function makeReservation(
+  studentId: string,
+  position: number,
+  status: ReservationStatus = ReservationStatus.waiting,
+  overrides: Partial<{ notifiedAt: Date; expiresAt: Date }> = {},
+) {
+  return prisma.reservation.create({
+    data: {
+      studentId,
+      bookId: BOOK_ID,
+      queuePosition: position,
+      status,
+      ...overrides,
+    },
+  });
+}
+
+describe('ReservationService (unit, service-level)', () => {
+  beforeAll(async () => {
+    await cleanup();
+    await prisma.book.create({ data: BOOK_DATA });
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    await prisma.$disconnect();
+  });
+
+  beforeEach(async () => {
+    // Wipe reservations and students between tests to keep cases independent
+    // (book row is preserved).
+    await prisma.reservation.deleteMany({ where: { bookId: BOOK_ID } });
+    await prisma.student.deleteMany({
+      where: { username: { startsWith: PREFIX } },
+    });
+  });
+
+  describe('notifyNextInQueue', () => {
+    it('notifies the first waiting reservation and sets a 24h expiry', async () => {
+      const a = await createStudent('a');
+      const b = await createStudent('b');
+      await makeReservation(a.id, 1);
+      await makeReservation(b.id, 2);
+
+      const before = Date.now();
+      const updated = await reservationService.notifyNextInQueue(BOOK_ID);
+      const after = Date.now();
+
+      expect(updated).not.toBeNull();
+      expect(updated!.studentId).toBe(a.id);
+      expect(updated!.status).toBe(ReservationStatus.notified);
+      expect(updated!.notifiedAt).not.toBeNull();
+
+      const expiresAt = updated!.expiresAt!.getTime();
+      // Within ±5 seconds of (now + 24h) for both bounds.
+      expect(expiresAt).toBeGreaterThanOrEqual(before + 24 * 60 * 60 * 1000 - 5000);
+      expect(expiresAt).toBeLessThanOrEqual(after + 24 * 60 * 60 * 1000 + 5000);
+
+      // The second reservation should remain untouched.
+      const second = await prisma.reservation.findFirst({
+        where: { studentId: b.id },
+      });
+      expect(second!.status).toBe(ReservationStatus.waiting);
+    });
+
+    it('returns null when there is nothing waiting', async () => {
+      const result = await reservationService.notifyNextInQueue(BOOK_ID);
+      expect(result).toBeNull();
+    });
+
+    it('skips already-notified reservations and picks the next waiting', async () => {
+      const a = await createStudent('a');
+      const b = await createStudent('b');
+      await makeReservation(a.id, 1, ReservationStatus.notified, {
+        notifiedAt: new Date(),
+        expiresAt: new Date(Date.now() + 60_000),
+      });
+      await makeReservation(b.id, 2);
+
+      const updated = await reservationService.notifyNextInQueue(BOOK_ID);
+      expect(updated!.studentId).toBe(b.id);
+    });
+  });
+
+  describe('handleExpiredReservations', () => {
+    it('marks notified reservations past expiry as expired and notifies the next', async () => {
+      const a = await createStudent('a');
+      const b = await createStudent('b');
+      const past = new Date(Date.now() - 60_000);
+      await makeReservation(a.id, 1, ReservationStatus.notified, {
+        notifiedAt: new Date(Date.now() - 25 * 60 * 60 * 1000),
+        expiresAt: past,
+      });
+      await makeReservation(b.id, 2);
+
+      const expired = await reservationService.handleExpiredReservations();
+
+      expect(expired).toHaveLength(1);
+      expect(expired[0].studentId).toBe(a.id);
+
+      const refreshedA = await prisma.reservation.findFirst({
+        where: { studentId: a.id },
+      });
+      expect(refreshedA!.status).toBe(ReservationStatus.expired);
+
+      const refreshedB = await prisma.reservation.findFirst({
+        where: { studentId: b.id },
+      });
+      expect(refreshedB!.status).toBe(ReservationStatus.notified);
+    });
+
+    it('returns empty array when nothing is expired', async () => {
+      const a = await createStudent('a');
+      // Notified but not yet past expiry.
+      await makeReservation(a.id, 1, ReservationStatus.notified, {
+        notifiedAt: new Date(),
+        expiresAt: new Date(Date.now() + 60_000),
+      });
+
+      const expired = await reservationService.handleExpiredReservations();
+      expect(expired).toHaveLength(0);
+    });
+  });
+
+  describe('reorderQueue', () => {
+    it('renumbers gaps so positions are sequential 1..N', async () => {
+      const a = await createStudent('a');
+      const b = await createStudent('b');
+      const c = await createStudent('c');
+      // Intentional gap (1, 3, 5) to verify renumbering compacts to 1, 2, 3.
+      await makeReservation(a.id, 1);
+      await makeReservation(b.id, 3);
+      await makeReservation(c.id, 5);
+
+      await reservationService.reorderQueue(BOOK_ID);
+
+      const list = await prisma.reservation.findMany({
+        where: { bookId: BOOK_ID },
+        orderBy: { queuePosition: 'asc' },
+      });
+      expect(list.map((r) => r.queuePosition)).toEqual([1, 2, 3]);
+      expect(list.map((r) => r.studentId)).toEqual([a.id, b.id, c.id]);
+    });
+
+    it('renumbers active rows 1..N and parks non-active rows in a negative slot', async () => {
+      const a = await createStudent('a');
+      const b = await createStudent('b');
+      const c = await createStudent('c');
+      // Cancelled occupies a positive slot; without parking it, the unique
+      // (bookId, queuePosition) constraint would block compaction of the
+      // active rows. After reorderQueue, active rows get 1..2 and cancelled
+      // sits at a negative slot (its exact value is an internal detail).
+      await makeReservation(a.id, 10, ReservationStatus.cancelled);
+      await makeReservation(b.id, 20);
+      await makeReservation(c.id, 30);
+
+      await reservationService.reorderQueue(BOOK_ID);
+
+      const cancelled = await prisma.reservation.findFirst({
+        where: { studentId: a.id },
+      });
+      expect(cancelled!.status).toBe(ReservationStatus.cancelled);
+      expect(cancelled!.queuePosition).toBeLessThan(0);
+
+      const list = await prisma.reservation.findMany({
+        where: {
+          bookId: BOOK_ID,
+          status: { in: [ReservationStatus.waiting, ReservationStatus.notified] },
+        },
+        orderBy: { queuePosition: 'asc' },
+      });
+      expect(list.map((r) => r.queuePosition)).toEqual([1, 2]);
+      expect(list.map((r) => r.studentId)).toEqual([b.id, c.id]);
+    });
+  });
+
+  describe('cancelReservation', () => {
+    it('cancels a waiting reservation owned by the student and reorders the queue', async () => {
+      const a = await createStudent('a');
+      const b = await createStudent('b');
+      const r1 = await makeReservation(a.id, 1);
+      await makeReservation(b.id, 2);
+
+      await reservationService.cancelReservation(r1.id, a.id);
+
+      const cancelled = await prisma.reservation.findUnique({ where: { id: r1.id } });
+      expect(cancelled!.status).toBe(ReservationStatus.cancelled);
+
+      // After reorder, b should now be at position 1.
+      const refreshedB = await prisma.reservation.findFirst({
+        where: { studentId: b.id },
+      });
+      expect(refreshedB!.queuePosition).toBe(1);
+    });
+
+    it('throws when reservation does not exist', async () => {
+      await expect(
+        reservationService.cancelReservation(
+          '00000000-0000-0000-0000-000000000000',
+          'nope',
+        ),
+      ).rejects.toThrow('예약을 찾을 수 없습니다');
+    });
+
+    it('throws when student does not own the reservation', async () => {
+      const a = await createStudent('a');
+      const b = await createStudent('b');
+      const r = await makeReservation(a.id, 1);
+
+      await expect(
+        reservationService.cancelReservation(r.id, b.id),
+      ).rejects.toThrow('권한이 없습니다');
+    });
+
+    it('throws when the reservation is not in a cancellable status', async () => {
+      const a = await createStudent('a');
+      const r = await makeReservation(a.id, 1, ReservationStatus.expired);
+
+      await expect(
+        reservationService.cancelReservation(r.id, a.id),
+      ).rejects.toThrow('대기 중이거나 알림받은 예약만');
+    });
+  });
+
+  describe('getQueuePosition', () => {
+    it('returns position metadata for an active reservation', async () => {
+      const a = await createStudent('a');
+      const b = await createStudent('b');
+      await makeReservation(a.id, 1);
+      await makeReservation(b.id, 2);
+
+      const pos = await reservationService.getQueuePosition(b.id, BOOK_ID);
+      expect(pos).not.toBeNull();
+      expect(pos!.position).toBe(2);
+      expect(pos!.totalInQueue).toBe(2);
+      expect(pos!.status).toBe(ReservationStatus.waiting);
+    });
+
+    it('returns null when the student has no active reservation for the book', async () => {
+      const a = await createStudent('a');
+      // Cancelled reservations should not count.
+      await makeReservation(a.id, 1, ReservationStatus.cancelled);
+
+      const pos = await reservationService.getQueuePosition(a.id, BOOK_ID);
+      expect(pos).toBeNull();
+    });
+  });
+});

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lib_42_flutter
 description: 42 Learning Space Library Management System - Flutter App
 publish_to: 'none'
-version: 0.4.1+1
+version: 0.5.0+1
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/test/features/admin_catalog/data/repositories/admin_book_repository_impl_test.dart
+++ b/test/features/admin_catalog/data/repositories/admin_book_repository_impl_test.dart
@@ -1,0 +1,154 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lib_42_flutter/features/admin_catalog/data/repositories/admin_book_repository_impl.dart';
+import 'package:lib_42_flutter/features/admin_catalog/domain/repositories/admin_book_repository.dart';
+
+import '../../../../support/fake_dio_adapter.dart';
+import '../../../../support/fake_secure_storage_service.dart';
+
+AdminBookRepositoryImpl _build(FakeDioAdapter adapter, {String? adminToken}) {
+  final dio = Dio(BaseOptions(
+    baseUrl: 'https://api.test',
+    validateStatus: (s) => s != null && s < 500,
+  ));
+  dio.httpClientAdapter = adapter;
+  return AdminBookRepositoryImpl(
+    baseUrl: 'https://api.test',
+    httpClient: dio,
+    storage: FakeSecureStorageService(adminToken: adminToken),
+  );
+}
+
+const _bookJson = {
+  'id': 'b1',
+  'title': '클린 아키텍처',
+  'author': 'R. Martin',
+  'category': 'Programming',
+  'isbn': '9780134494166',
+  'description': null,
+  'publicationYear': 2017,
+  'quantity': 3,
+  'availableQuantity': 2,
+  'coverImageUrl': null,
+  'createdAt': '2024-01-01T00:00:00.000Z',
+  'updatedAt': '2024-01-01T00:00:00.000Z',
+};
+
+const _validPayload = AdminBookPayload(
+  title: '클린 아키텍처',
+  author: 'R. Martin',
+  category: 'Programming',
+  quantity: 3,
+  availableQuantity: 2,
+);
+
+void main() {
+  group('AdminBookRepositoryImpl', () {
+    test('fetchBooks parses 200 response into Book list', () async {
+      final adapter = FakeDioAdapter()..enqueue(bodyList: [_bookJson]);
+      final repo = _build(adapter);
+
+      final books = await repo.fetchBooks();
+
+      expect(books, hasLength(1));
+      expect(books.first.title, '클린 아키텍처');
+      expect(books.first.quantity, 3);
+      expect(adapter.requests.single.path, '/v1/books');
+      expect(adapter.requests.single.queryParameters,
+          {'page': 1, 'limit': 200});
+    });
+
+    test('fetchBooks throws on non-200', () async {
+      // 4xx stays under the 500 threshold so the repo path (not Dio) rejects.
+      final adapter = FakeDioAdapter()
+        ..enqueue(statusCode: 401, body: {'error': 'unauthorized'});
+      final repo = _build(adapter);
+
+      await expectLater(repo.fetchBooks(), throwsA(isA<BookConflictException>()));
+    });
+
+    test('createBook posts payload and returns Book on 201', () async {
+      final adapter = FakeDioAdapter()
+        ..enqueue(statusCode: 201, body: _bookJson);
+      final repo = _build(adapter);
+
+      final book = await repo.createBook(_validPayload);
+
+      expect(book.id, 'b1');
+      expect(adapter.requests.single.method, 'POST');
+      expect(adapter.requests.single.path, '/v1/books');
+      expect(adapter.lastRequestBody['title'], '클린 아키텍처');
+    });
+
+    test('createBook surfaces 400 validation error message', () async {
+      final adapter = FakeDioAdapter()
+        ..enqueue(statusCode: 400, body: {'error': 'ISBN already exists'});
+      final repo = _build(adapter);
+
+      await expectLater(
+        repo.createBook(_validPayload),
+        throwsA(isA<BookConflictException>().having(
+            (e) => e.message, 'message', contains('ISBN'))),
+      );
+    });
+
+    test('updateBook puts to /v1/books/:id and returns Book on 200', () async {
+      final adapter = FakeDioAdapter()
+        ..enqueue(statusCode: 200, body: _bookJson);
+      final repo = _build(adapter);
+
+      final book = await repo.updateBook('b1', _validPayload);
+
+      expect(book.id, 'b1');
+      expect(adapter.requests.single.method, 'PUT');
+      expect(adapter.requests.single.path, '/v1/books/b1');
+    });
+
+    test('deleteBook returns normally on 204', () async {
+      final adapter = FakeDioAdapter()..enqueue(statusCode: 204);
+      final repo = _build(adapter);
+
+      await repo.deleteBook('b1');
+
+      expect(adapter.requests.single.method, 'DELETE');
+    });
+
+    test('deleteBook throws BookInUseException on 409 with active loans',
+        () async {
+      final adapter = FakeDioAdapter()
+        ..enqueue(
+          statusCode: 409,
+          body: {'activeLoans': 2, 'pendingRequests': 1},
+        );
+      final repo = _build(adapter);
+
+      await expectLater(
+        repo.deleteBook('b1'),
+        throwsA(isA<BookInUseException>()
+            .having((e) => e.activeLoans, 'activeLoans', 2)
+            .having((e) => e.pendingRequests, 'pendingRequests', 1)),
+      );
+    });
+
+    test('admin token is attached as Authorization header when present',
+        () async {
+      final adapter = FakeDioAdapter()..enqueue(bodyList: const []);
+      final repo = _build(adapter, adminToken: 'tok-xyz');
+
+      await repo.fetchBooks();
+
+      expect(adapter.requests.single.headers['Authorization'],
+          'Bearer tok-xyz');
+    });
+
+    test('Authorization header is omitted when admin token is null', () async {
+      final adapter = FakeDioAdapter()..enqueue(bodyList: const []);
+      final repo = _build(adapter, adminToken: null);
+
+      await repo.fetchBooks();
+
+      expect(adapter.requests.single.headers.containsKey('Authorization'),
+          isFalse);
+    });
+  });
+}

--- a/test/features/book_suggestions/data/repositories/admin_suggestion_repository_impl_test.dart
+++ b/test/features/book_suggestions/data/repositories/admin_suggestion_repository_impl_test.dart
@@ -1,0 +1,187 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lib_42_flutter/features/book_suggestions/data/models/book_suggestion.dart';
+import 'package:lib_42_flutter/features/book_suggestions/data/models/collection_period.dart';
+import 'package:lib_42_flutter/features/book_suggestions/data/repositories/admin_suggestion_repository_impl.dart';
+import 'package:lib_42_flutter/features/book_suggestions/domain/repositories/admin_suggestion_repository.dart';
+
+import '../../../../support/fake_dio_adapter.dart';
+import '../../../../support/fake_secure_storage_service.dart';
+
+AdminSuggestionRepositoryImpl _build(FakeDioAdapter adapter,
+    {String? adminToken}) {
+  final dio = Dio(BaseOptions(
+    baseUrl: 'https://api.test',
+    validateStatus: (s) => s != null && s < 500,
+  ));
+  dio.httpClientAdapter = adapter;
+  return AdminSuggestionRepositoryImpl(
+    baseUrl: 'https://api.test',
+    httpClient: dio,
+    storage: FakeSecureStorageService(adminToken: adminToken),
+  );
+}
+
+const _suggestionJson = {
+  'id': 's1',
+  'studentId': 'stu-1',
+  'suggestedTitle': '클린 아키텍처',
+  'suggestedAuthor': 'R. Martin',
+  'reason': '학습용',
+  'collectionPeriodId': 'p1',
+  'status': 'submitted',
+  'submittedAt': '2024-02-01T00:00:00.000Z',
+};
+
+const _groupedJson = {
+  'suggestedTitle': '클린 아키텍처',
+  'suggestedAuthor': 'R. Martin',
+  'collectionPeriodId': 'p1',
+  'requesterCount': 2,
+  'statuses': {'submitted': 1, 'approved': 1},
+  'latestSubmittedAt': '2024-02-01T00:00:00.000Z',
+  'items': [_suggestionJson],
+};
+
+const _periodJson = {
+  'id': 'p1',
+  'name': '2024 Q1',
+  'startDate': '2024-01-01T00:00:00.000Z',
+  'endDate': '2024-03-31T00:00:00.000Z',
+  'status': 'active',
+};
+
+void main() {
+  group('AdminSuggestionRepositoryImpl', () {
+    test('fetchGrouped parses grouped payload', () async {
+      final adapter = FakeDioAdapter()..enqueue(bodyList: [_groupedJson]);
+      final repo = _build(adapter);
+
+      final groups = await repo.fetchGrouped();
+
+      expect(groups, hasLength(1));
+      expect(groups.first.suggestedTitle, '클린 아키텍처');
+      expect(groups.first.requesterCount, 2);
+      expect(adapter.requests.single.path, '/v1/suggestions');
+    });
+
+    test('fetchGrouped passes periodId as query param', () async {
+      final adapter = FakeDioAdapter()..enqueue(bodyList: const []);
+      final repo = _build(adapter);
+
+      await repo.fetchGrouped(periodId: 'p99');
+
+      expect(adapter.requests.single.queryParameters['periodId'], 'p99');
+    });
+
+    test('fetchGrouped throws AdminSuggestionException on non-200', () async {
+      // 4xx is below the 500 threshold so it returns to user code (does not
+      // throw at Dio level), then the repository explicitly rejects non-200.
+      final adapter = FakeDioAdapter()
+        ..enqueue(statusCode: 401, body: {'error': 'unauthorized'});
+      final repo = _build(adapter);
+
+      await expectLater(
+        repo.fetchGrouped(),
+        throwsA(isA<AdminSuggestionException>()
+            .having((e) => e.code, 'code', 'fetch_failed')),
+      );
+    });
+
+    test('review returns updated suggestion with approved status', () async {
+      final adapter = FakeDioAdapter()
+        ..enqueue(statusCode: 200, body: {
+          'data': {..._suggestionJson, 'status': 'approved'},
+        });
+      final repo = _build(adapter);
+
+      final updated = await repo.review('s1',
+          status: SuggestionStatus.approved, adminNotes: '구매 예정');
+
+      expect(updated.id, 's1');
+      expect(updated.status, SuggestionStatus.approved);
+      expect(adapter.requests.single.method, 'PUT');
+      expect(adapter.requests.single.path, '/v1/suggestions/s1/status');
+      expect(adapter.lastRequestBody['status'], 'approved');
+      expect(adapter.lastRequestBody['adminNotes'], '구매 예정');
+    });
+
+    test('review converts underReview to wire form `under_review`', () async {
+      final adapter = FakeDioAdapter()
+        ..enqueue(statusCode: 200, body: {
+          'data': {..._suggestionJson, 'status': 'under_review'},
+        });
+      final repo = _build(adapter);
+
+      await repo.review('s1', status: SuggestionStatus.underReview);
+
+      expect(adapter.lastRequestBody['status'], 'under_review');
+      // adminNotes omitted when null/empty.
+      expect(adapter.lastRequestBody.containsKey('adminNotes'), isFalse);
+    });
+
+    test('review surfaces backend error message', () async {
+      final adapter = FakeDioAdapter()
+        ..enqueue(statusCode: 400, body: {
+          'error': 'invalid_status',
+          'message': '상태 전환이 허용되지 않습니다.',
+        });
+      final repo = _build(adapter);
+
+      await expectLater(
+        repo.review('s1', status: SuggestionStatus.approved),
+        throwsA(isA<AdminSuggestionException>()
+            .having((e) => e.code, 'code', 'invalid_status')
+            .having((e) => e.message, 'message', '상태 전환이 허용되지 않습니다.')),
+      );
+    });
+
+    test('createPeriod posts payload and returns CollectionPeriod', () async {
+      final adapter = FakeDioAdapter()
+        ..enqueue(statusCode: 201, body: {'data': _periodJson});
+      final repo = _build(adapter);
+
+      final period = await repo.createPeriod(
+        name: '2024 Q1',
+        startDate: DateTime.utc(2024, 1, 1),
+        endDate: DateTime.utc(2024, 3, 31),
+        status: PeriodStatus.active,
+      );
+
+      expect(period.id, 'p1');
+      expect(period.status, PeriodStatus.active);
+      expect(adapter.requests.single.path, '/v1/collection-periods');
+      expect(adapter.lastRequestBody['name'], '2024 Q1');
+      expect(adapter.lastRequestBody['status'], 'active');
+    });
+
+    test('createPeriod surfaces backend error message', () async {
+      final adapter = FakeDioAdapter()
+        ..enqueue(statusCode: 400, body: {
+          'error': 'validation_error',
+          'message': '시작일이 종료일보다 늦을 수 없습니다.',
+        });
+      final repo = _build(adapter);
+
+      await expectLater(
+        repo.createPeriod(
+          name: 'X',
+          startDate: DateTime.utc(2024, 4, 1),
+          endDate: DateTime.utc(2024, 1, 1),
+        ),
+        throwsA(isA<AdminSuggestionException>()
+            .having((e) => e.code, 'code', 'validation_error')),
+      );
+    });
+
+    test('admin token is attached as Authorization header', () async {
+      final adapter = FakeDioAdapter()..enqueue(bodyList: const []);
+      final repo = _build(adapter, adminToken: 'admin-token');
+
+      await repo.fetchGrouped();
+
+      expect(adapter.requests.single.headers['Authorization'],
+          'Bearer admin-token');
+    });
+  });
+}

--- a/test/support/fake_dio_adapter.dart
+++ b/test/support/fake_dio_adapter.dart
@@ -1,0 +1,69 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+
+/// Minimal Dio adapter for tests. Records every request and serves canned
+/// responses queued via [enqueue]. The default response when the queue is
+/// empty is 200 OK with the body `{ "data": [] }`, which keeps tests forgiving
+/// about unrelated bookkeeping calls.
+class FakeDioAdapter implements HttpClientAdapter {
+  final List<RequestOptions> requests = [];
+  final List<_FakeResponse> _queue = [];
+  bool throwTimeout = false;
+
+  void enqueue({
+    int statusCode = 200,
+    Map<String, dynamic>? body,
+    List<dynamic>? bodyList,
+    String? rawBody,
+  }) {
+    final encoded = rawBody ??
+        jsonEncode(bodyList != null ? {'data': bodyList} : (body ?? {}));
+    _queue.add(_FakeResponse(statusCode: statusCode, body: encoded));
+  }
+
+  /// Most recent request's body decoded as JSON. Throws if no requests.
+  Map<String, dynamic> get lastRequestBody {
+    final r = requests.last;
+    final raw = r.data;
+    if (raw is Map<String, dynamic>) return raw;
+    if (raw is String) return jsonDecode(raw) as Map<String, dynamic>;
+    throw StateError('Unsupported request body type: ${raw.runtimeType}');
+  }
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<dynamic>? cancelFuture,
+  ) async {
+    requests.add(options);
+    if (throwTimeout) {
+      throw DioException(
+        requestOptions: options,
+        type: DioExceptionType.connectionTimeout,
+        message: 'fake timeout',
+      );
+    }
+    final canned = _queue.isNotEmpty
+        ? _queue.removeAt(0)
+        : _FakeResponse(statusCode: 200, body: jsonEncode({'data': []}));
+    return ResponseBody.fromString(
+      canned.body,
+      canned.statusCode,
+      headers: {
+        Headers.contentTypeHeader: ['application/json; charset=utf-8'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+class _FakeResponse {
+  _FakeResponse({required this.statusCode, required this.body});
+  final int statusCode;
+  final String body;
+}

--- a/test/support/fake_secure_storage_service.dart
+++ b/test/support/fake_secure_storage_service.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_secure_storage_platform_interface/flutter_secure_storage_platform_interface.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lib_42_flutter/services/storage/secure_storage_service.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+/// Stand-in for [SecureStorageService] that doesn't touch the platform
+/// channel. Only [readAdminToken] is exposed — extend as needed.
+class FakeSecureStorageService extends SecureStorageService {
+  FakeSecureStorageService({this.adminToken = 'test-admin-token'})
+      : super(storage: const _NoopFlutterSecureStorage());
+
+  String? adminToken;
+
+  @override
+  Future<String?> readAdminToken() async => adminToken;
+}
+
+/// FlutterSecureStorage that throws if any platform call slips through.
+/// Construction requires no platform channel because we never call into it.
+class _NoopFlutterSecureStorage implements FlutterSecureStorage {
+  const _NoopFlutterSecureStorage();
+
+  @override
+  noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('Real storage call leaked into test');
+}
+
+/// Optional helper: install a no-op platform handler so any code path that
+/// instantiates a real SecureStorageService doesn't crash. Call from
+/// `setUpAll` if needed.
+void installNoopSecureStoragePlatform() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  FlutterSecureStoragePlatform.instance = _NoopPlatform();
+}
+
+class _NoopPlatform extends FlutterSecureStoragePlatform with MockPlatformInterfaceMixin {
+  @override
+  Future<bool> containsKey(
+          {required String key, required Map<String, String> options}) async =>
+      false;
+
+  @override
+  Future<void> delete(
+      {required String key, required Map<String, String> options}) async {}
+
+  @override
+  Future<void> deleteAll({required Map<String, String> options}) async {}
+
+  @override
+  Future<String?> read(
+          {required String key, required Map<String, String> options}) async =>
+      null;
+
+  @override
+  Future<Map<String, String>> readAll(
+          {required Map<String, String> options}) async =>
+      {};
+
+  @override
+  Future<void> write(
+      {required String key,
+      required String value,
+      required Map<String, String> options}) async {}
+}


### PR DESCRIPTION
Closes #119

## 범위

**v0.5.0 — Phase 11 하드닝 1차 묶음**

### 머지된 PR
- #114 backend reservation_service 단위 테스트 + reorderQueue latent 버그 수정
- #116 Flutter admin HTTP repository impls 단위 테스트 (재사용 가능한 FakeDioAdapter / FakeSecureStorageService 추가)
- #118 backend loan_request_service 단위 테스트

### 효과

| | Before | After | Δ |
|--|--|--|--|
| Backend coverage | 65.4% | **73.4%** | +8.0% |
| Flutter coverage | 61.3% | **67.1%** | +5.8% |
| Backend 테스트 | 74 | **102** | +28 |
| Flutter 테스트 | 136 | **154** | +18 |

### 주요 버그 수정 (운영 영향)

**`reorderQueue`**: `@@unique([bookId, queuePosition])` 제약 때문에 cancelled/expired 행이 positive 슬롯을 점유하면 활성 행 압축 실패. 트랜잭션 + 2-phase 업데이트로 수정 (모든 행을 음수 슬롯에 일단 파킹 → 활성 행만 1..N 재배치). 다운스트림 모두 status 필터링이라 비활성 음수 위치 무해.

## Deferred (v0.5.x로)

- backend `auth_42_service.ts` 43% (OAuth, mocking 까다로움)
- Flutter `secure_storage_service.dart` 0%, `auth_bloc.dart` 0% (플랫폼 채널 의존성)

## Test plan

- [x] 누적 backend 102/102, flutter 154/154
- [x] CI green (analyze + test + web build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)