### PR TITLE
[#123] 📝 docs: T231 + T232 — README 업데이트 + .env.example 정리

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,12 +92,18 @@ cd 42lib-flutter
 #### 1단계: 환경 변수 설정
 
 ```bash
-# Backend 환경 변수 파일 확인 (이미 생성되어 있음)
-cat backend/.env
+# 템플릿 복사 (각 변수의 의미·기본값·필수 여부는 파일 안 주석 참고)
+cp backend/.env.example backend/.env
 
-# 필요한 경우 42 OAuth 정보 업데이트
-# FORTYTWO_CLIENT_ID, FORTYTWO_CLIENT_SECRET 설정
+# 학생 로그인을 동작시키려면 42 OAuth 정보 필수:
+# https://profile.intra.42.fr/oauth/applications 에서 앱 생성 후
+# FORTYTWO_CLIENT_ID, FORTYTWO_CLIENT_SECRET, FORTYTWO_REDIRECT_URI 채우기
+#
+# JWT_SECRET은 운영 배포 전 반드시 교체:
+# openssl rand -hex 32
 ```
+
+> Docker Compose는 `backend/.env`가 없어도 `docker-compose.yml`의 기본값으로 동작합니다 (개발 편의). 운영/스테이징은 반드시 `.env`로 명시 주입하세요.
 
 #### 2단계: Docker Compose로 전체 스택 실행
 
@@ -166,6 +172,8 @@ docker-compose exec redis-cache redis-cli ping
 **Backend API** (자동 실행됨):
 - 포트: `http://localhost:3000`
 - API 엔드포인트: `http://localhost:3000/api/v1`
+- API 문서 (Swagger UI): `http://localhost:3000/api/docs`
+- 원본 OpenAPI JSON: `http://localhost:3000/api/docs/openapi.json`
 - Health Check: `http://localhost:3000/health`
 
 **Flutter Web 개발 서버**:
@@ -401,39 +409,27 @@ CI/CD 전략 (Constitution XVI):
    http://localhost:8080
    ```
 
-### 현재 구현된 기능 (User Story 1)
+### 현재 출하 상태 (v0.5.0)
 
-- ✅ 도서 목록 화면 (Grid/List 레이아웃)
-- ✅ 도서 검색 바 (Debounce 지원)
-- ✅ 도서 카드 (표지, 정보, 대출 가능 여부)
-- ✅ 반응형 레이아웃
-- ✅ 23개 자동화 테스트 (100% 통과)
+학생 앱 (Flutter mobile/web):
+- ✅ US1 — 도서 검색·목록·상세 (반응형 Grid/List, 검색 debounce)
+- ✅ US2 — 대출 신청 + 예약 큐 (FIFO, 24h 만료)
+- ✅ US3 — 도서 추천 제출 + 활성 수집 기간 표시
 
-### 테스트 시나리오
+관리자 대시보드 (Flutter web):
+- ✅ US4 — 카탈로그 관리 (도서 CRUD, 재고 관리)
+- ✅ US5 — 대출 추적·승인·반납
+- ✅ US6 — 도서 추천 검토, 수집 기간 관리, 승인 추천 → 카탈로그 직행 (T196)
 
-**시나리오 1: 도서 목록 확인**
-- 브라우저에서 초기 화면 로드
-- Grid 레이아웃으로 도서 카드 표시 확인
-- 도서 정보 (제목, 저자, 대출 가능 여부) 표시 확인
+품질 / 인프라:
+- ✅ Phase 11 1차 하드닝 — Backend 73.4%, Flutter 67.1% 커버리지 (v0.5.0)
+- ✅ `reorderQueue` latent 버그 수정 (`@@unique([bookId, queuePosition])` 충돌)
+- ✅ Swagger UI / OpenAPI JSON 노출 (`/api/docs`)
 
-**시나리오 2: 검색 기능**
-- 검색 바에 텍스트 입력
-- Debounce 동작 확인 (0.5초 후 반영)
-- 클리어 버튼으로 입력 초기화
-
-**시나리오 3: 반응형 테스트**
-- 브라우저 창 크기 조절
-- 큰 화면: 4열 Grid
-- 중간 화면: 2열 Grid  
-- 작은 화면: 1열 List
-
-### 알려진 제약사항
-
-- **데이터**: 하드코딩된 샘플 데이터 (42 API 연동은 User Story 4)
-- **상세 화면**: 미구현 (User Story 2)
-- **상태 관리**: Riverpod 미적용 (User Story 3)
-
-자세한 내용은 `docs/web-test-guide.md` 참조
+다음 (deferred):
+- T196 (카탈로그 직행)을 제외한 T197 추천 통계
+- Phase 11 2차 — auth 흐름 (OAuth, secure storage) 커버리지
+- Phase 12 잔여 — 배포 가이드, ADR 정리
 
 
 ## 🚀 빠른 시작 (Quick Start)

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,27 +1,58 @@
-# Database
+# 42lib Backend — Environment Variables
+#
+# 사용법:
+#   cp backend/.env.example backend/.env
+#   # 필요한 항목 채우기 (특히 JWT_SECRET, FORTYTWO_*)
+#
+# Docker Compose는 backend/.env가 없어도 docker-compose.yml의 environment
+# 블록 기본값으로 동작합니다 (개발 편의용). 운영/스테이징은 반드시 .env로
+# 명시 주입하세요.
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 데이터베이스 (필수)
+# ─────────────────────────────────────────────────────────────────────────────
+# Prisma용 PostgreSQL 연결 문자열. docker-compose.yml에서 기본값 주입됨.
 DATABASE_URL="postgresql://library_user:library_pass@postgres-db:5432/library_db?schema=public"
 
-# Redis Cache
-REDIS_HOST="redis-cache"
-REDIS_PORT=6379
-REDIS_PASSWORD=""
-
-# JWT
-JWT_SECRET="your-secret-key-change-in-production"
+# ─────────────────────────────────────────────────────────────────────────────
+# JWT (필수)
+# ─────────────────────────────────────────────────────────────────────────────
+# 운영 환경에서는 반드시 32+자 랜덤 시크릿으로 교체.
+# 노출 시 즉시 회전: openssl rand -hex 32
+JWT_SECRET="change-me-in-production-use-openssl-rand-hex-32"
+# 학생/관리자 토큰 만료 (jsonwebtoken 형식: "7d", "12h", "30m" 등)
 JWT_EXPIRES_IN="7d"
 
-# 42 API OAuth
+# ─────────────────────────────────────────────────────────────────────────────
+# 42 OAuth (필수 — 학생 로그인 동작에 필요)
+# ─────────────────────────────────────────────────────────────────────────────
+# https://profile.intra.42.fr/oauth/applications 에서 발급
 FORTYTWO_CLIENT_ID="your_42_client_id"
 FORTYTWO_CLIENT_SECRET="your_42_client_secret"
+# 콜백 URI는 42 앱 등록 정보와 정확히 일치해야 함
 FORTYTWO_REDIRECT_URI="http://localhost:3000/api/v1/auth/42/callback"
 
-# Server
+# ─────────────────────────────────────────────────────────────────────────────
+# 서버 (선택 — 모두 기본값 있음)
+# ─────────────────────────────────────────────────────────────────────────────
 PORT=3000
+# development | production | test (jest는 자동으로 test 설정)
 NODE_ENV="development"
 
-# Rate Limiting
+# Rate limit: windowMs 동안 max 요청을 초과하면 429.
+# 기본 60초/100req. 운영 환경에 맞춰 조정.
 RATE_LIMIT_WINDOW_MS=60000
 RATE_LIMIT_MAX_REQUESTS=100
 
-# Logging
-LOG_LEVEL="info"
+# Swagger UI (/api/docs)가 읽을 OpenAPI YAML 경로.
+# 미설정 시 Docker 볼륨 (/specs/...) → repo fallback 순으로 자동 해결.
+# 컨테이너 외부 배포에서 스펙을 별도 위치에 둘 때만 명시.
+# OPENAPI_SPEC_PATH="/specs/001-library-management/contracts/openapi.yaml"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 예약 — 아직 코드에서 참조하지 않음 (향후 캐시·로깅 모듈 도입 시 활성화)
+# ─────────────────────────────────────────────────────────────────────────────
+# REDIS_HOST="redis-cache"
+# REDIS_PORT=6379
+# REDIS_PASSWORD=""
+# LOG_LEVEL="info"

--- a/specs/001-library-management/tasks.md
+++ b/specs/001-library-management/tasks.md
@@ -486,8 +486,8 @@
 **Purpose**: Complete documentation and prepare for deployment
 
 - [X] T230 [P] Create API documentation with Swagger UI in backend/src/swagger.ts (mounts spec via docker volume; serves /api/docs and /api/docs/openapi.json)
-- [ ] T231 [P] Update README.md with final setup instructions (Korean)
-- [ ] T232 [P] Document environment variables in .env.example
+- [X] T231 [P] Update README.md with final setup instructions (Korean) — 환경 변수 단계 + Swagger URL + 현재 출하 상태(v0.5.0) 반영
+- [X] T232 [P] Document environment variables in .env.example — 섹션·필수 여부·기본값·OPENAPI_SPEC_PATH 추가
 - [ ] T233 [P] Create deployment guide in docs/deployment.md (Korean)
 - [ ] T234 [P] Create user manual for mobile app in docs/user-guide.md (Korean)
 - [ ] T235 [P] Create admin manual for web dashboard in docs/admin-guide.md (Korean)


### PR DESCRIPTION
Closes #123

## Summary

Phase 12 진행 중 두 작업을 한 PR로 묶음.

### T232 — `backend/.env.example`

- 섹션 헤더로 그룹화 (DB / JWT / 42 OAuth / 서버 / 예약)
- 변수별 **필수/선택** + 기본값 명시
- `JWT_SECRET` 운영 회전 가이드 (`openssl rand -hex 32`)
- `OPENAPI_SPEC_PATH` 추가 (PR #122 Swagger 스펙 경로 오버라이드)
- 미사용 변수 (`REDIS_*`, `LOG_LEVEL`)는 "예약" 섹션으로 분리

### T231 — `README.md`

- 환경 변수 단계: `cat backend/.env` → `cp backend/.env.example backend/.env` 로 정정. 42 OAuth / JWT_SECRET 가이드 추가.
- API 엔드포인트 섹션에 **Swagger UI** (`/api/docs`) + OpenAPI JSON URL 추가
- 거짓 정보였던 "현재 구현된 기능 (User Story 1)" 섹션 교체 — v0.5.0 기준 출하 상태 (US1-6 + 관리자 + Phase 11 + Swagger) + deferred 항목

## 의도적으로 안 건드린 것

README 후반부의 "🚀 빠른 시작 (Quick Start)" 섹션이 상단 "Docker 통합 개발 환경 구축"과 일부 중복되지만, 별도 정리 PR로 분리. 이 PR은 정확성 위주.

## Test plan

- [x] backend `npm test` 104/104 (회귀 없음)
- [x] 수동: `cat backend/.env.example` 가독성 확인
- [x] README 마크다운 렌더링 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)