### PR TITLE
[Release #141] v0.5.4 패치 — Phase 12 운영 가이드 묶음

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ GitHub Actions를 통한 자동화:
 ### 운영 가이드
 - [42 OAuth 등록 가이드](docs/guides/42-oauth-setup.md) - 학생 로그인 활성화에 필요한 자격증명 발급 및 주입 절차
 - [데이터베이스 백업 / 복원](docs/guides/database-backup-restore.md) - 수동 백업 / 복원 / 자동화 / 마이그레이션과의 관계
+- [CI/CD 파이프라인](docs/guides/ci-cd-pipeline.md) - GitHub Actions 트리거·job 그래프·커버리지 게이트·알려진 한계
 
 ## 기여 방법
 

--- a/README.md
+++ b/README.md
@@ -333,6 +333,10 @@ GitHub Actions를 통한 자동화:
 - [문서 디렉토리](docs/) - 모든 프로젝트 문서 (한글)
 - [GitHub Wiki](../../wiki) - 문서 검색 및 탐색
 
+### 운영 가이드
+- [42 OAuth 등록 가이드](docs/guides/42-oauth-setup.md) - 학생 로그인 활성화에 필요한 자격증명 발급 및 주입 절차
+- [데이터베이스 백업 / 복원](docs/guides/database-backup-restore.md) - 수동 백업 / 복원 / 자동화 / 마이그레이션과의 관계
+
 ## 기여 방법
 
 1. 이슈 생성 (한글)

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "42lib-backend",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "42 Learning Space Library Management System - Backend API",
   "main": "src/server.ts",
   "scripts": {

--- a/docs/guides/42-oauth-setup.md
+++ b/docs/guides/42-oauth-setup.md
@@ -1,0 +1,105 @@
+# 42 OAuth 등록 가이드
+
+> **목적**: 학생 로그인을 동작시키려면 42 인트라넷에서 OAuth 앱을 등록하고 그 자격증명을 백엔드에 주입해야 합니다. 이 문서는 첫 설치 시 따라가는 절차 입니다.
+
+## 사전 요구
+
+- 42 인트라넷 계정 (학생 또는 직원).
+- 운영/스테이징 도메인 또는 로컬 dev URL 결정.
+
+## 절차
+
+### 1. 42 OAuth 앱 등록
+
+1. https://profile.intra.42.fr/oauth/applications 접속 (42 인트라 로그인 필요).
+2. **Register a new app** 클릭.
+3. 폼 작성:
+
+   | 필드 | 값 |
+   |--|--|
+   | **Name** | `42lib (env)` 형태 권장 (예: `42lib (dev)`, `42lib (prod)`) |
+   | **Redirect URI** | 환경별로 정확히 일치해야 함. 아래 표 참고. |
+   | **Scopes** | `public` (현재 기본 scope; 학생 기본 정보만 필요) |
+
+   **Redirect URI 매트릭스**
+
+   | 환경 | Redirect URI |
+   |--|--|
+   | 로컬 dev (Docker) | `http://localhost:3000/api/v1/auth/42/callback` |
+   | 스테이징 | `https://staging.your-domain.kr/api/v1/auth/42/callback` |
+   | 운영 | `https://api.your-domain.kr/api/v1/auth/42/callback` |
+
+   여러 환경을 쓰려면 **환경별로 별도 앱을 생성**하세요. 한 앱에 여러 redirect URI를 섞으면 콜백이 의도와 다른 환경으로 갈 위험이 있습니다.
+
+4. 저장 후 화면에 표시되는 **UID** (= `client_id`) 와 **Secret** (= `client_secret`) 복사.
+
+   ⚠️ **Secret은 한 번만 표시됩니다**. 안전한 곳에 즉시 저장하세요. 분실 시 앱을 재등록하거나 secret을 회전해야 합니다.
+
+### 2. 백엔드에 자격증명 주입
+
+`backend/.env` (없으면 `cp backend/.env.example backend/.env`):
+
+```bash
+# 위 단계에서 복사한 값을 그대로 붙여넣기
+FORTYTWO_CLIENT_ID="u-s4t2ud-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+FORTYTWO_CLIENT_SECRET="s-s4t2ud-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+# 위 1단계의 Redirect URI와 정확히 일치
+FORTYTWO_REDIRECT_URI="http://localhost:3000/api/v1/auth/42/callback"
+```
+
+**비밀 보호**:
+- `backend/.env`는 `.gitignore`에 포함되어 있습니다. 절대 커밋하지 마세요.
+- 운영에서는 secrets manager (예: AWS Secrets Manager, GCP Secret Manager, Doppler) 사용을 권장합니다.
+- secret이 의심스럽게 노출됐으면 즉시 인트라 OAuth 앱 페이지에서 회전하세요.
+
+### 3. 백엔드 재시작 후 검증
+
+```bash
+# 컨테이너 재시작으로 새 .env 반영
+docker compose -f docker/docker-compose.yml restart backend-api
+
+# 로그에서 경고가 사라졌는지 확인
+docker compose -f docker/docker-compose.yml logs backend-api | grep -i "42 OAuth"
+# 정상: 아무 경고 없음
+# 비정상: "42 OAuth credentials not configured" → .env 미반영
+```
+
+`Auth42Service` 생성자는 자격증명이 없어도 죽지 않고 경고만 찍습니다 (관리자 흐름은 OAuth 없이 동작). 학생 로그인 시점에야 비로소 미설정이 에러로 표면화됩니다.
+
+### 4. 학생 로그인 종단 검증
+
+1. Flutter 앱 (web/mobile) 또는 직접 `GET /api/v1/auth/42/login` 호출.
+2. 42 인트라 로그인 페이지로 리디렉트되는지.
+3. 로그인 후 `FORTYTWO_REDIRECT_URI`로 돌아오면서 `?code=...` 쿼리 파라미터가 붙는지.
+4. 콜백 핸들러가 JWT를 발급하고 학생 레코드를 생성/갱신하는지.
+
+서비스 동작은 다음과 같이 단계화됩니다 (`backend/src/services/auth_42_service.ts`):
+
+1. `exchangeCodeForToken(code)` → 42 토큰 엔드포인트 POST.
+2. `getUserInfo(accessToken)` → 42 `/v2/me`로 프로필 조회.
+3. `findOrCreateStudent(fortyTwoUser)` → DB upsert (BR-102: 신규 생성, BR-103: 매 로그인마다 정보 갱신).
+4. 백엔드 JWT 서명 후 클라이언트에 응답.
+
+## 트러블슈팅
+
+| 증상 | 원인 | 해결 |
+|--|--|--|
+| `42 OAuth configuration missing` | 환경 변수 미주입 | `.env` 확인 후 컨테이너 재시작 |
+| 콜백 리디렉트 실패 (404 또는 mismatch) | Redirect URI 불일치 | 인트라 앱 등록 화면과 `.env`의 `FORTYTWO_REDIRECT_URI` 글자 단위로 일치시키기 (trailing slash 포함) |
+| `42 OAuth token exchange failed` | client_secret 오타 또는 회전됨 | 인트라에서 secret 재확인, 회전했으면 `.env` 업데이트 |
+| 학생 정보가 갱신되지 않음 | 정상 동작 (BR-103: 로그인 시점에만 갱신) | 학생이 다시 로그인하면 갱신됨 |
+
+## 보안 체크리스트
+
+- [ ] `.env`가 git에 커밋되지 않았는가
+- [ ] `JWT_SECRET`이 32자 이상의 랜덤 값인가 (`openssl rand -hex 32`)
+- [ ] 운영 redirect URI가 HTTPS인가
+- [ ] 운영 인스턴스에 secrets manager가 적용되었는가
+- [ ] secret 회전 절차가 문서화되었는가 (이 문서 + 운영 ADR)
+
+## 관련 문서
+
+- 백엔드 환경 변수 전체: `backend/.env.example`
+- API 문서 (Swagger UI): `http://localhost:3000/api/docs`
+- 데이터베이스 백업/복원: `docs/guides/database-backup-restore.md`

--- a/docs/guides/ci-cd-pipeline.md
+++ b/docs/guides/ci-cd-pipeline.md
@@ -1,0 +1,89 @@
+# CI/CD 파이프라인
+
+> **대상**: 기여자 / 운영자.
+> **소스**: `.github/workflows/ci.yml`, `codecov.yml`.
+
+이 문서는 GitHub Actions 파이프라인의 동작/규칙/한계를 설명합니다. workflow 자체가 단일 진실의 원천이며, 이 가이드는 그 의도를 풀어 적은 사이드카입니다.
+
+## 트리거
+
+| 이벤트 | 대상 브랜치 | 무엇이 실행되나 |
+|--|--|--|
+| `pull_request` | `dev`, `main` | analyze → test → build-web |
+| `push` | `dev`, `main` | analyze → test → build-web |
+| `push` (tag) | `v*` | analyze → test → build-web + **build-android + build-ios** |
+
+태그 (`v0.5.x` 등) 푸시에만 모바일 빌드가 도는 이유 — Constitution v1.10.0 결정. PR 피드백 시간을 보호하면서 릴리스 시점에는 모든 플랫폼 검증.
+
+## Job 그래프
+
+```
+analyze (Ubuntu, 항상)
+   │
+   └─▶ test (Ubuntu, 항상) ─────────────┬─▶ build-web (Ubuntu, 항상)
+                                        │
+                                        ├─▶ build-android (Ubuntu, 태그 푸시만)
+                                        │
+                                        └─▶ build-ios (macOS, 태그 푸시만)
+```
+
+`needs:` 의존성으로 직렬화되어 있어 analyze 실패 시 그 이후가 모두 스킵됩니다.
+
+## 각 Job의 검증 항목
+
+### `analyze` — 코드 분석
+
+- `flutter pub get`
+- `flutter analyze --no-fatal-infos` — error/warning만 실패 사유. info는 허용.
+- `dart format --set-exit-if-changed .` — 포맷 미적용 시 실패. CI는 자동 수정하지 않음 (로컬에서 `dart format .` 실행 후 커밋).
+
+### `test` — 단위 테스트
+
+- `flutter test --coverage` — `coverage/lcov.info` 생성.
+- `codecov/codecov-action@v3`로 업로드 → Codecov가 PR에 코멘트.
+
+### `build-web` — Flutter Web 릴리스 빌드
+
+- `flutter build web --release`
+- 산출물 `build/web/`을 `web-build` 아티팩트로 업로드 (배포 검증/수동 다운로드용).
+
+### `build-android` / `build-ios` — 모바일 릴리스 빌드 (태그 푸시 한정)
+
+- Android: `flutter build apk --release` → `app-release.apk` 아티팩트.
+- iOS: `flutter build ios --release --no-codesign` (CI에서는 코드 사인 안 함).
+
+## 커버리지 게이트 (`codecov.yml`)
+
+| 체크 | 기준 |
+|--|--|
+| `project` | 전체 커버리지가 baseline 대비 1%p 이상 하락하면 실패 (`target: auto`, `threshold: 1%`) |
+| `patch` | PR이 추가/변경한 라인의 50% 이상에 테스트 커버리지가 있어야 함 (`threshold: 5%` — 변동 허용) |
+
+baseline은 Codecov가 머지된 main 기준으로 자동 갱신합니다. 점진 상향은 PR 단위로 spec MVP 정의 (Backend/Flutter 80%)를 목표.
+
+## 알려진 한계 / TODO
+
+- **백엔드 테스트가 CI에서 돌지 않습니다**. `backend/tests/`의 100건 이상이 로컬에서만 검증되는 상태. 추가 job 필요 (TODO):
+  - `services` 블록으로 Postgres 16 띄우기
+  - `npm ci && npm run migrate && npm test` 실행
+  - lcov 업로드 (Flutter와 별도 flag로)
+- 모바일 빌드는 태그 푸시에만 실행 → PR에서 모바일 회귀 발견 불가. 로컬 `./scripts/local-verify.sh --mvp-mode`로 보완 (Constitution XVI).
+- iOS는 `--no-codesign` 빌드만 — 실제 .ipa는 별도 릴리스 파이프라인 필요 (App Store / TestFlight 결정 시).
+
+## 로컬에서 CI와 동일한 검사 돌리기
+
+```bash
+# 빠른 사전 검증 (CI analyze + test와 동등)
+./scripts/local-verify.sh --skip-build
+
+# 전체 (모바일 포함; MVP 전 정책)
+./scripts/local-verify.sh --mvp-mode
+```
+
+`scripts/local-verify.sh`는 `logs/YYYY-MM-DD/verify-*.log`에 기록을 남깁니다. CI 푸시 전 실패를 잡아 RTT를 줄이는 게 목적.
+
+## 머지 게이트
+
+- 1 approval 이상 + 모든 CI green이어야 dev/main 머지 가능 (자세한 정책은 `~/.claude/rules/code-review.md`).
+- `dev`/`main` 직접 푸시 금지 (Constitution).
+- feature 브랜치는 squash merge, release 브랜치는 merge commit (Git Flow + tag 추적성 유지).

--- a/docs/guides/database-backup-restore.md
+++ b/docs/guides/database-backup-restore.md
@@ -1,0 +1,144 @@
+# 데이터베이스 백업 / 복원 절차
+
+> **대상**: 운영 / 스테이징 인스턴스를 관리하는 운영자.
+> **DB 엔진**: PostgreSQL 16 (`docker/docker-compose.yml`의 `postgres-db` 서비스).
+
+## 큰 그림
+
+이 시스템은 두 가지 영속성을 사용합니다:
+
+1. **Postgres** — 모든 비즈니스 데이터 (도서, 학생, 대출, 예약, 추천 등). **반드시 백업해야 함**.
+2. **Redis** — 캐시 전용. 휘발성 OK. 백업 불필요.
+
+학생/관리자가 업로드한 파일은 현재 없습니다 (도서 표지는 외부 URL 참조).
+
+## 권장 정책 (recommended defaults)
+
+| 환경 | 빈도 | 보관 기간 | 도구 |
+|--|--|--|--|
+| 운영 (production) | 일 1회 + WAL 연속 | 30일 | `pg_dumpall` + cron + cloud storage |
+| 스테이징 | 주 1회 | 14일 | `pg_dump` + 로컬 |
+| 개발 | 즉시 시드 가능 | n/a | `make db-reset` + `npm run seed` |
+
+자세한 백업/복원 정책 ADR은 운영 환경 결정 시 추가합니다 (TODO).
+
+---
+
+## 1. 수동 백업 (full dump)
+
+### 1.1 컨테이너 내부에서 (개발/스테이징)
+
+```bash
+# 단일 DB 덤프 (custom format, pg_restore로 부분 복원 가능)
+docker compose -f docker/docker-compose.yml exec postgres-db \
+  pg_dump -U library_user -F c -d library_db > backup-$(date +%Y%m%d-%H%M%S).dump
+
+# 평문 SQL 덤프 (psql로 전체 적용 — 가독성 우선)
+docker compose -f docker/docker-compose.yml exec postgres-db \
+  pg_dump -U library_user library_db > backup-$(date +%Y%m%d-%H%M%S).sql
+```
+
+### 1.2 호스트에서 직접 (운영)
+
+운영 인스턴스가 호스트의 `5432`로 노출되어 있다면:
+
+```bash
+PGPASSWORD=$DB_PASSWORD pg_dump \
+  -h $DB_HOST -p 5432 -U $DB_USER -F c \
+  -d $DB_NAME > backup-$(date +%Y%m%d-%H%M%S).dump
+```
+
+**주의**: 운영에서는 `DATABASE_URL`을 환경 변수로 주입하고 위 변수도 거기서 파싱하세요. 시크릿을 명령 히스토리에 남기지 마세요.
+
+---
+
+## 2. 복원
+
+### 2.1 custom format dump 복원
+
+```bash
+# 컨테이너 내부 (테스트/스테이징)
+cat backup-20240315-093000.dump | \
+  docker compose -f docker/docker-compose.yml exec -T postgres-db \
+  pg_restore -U library_user -d library_db --clean --if-exists
+
+# 호스트 직접
+PGPASSWORD=$DB_PASSWORD pg_restore \
+  -h $DB_HOST -p 5432 -U $DB_USER -d $DB_NAME \
+  --clean --if-exists backup-20240315-093000.dump
+```
+
+`--clean --if-exists`는 기존 객체를 drop 후 복원합니다. 빈 DB로 복원하려면 빼도 됩니다.
+
+### 2.2 평문 SQL 덤프 복원
+
+```bash
+# 컨테이너
+cat backup-20240315-093000.sql | \
+  docker compose -f docker/docker-compose.yml exec -T postgres-db \
+  psql -U library_user -d library_db
+```
+
+### 2.3 복원 후 점검 체크리스트
+
+- [ ] `SELECT count(*) FROM books;` — 도서 수 일치
+- [ ] `SELECT count(*) FROM students;` — 학생 수 일치
+- [ ] `SELECT count(*) FROM loan_requests WHERE status = 'pending';` — pending 상태 보존
+- [ ] `SELECT count(*) FROM reservations WHERE status IN ('waiting','notified');` — 활성 예약 보존
+- [ ] `npm run migrate` — Prisma 스키마와 일치 확인 (필요 시 마이그레이션)
+- [ ] `/health` 엔드포인트 200 OK
+- [ ] 학생 로그인 + 관리자 로그인 한 번씩 수동 검증
+
+---
+
+## 3. 자동 백업 (cron 예시)
+
+운영 인스턴스 호스트에서:
+
+```bash
+# /etc/cron.d/lib42-backup (운영자 수정 필요)
+0 3 * * * lib42 /opt/lib42/scripts/backup-postgres.sh
+```
+
+`scripts/backup-postgres.sh` 예시 골격:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+TS=$(date +%Y%m%d-%H%M%S)
+DEST=${BACKUP_DIR:-/var/backups/lib42}
+mkdir -p "$DEST"
+PGPASSWORD="$DB_PASSWORD" pg_dump \
+  -h "$DB_HOST" -U "$DB_USER" -F c -d "$DB_NAME" \
+  | gzip > "$DEST/library_db-$TS.dump.gz"
+
+# 30일 이상 된 백업 정리
+find "$DEST" -name 'library_db-*.dump.gz' -mtime +30 -delete
+
+# (옵션) 클라우드 스토리지 업로드
+# aws s3 cp "$DEST/library_db-$TS.dump.gz" s3://your-backup-bucket/postgres/
+```
+
+이 스크립트는 아직 repo에 포함되어 있지 않습니다. 운영 환경 결정 시 추가 (TODO).
+
+---
+
+## 4. 마이그레이션과의 관계
+
+- `npm run migrate` (`prisma migrate deploy`)는 **스키마 변경**을 적용합니다. 데이터 백업과는 별개입니다.
+- 운영 배포 순서: **(1) DB 백업 → (2) 마이그레이션 → (3) 앱 배포**.
+- 마이그레이션은 항상 backwards-compatible로 작성합니다 (컬럼 추가는 nullable, 삭제는 단계적). 자세한 정책은 `~/.claude/rules/database.md` 참조.
+
+---
+
+## 5. 로컬 개발자에게: 빠른 초기화
+
+데이터를 통째로 날리고 시드 데이터로 다시 채우려면:
+
+```bash
+make db-reset       # 컨테이너 + 볼륨 재생성
+make db-migrate     # Prisma 스키마 적용
+docker compose -f docker/docker-compose.yml exec backend-api npm run seed
+```
+
+**경고**: `db-reset`은 모든 데이터를 삭제합니다. 운영에서는 절대 사용하지 마세요.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lib_42_flutter
 description: 42 Learning Space Library Management System - Flutter App
 publish_to: 'none'
-version: 0.5.3+1
+version: 0.5.4+1
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/specs/001-library-management/tasks.md
+++ b/specs/001-library-management/tasks.md
@@ -494,7 +494,7 @@
 - [ ] T236 Validate quickstart.md setup instructions
 - [X] T237 Create database backup and restore procedures — `docs/guides/database-backup-restore.md`
 - [X] T238 Document 42 OAuth setup instructions — `docs/guides/42-oauth-setup.md`
-- [ ] T239 Create CI/CD pipeline configuration in .github/workflows/ci.yml
+- [X] T239 Create CI/CD pipeline configuration in .github/workflows/ci.yml — workflow는 v0.1 시절부터 존재. 이번 PR은 동작/규칙/한계 문서화 (`docs/guides/ci-cd-pipeline.md`). 백엔드 테스트 CI 미실행 갭은 TODO로 명시.
 
 ---
 

--- a/specs/001-library-management/tasks.md
+++ b/specs/001-library-management/tasks.md
@@ -492,8 +492,8 @@
 - [ ] T234 [P] Create user manual for mobile app in docs/user-guide.md (Korean)
 - [ ] T235 [P] Create admin manual for web dashboard in docs/admin-guide.md (Korean)
 - [ ] T236 Validate quickstart.md setup instructions
-- [ ] T237 Create database backup and restore procedures
-- [ ] T238 Document 42 OAuth setup instructions
+- [X] T237 Create database backup and restore procedures — `docs/guides/database-backup-restore.md`
+- [X] T238 Document 42 OAuth setup instructions — `docs/guides/42-oauth-setup.md`
 - [ ] T239 Create CI/CD pipeline configuration in .github/workflows/ci.yml
 
 ---


### PR DESCRIPTION
Closes #141

## 범위

**v0.5.4 패치** — Phase 12 운영 가이드 묶음.

### 머지된 PR
- #138 (T237 + T238) — DB 백업/복원 + 42 OAuth 등록 가이드
- #140 (T239) — CI/CD 파이프라인 문서

## 효과

운영자가 첫 설치 시 막히는 세 지점 — **DB 백업**, **OAuth 등록**, **CI 동작** — 모두 문서화.

| 가이드 | 위치 |
|--|--|
| 42 OAuth 등록 | `docs/guides/42-oauth-setup.md` |
| DB 백업 / 복원 | `docs/guides/database-backup-restore.md` |
| CI/CD 파이프라인 | `docs/guides/ci-cd-pipeline.md` |

코드 변경 없음. `backend/package.json` 0.5.3 → 0.5.4, `pubspec.yaml` 0.5.3+1 → 0.5.4+1만.

## Phase 12 진척

| Task | 상태 | 릴리스 |
|--|--|--|
| T230 Swagger UI | ✅ | v0.5.1 |
| T231 README | ✅ | v0.5.1 |
| T232 .env.example | ✅ | v0.5.1 |
| T237 DB 백업/복원 | ✅ | v0.5.4 |
| T238 42 OAuth 가이드 | ✅ | v0.5.4 |
| T239 CI/CD 문서화 | ✅ | v0.5.4 |
| T233 deployment guide | ⏳ | 배포 타깃 결정 후 |
| T234/T235 user/admin manual | ⏳ | UI 안정화 후 |
| T236 quickstart 검증 | ⏳ | 별도 검증 작업 |

## 알려진 한계 (T239가 노출)

백엔드 테스트가 CI에서 돌지 않는 갭 — 100+ 테스트가 로컬 한정. 별도 PR로 services Postgres 띄우는 backend job 추가 필요.

## Test plan

- [x] CI green (analyze + test + web build)
- [x] 코드 변경 없음 (회귀 위험 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)