### PR TITLE
[Release #125] v0.5.1 패치 — Swagger UI + 문서 정리

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,12 +92,18 @@ cd 42lib-flutter
 #### 1단계: 환경 변수 설정
 
 ```bash
-# Backend 환경 변수 파일 확인 (이미 생성되어 있음)
-cat backend/.env
+# 템플릿 복사 (각 변수의 의미·기본값·필수 여부는 파일 안 주석 참고)
+cp backend/.env.example backend/.env
 
-# 필요한 경우 42 OAuth 정보 업데이트
-# FORTYTWO_CLIENT_ID, FORTYTWO_CLIENT_SECRET 설정
+# 학생 로그인을 동작시키려면 42 OAuth 정보 필수:
+# https://profile.intra.42.fr/oauth/applications 에서 앱 생성 후
+# FORTYTWO_CLIENT_ID, FORTYTWO_CLIENT_SECRET, FORTYTWO_REDIRECT_URI 채우기
+#
+# JWT_SECRET은 운영 배포 전 반드시 교체:
+# openssl rand -hex 32
 ```
+
+> Docker Compose는 `backend/.env`가 없어도 `docker-compose.yml`의 기본값으로 동작합니다 (개발 편의). 운영/스테이징은 반드시 `.env`로 명시 주입하세요.
 
 #### 2단계: Docker Compose로 전체 스택 실행
 
@@ -166,6 +172,8 @@ docker-compose exec redis-cache redis-cli ping
 **Backend API** (자동 실행됨):
 - 포트: `http://localhost:3000`
 - API 엔드포인트: `http://localhost:3000/api/v1`
+- API 문서 (Swagger UI): `http://localhost:3000/api/docs`
+- 원본 OpenAPI JSON: `http://localhost:3000/api/docs/openapi.json`
 - Health Check: `http://localhost:3000/health`
 
 **Flutter Web 개발 서버**:
@@ -401,39 +409,27 @@ CI/CD 전략 (Constitution XVI):
    http://localhost:8080
    ```
 
-### 현재 구현된 기능 (User Story 1)
+### 현재 출하 상태 (v0.5.0)
 
-- ✅ 도서 목록 화면 (Grid/List 레이아웃)
-- ✅ 도서 검색 바 (Debounce 지원)
-- ✅ 도서 카드 (표지, 정보, 대출 가능 여부)
-- ✅ 반응형 레이아웃
-- ✅ 23개 자동화 테스트 (100% 통과)
+학생 앱 (Flutter mobile/web):
+- ✅ US1 — 도서 검색·목록·상세 (반응형 Grid/List, 검색 debounce)
+- ✅ US2 — 대출 신청 + 예약 큐 (FIFO, 24h 만료)
+- ✅ US3 — 도서 추천 제출 + 활성 수집 기간 표시
 
-### 테스트 시나리오
+관리자 대시보드 (Flutter web):
+- ✅ US4 — 카탈로그 관리 (도서 CRUD, 재고 관리)
+- ✅ US5 — 대출 추적·승인·반납
+- ✅ US6 — 도서 추천 검토, 수집 기간 관리, 승인 추천 → 카탈로그 직행 (T196)
 
-**시나리오 1: 도서 목록 확인**
-- 브라우저에서 초기 화면 로드
-- Grid 레이아웃으로 도서 카드 표시 확인
-- 도서 정보 (제목, 저자, 대출 가능 여부) 표시 확인
+품질 / 인프라:
+- ✅ Phase 11 1차 하드닝 — Backend 73.4%, Flutter 67.1% 커버리지 (v0.5.0)
+- ✅ `reorderQueue` latent 버그 수정 (`@@unique([bookId, queuePosition])` 충돌)
+- ✅ Swagger UI / OpenAPI JSON 노출 (`/api/docs`)
 
-**시나리오 2: 검색 기능**
-- 검색 바에 텍스트 입력
-- Debounce 동작 확인 (0.5초 후 반영)
-- 클리어 버튼으로 입력 초기화
-
-**시나리오 3: 반응형 테스트**
-- 브라우저 창 크기 조절
-- 큰 화면: 4열 Grid
-- 중간 화면: 2열 Grid  
-- 작은 화면: 1열 List
-
-### 알려진 제약사항
-
-- **데이터**: 하드코딩된 샘플 데이터 (42 API 연동은 User Story 4)
-- **상세 화면**: 미구현 (User Story 2)
-- **상태 관리**: Riverpod 미적용 (User Story 3)
-
-자세한 내용은 `docs/web-test-guide.md` 참조
+다음 (deferred):
+- T196 (카탈로그 직행)을 제외한 T197 추천 통계
+- Phase 11 2차 — auth 흐름 (OAuth, secure storage) 커버리지
+- Phase 12 잔여 — 배포 가이드, ADR 정리
 
 
 ## 🚀 빠른 시작 (Quick Start)

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,27 +1,58 @@
-# Database
+# 42lib Backend — Environment Variables
+#
+# 사용법:
+#   cp backend/.env.example backend/.env
+#   # 필요한 항목 채우기 (특히 JWT_SECRET, FORTYTWO_*)
+#
+# Docker Compose는 backend/.env가 없어도 docker-compose.yml의 environment
+# 블록 기본값으로 동작합니다 (개발 편의용). 운영/스테이징은 반드시 .env로
+# 명시 주입하세요.
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 데이터베이스 (필수)
+# ─────────────────────────────────────────────────────────────────────────────
+# Prisma용 PostgreSQL 연결 문자열. docker-compose.yml에서 기본값 주입됨.
 DATABASE_URL="postgresql://library_user:library_pass@postgres-db:5432/library_db?schema=public"
 
-# Redis Cache
-REDIS_HOST="redis-cache"
-REDIS_PORT=6379
-REDIS_PASSWORD=""
-
-# JWT
-JWT_SECRET="your-secret-key-change-in-production"
+# ─────────────────────────────────────────────────────────────────────────────
+# JWT (필수)
+# ─────────────────────────────────────────────────────────────────────────────
+# 운영 환경에서는 반드시 32+자 랜덤 시크릿으로 교체.
+# 노출 시 즉시 회전: openssl rand -hex 32
+JWT_SECRET="change-me-in-production-use-openssl-rand-hex-32"
+# 학생/관리자 토큰 만료 (jsonwebtoken 형식: "7d", "12h", "30m" 등)
 JWT_EXPIRES_IN="7d"
 
-# 42 API OAuth
+# ─────────────────────────────────────────────────────────────────────────────
+# 42 OAuth (필수 — 학생 로그인 동작에 필요)
+# ─────────────────────────────────────────────────────────────────────────────
+# https://profile.intra.42.fr/oauth/applications 에서 발급
 FORTYTWO_CLIENT_ID="your_42_client_id"
 FORTYTWO_CLIENT_SECRET="your_42_client_secret"
+# 콜백 URI는 42 앱 등록 정보와 정확히 일치해야 함
 FORTYTWO_REDIRECT_URI="http://localhost:3000/api/v1/auth/42/callback"
 
-# Server
+# ─────────────────────────────────────────────────────────────────────────────
+# 서버 (선택 — 모두 기본값 있음)
+# ─────────────────────────────────────────────────────────────────────────────
 PORT=3000
+# development | production | test (jest는 자동으로 test 설정)
 NODE_ENV="development"
 
-# Rate Limiting
+# Rate limit: windowMs 동안 max 요청을 초과하면 429.
+# 기본 60초/100req. 운영 환경에 맞춰 조정.
 RATE_LIMIT_WINDOW_MS=60000
 RATE_LIMIT_MAX_REQUESTS=100
 
-# Logging
-LOG_LEVEL="info"
+# Swagger UI (/api/docs)가 읽을 OpenAPI YAML 경로.
+# 미설정 시 Docker 볼륨 (/specs/...) → repo fallback 순으로 자동 해결.
+# 컨테이너 외부 배포에서 스펙을 별도 위치에 둘 때만 명시.
+# OPENAPI_SPEC_PATH="/specs/001-library-management/contracts/openapi.yaml"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 예약 — 아직 코드에서 참조하지 않음 (향후 캐시·로깅 모듈 도입 시 활성화)
+# ─────────────────────────────────────────────────────────────────────────────
+# REDIS_HOST="redis-cache"
+# REDIS_PORT=6379
+# REDIS_PASSWORD=""
+# LOG_LEVEL="info"

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "42lib-backend",
-  "version": "0.1.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "42lib-backend",
-      "version": "0.1.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@prisma/client": "^5.7.0",
@@ -18,7 +18,9 @@
         "express-rate-limit": "^7.1.5",
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
+        "swagger-ui-express": "^5.0.1",
         "winston": "^3.11.0",
+        "yamljs": "^0.3.0",
         "zod": "^3.25.76"
       },
       "devDependencies": {
@@ -28,8 +30,13 @@
         "@types/jest": "^29.5.11",
         "@types/jsonwebtoken": "^9.0.5",
         "@types/node": "^20.10.6",
+        "@types/supertest": "^6.0.2",
+        "@types/swagger-ui-express": "^4.1.8",
+        "@types/yamljs": "^0.2.34",
         "jest": "^29.7.0",
         "prisma": "^5.7.0",
+        "supertest": "^7.0.0",
+        "ts-jest": "^29.1.1",
         "ts-node": "^10.9.2",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.3.3"
@@ -900,6 +907,29 @@
         "node-pre-gyp": "bin/node-pre-gyp"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
+    },
     "node_modules/@prisma/client": {
       "version": "5.22.0",
       "hasInstallScript": true,
@@ -955,6 +985,13 @@
       "dependencies": {
         "@prisma/debug": "5.22.0"
       }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -1067,6 +1104,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/cors": {
       "version": "2.8.19",
       "dev": true,
@@ -1149,6 +1193,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "dev": true,
@@ -1219,8 +1270,50 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/superagent": {
+      "version": "8.1.9",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
+      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-6.0.3.tgz",
+      "integrity": "sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
+      }
+    },
+    "node_modules/@types/swagger-ui-express": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.8.tgz",
+      "integrity": "sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
+      }
+    },
     "node_modules/@types/triple-beam": {
       "version": "1.3.5",
+      "license": "MIT"
+    },
+    "node_modules/@types/yamljs": {
+      "version": "0.2.34",
+      "resolved": "https://registry.npmjs.org/@types/yamljs/-/yamljs-0.2.34.tgz",
+      "integrity": "sha512-gJvfRlv9ErxdOv7ux7UsJVePtX54NAvQyd8ncoiFqK8G5aeHIfQfGH2fbruvjAQ9657HwAaO54waS+Dsk2QTUQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -1371,7 +1464,6 @@
     },
     "node_modules/argparse": {
       "version": "1.0.10",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
@@ -1379,6 +1471,13 @@
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
+      "license": "MIT"
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/async": {
@@ -1620,6 +1719,19 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/bser": {
@@ -1885,6 +1997,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "license": "MIT"
@@ -1924,6 +2046,13 @@
     },
     "node_modules/cookie-signature": {
       "version": "1.0.7",
+      "license": "MIT"
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -2044,6 +2173,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/diff": {
@@ -2326,6 +2466,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
       "dev": true,
@@ -2415,6 +2562,24 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -2610,6 +2775,28 @@
       "version": "4.2.11",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -3636,6 +3823,13 @@
       "version": "4.0.1",
       "license": "MIT"
     },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.once": {
       "version": "4.1.1",
       "license": "MIT"
@@ -3855,6 +4049,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/node-addon-api": {
       "version": "5.1.0",
@@ -4367,7 +4568,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.3",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -4542,7 +4745,6 @@
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/stack-trace": {
@@ -4638,6 +4840,106 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/superagent/node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "dev": true,
@@ -4658,6 +4960,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.32.5",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.5.tgz",
+      "integrity": "sha512-7/FQfWe9A4qoyYFdAwy0chD0uDYidDp/ZT9VQ9LZlgD4AnnHJk8/+ytAA1HkJYOPySmK6helPDdJQMlcumt7HA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/tar": {
@@ -4736,6 +5062,72 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/ts-jest": {
+      "version": "29.4.9",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.9.tgz",
+      "integrity": "sha512-LTb9496gYPMCqjeDLdPrKuXtncudeV1yRZnF4Wo5l3SFi0RYEnYRNgMrFIdg+FHvfzjCyQk1cLncWVqiSX+EvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bs-logger": "^0.2.6",
+        "fast-json-stable-stringify": "^2.1.0",
+        "handlebars": "^4.7.9",
+        "json5": "^2.2.3",
+        "lodash.memoize": "^4.1.2",
+        "make-error": "^1.3.6",
+        "semver": "^7.7.4",
+        "type-fest": "^4.41.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/transform": "^29.0.0 || ^30.0.0",
+        "@jest/types": "^29.0.0 || ^30.0.0",
+        "babel-jest": "^29.0.0 || ^30.0.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "jest-util": "^29.0.0 || ^30.0.0",
+        "typescript": ">=4.3 <7"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/transform": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jest-util": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-jest/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ts-node": {
@@ -4893,6 +5285,20 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "dev": true,
@@ -5043,6 +5449,13 @@
         "node": ">= 12.0.0"
       }
     },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "dev": true,
@@ -5095,6 +5508,20 @@
       "version": "3.1.1",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yamljs": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/yamljs/-/yamljs-0.3.0.tgz",
+      "integrity": "sha512-C/FsVVhht4iPQYXOInoxUM/1ELSf9EsgKH34FofQOp6hwCPrW4vG4w5++TED3xRUo8gD7l0P1J1dLlDYzODsTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "glob": "^7.0.5"
+      },
+      "bin": {
+        "json2yaml": "bin/json2yaml",
+        "yaml2json": "bin/yaml2json"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "42lib-backend",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "42 Learning Space Library Management System - Backend API",
   "main": "src/server.ts",
   "scripts": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -31,7 +31,9 @@
     "express-rate-limit": "^7.1.5",
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
+    "swagger-ui-express": "^5.0.1",
     "winston": "^3.11.0",
+    "yamljs": "^0.3.0",
     "zod": "^3.25.76"
   },
   "devDependencies": {
@@ -42,6 +44,8 @@
     "@types/jsonwebtoken": "^9.0.5",
     "@types/node": "^20.10.6",
     "@types/supertest": "^6.0.2",
+    "@types/swagger-ui-express": "^4.1.8",
+    "@types/yamljs": "^0.2.34",
     "jest": "^29.7.0",
     "prisma": "^5.7.0",
     "supertest": "^7.0.0",

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -12,6 +12,7 @@ import loanRoutes from './routes/loans';
 import adminRoutes from './routes/admin';
 import suggestionRoutes from './routes/suggestions';
 import collectionPeriodRoutes from './routes/collection_periods';
+import { buildSwaggerRouter } from './swagger';
 
 const app: Express = express();
 const prisma = new PrismaClient();
@@ -49,6 +50,10 @@ app.get('/api/v1', (req, res) => {
   res.json({ message: '42lib API v1', status: 'ready' });
 });
 
+// API documentation (Swagger UI + raw OpenAPI JSON). Mount before the
+// error handler so swagger-ui's HTML/JSON aren't intercepted.
+app.use('/api/docs', buildSwaggerRouter());
+
 // 에러 핸들링 미들웨어 (마지막에 추가)
 app.use(errorHandler);
 
@@ -59,6 +64,7 @@ if (process.env.NODE_ENV !== 'test') {
     logger.info(`📚 42lib Backend API v1`);
     logger.info(`🔗 Health: http://localhost:${PORT}/health`);
     logger.info(`🔗 API: http://localhost:${PORT}/api/v1`);
+    logger.info(`📖 Docs: http://localhost:${PORT}/api/docs`);
   });
 }
 

--- a/backend/src/swagger.ts
+++ b/backend/src/swagger.ts
@@ -1,0 +1,81 @@
+// T230: Swagger UI middleware that exposes the OpenAPI contract at /api/docs.
+// The OpenAPI spec is the single source of truth and lives in
+// specs/001-library-management/contracts/openapi.yaml.
+
+import path from 'path';
+import { Router } from 'express';
+import swaggerUi from 'swagger-ui-express';
+import YAML from 'yamljs';
+import { logger } from './utils/logger';
+
+// Resolution order:
+//   1. OPENAPI_SPEC_PATH env override (deploy-friendly)
+//   2. /specs/... (Docker volume mount — see docker-compose.yml)
+//   3. ../../specs/... (repo layout when running outside Docker)
+function resolveSpecPath(): string {
+  const candidates = [
+    process.env.OPENAPI_SPEC_PATH,
+    '/specs/001-library-management/contracts/openapi.yaml',
+    path.resolve(
+      __dirname,
+      '..',
+      '..',
+      'specs',
+      '001-library-management',
+      'contracts',
+      'openapi.yaml',
+    ),
+  ].filter((p): p is string => Boolean(p));
+
+  for (const candidate of candidates) {
+    try {
+      // Throws if not readable. fs.statSync would also work — keeping the
+      // require here cheap by deferring to YAML.load below.
+      require('fs').accessSync(candidate);
+      return candidate;
+    } catch {
+      // try next
+    }
+  }
+  return candidates[candidates.length - 1];
+}
+
+const SPEC_PATH = resolveSpecPath();
+
+export function buildSwaggerRouter(): Router {
+  const router = Router();
+  let document: object | null = null;
+
+  try {
+    document = YAML.load(SPEC_PATH);
+  } catch (error: any) {
+    logger.error('Failed to load OpenAPI spec for /api/docs', {
+      path: SPEC_PATH,
+      error: error.message,
+    });
+  }
+
+  if (!document) {
+    router.get('/', (_req, res) => {
+      res.status(503).json({
+        error: 'openapi_unavailable',
+        message: 'OpenAPI 스펙을 로드하지 못했습니다.',
+      });
+    });
+    return router;
+  }
+
+  // Raw spec for tooling (Postman / contract tests / codegen).
+  router.get('/openapi.json', (_req, res) => res.json(document));
+
+  router.use(
+    '/',
+    swaggerUi.serve,
+    swaggerUi.setup(document, {
+      customSiteTitle: '42 Library API',
+      swaggerOptions: { displayRequestDuration: true },
+    }),
+  );
+
+  return router;
+}

--- a/backend/tests/unit/swagger.test.ts
+++ b/backend/tests/unit/swagger.test.ts
@@ -1,0 +1,26 @@
+// T230: smoke test for /api/docs (Swagger UI) + /api/docs/openapi.json.
+// We only assert on stable, content-agnostic shape so the test doesn't have
+// to be touched every time the OpenAPI spec evolves.
+
+import request from 'supertest';
+import { app } from '../../src/server';
+
+describe('GET /api/docs (T230 — Swagger UI)', () => {
+  it('serves Swagger UI HTML at /api/docs/', async () => {
+    const res = await request(app).get('/api/docs/').expect(200);
+    expect(res.headers['content-type']).toMatch(/html/);
+    expect(res.text).toContain('swagger-ui');
+  });
+
+  it('serves the raw OpenAPI document at /api/docs/openapi.json', async () => {
+    const res = await request(app)
+      .get('/api/docs/openapi.json')
+      .expect(200)
+      .expect('content-type', /json/);
+
+    expect(res.body.openapi).toMatch(/^3\./);
+    expect(res.body.info?.title).toContain('42');
+    expect(res.body.paths).toBeDefined();
+    expect(Object.keys(res.body.paths).length).toBeGreaterThan(0);
+  });
+});

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -49,6 +49,9 @@ services:
       - ../backend:/app
       - /app/node_modules
       - ../backend/logs:/app/logs
+      # Mount the OpenAPI contract read-only so /api/docs (Swagger UI) can
+      # serve it without duplicating the spec inside backend/.
+      - ../specs:/specs:ro
     working_dir: /app
     ports:
       - "3000:3000"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lib_42_flutter
 description: 42 Learning Space Library Management System - Flutter App
 publish_to: 'none'
-version: 0.5.0+1
+version: 0.5.1+1
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/specs/001-library-management/tasks.md
+++ b/specs/001-library-management/tasks.md
@@ -486,8 +486,8 @@
 **Purpose**: Complete documentation and prepare for deployment
 
 - [X] T230 [P] Create API documentation with Swagger UI in backend/src/swagger.ts (mounts spec via docker volume; serves /api/docs and /api/docs/openapi.json)
-- [ ] T231 [P] Update README.md with final setup instructions (Korean)
-- [ ] T232 [P] Document environment variables in .env.example
+- [X] T231 [P] Update README.md with final setup instructions (Korean) — 환경 변수 단계 + Swagger URL + 현재 출하 상태(v0.5.0) 반영
+- [X] T232 [P] Document environment variables in .env.example — 섹션·필수 여부·기본값·OPENAPI_SPEC_PATH 추가
 - [ ] T233 [P] Create deployment guide in docs/deployment.md (Korean)
 - [ ] T234 [P] Create user manual for mobile app in docs/user-guide.md (Korean)
 - [ ] T235 [P] Create admin manual for web dashboard in docs/admin-guide.md (Korean)

--- a/specs/001-library-management/tasks.md
+++ b/specs/001-library-management/tasks.md
@@ -485,7 +485,7 @@
 
 **Purpose**: Complete documentation and prepare for deployment
 
-- [ ] T230 [P] Create API documentation with Swagger UI in backend/src/swagger.ts
+- [X] T230 [P] Create API documentation with Swagger UI in backend/src/swagger.ts (mounts spec via docker volume; serves /api/docs and /api/docs/openapi.json)
 - [ ] T231 [P] Update README.md with final setup instructions (Korean)
 - [ ] T232 [P] Document environment variables in .env.example
 - [ ] T233 [P] Create deployment guide in docs/deployment.md (Korean)


### PR DESCRIPTION
Closes #125

## 범위

**v0.5.1 패치 — Phase 12 첫 묶음**

### 머지된 PR
- #122 (T230) — Swagger UI / OpenAPI JSON @ `/api/docs`
- #124 (T231+T232) — README + `.env.example` 정리

## 효과

| | 효과 |
|--|--|
| `/api/docs/` | Swagger UI HTML — 배포된 인스턴스 즉시 탐색 |
| `/api/docs/openapi.json` | 원본 OpenAPI JSON — codegen / Postman / 계약 테스트 |
| `backend/.env.example` | 섹션·필수 표시·기본값·`OPENAPI_SPEC_PATH` 추가 |
| `README.md` | v0.5.0 기준 "현재 출하 상태" + Swagger URL 노출, 거짓 정보 정정 |
| docker-compose | `../specs:/specs:ro` 마운트 (스펙 단일 진실의 원천 유지) |

## Test plan

- [x] backend `npm test` 104/104
- [x] CI green (analyze + test + web build)
- [x] 수동: `curl http://localhost:3000/api/docs/` → 200 HTML
- [x] 수동: `curl http://localhost:3000/api/docs/openapi.json` → 200 JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)