### PR TITLE
[#143] 👷 ci: 백엔드 테스트 job 추가 + Codecov flag 분리

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,24 +43,80 @@ jobs:
     needs: analyze
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Flutter 설정
         uses: subosito/flutter-action@v2
         with:
           flutter-version: '3.24.0'
           channel: 'stable'
           cache: true
-      
+
       - name: 의존성 설치
         run: flutter pub get
-      
+
       - name: 단위 테스트
         run: flutter test --coverage
-      
+
       - name: 커버리지 업로드
         uses: codecov/codecov-action@v3
         with:
           files: ./coverage/lcov.info
+          flags: flutter
+
+  backend-test:
+    name: 백엔드 테스트
+    runs-on: ubuntu-latest
+    # Flutter analyze와 독립적이므로 needs 없이 병렬 실행.
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: library_user
+          POSTGRES_PASSWORD: library_pass
+          POSTGRES_DB: library_db
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U library_user -d library_db"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgresql://library_user:library_pass@localhost:5432/library_db?schema=public
+      NODE_ENV: test
+      JWT_SECRET: ci-only-jwt-secret-not-for-prod
+      # 42 OAuth는 lazy init이라 비워둬도 부팅됨. 학생 OAuth 흐름을 직접 호출하는
+      # 테스트는 jest.mock('axios')으로 분리되어 있어 실제 호출 안 함.
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Node 설정
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: backend/package-lock.json
+
+      - name: 의존성 설치
+        run: npm ci
+
+      - name: Prisma client 생성
+        run: npx prisma generate
+
+      - name: 마이그레이션 적용
+        run: npx prisma migrate deploy
+
+      - name: 단위 + 통합 테스트 (커버리지 포함)
+        run: npm run test:coverage
+
+      - name: 커버리지 업로드
+        uses: codecov/codecov-action@v3
+        with:
+          files: ./backend/coverage/lcov.info
+          flags: backend
 
   # Android/iOS 빌드: v0.2.0 MVP 릴리스 후 활성화 (Constitution v1.10.0).
   # 태그 푸시 시에만 실행하여 PR/일반 푸시 피드백 시간을 보호.

--- a/codecov.yml
+++ b/codecov.yml
@@ -27,3 +27,15 @@ comment:
   layout: 'reach,diff,flags,files'
   behavior: default
   require_changes: false
+
+# Flag 분리 — Flutter (lib/) 와 백엔드 (backend/src/)를 독립적으로 추적.
+# 두 측이 같은 PR에서 동시에 떨어지지 않도록 게이트도 flag별로 평가됨.
+flags:
+  flutter:
+    paths:
+      - lib/
+    carryforward: true
+  backend:
+    paths:
+      - backend/src/
+    carryforward: true

--- a/docs/guides/ci-cd-pipeline.md
+++ b/docs/guides/ci-cd-pipeline.md
@@ -25,9 +25,12 @@ analyze (Ubuntu, 항상)
                                         ├─▶ build-android (Ubuntu, 태그 푸시만)
                                         │
                                         └─▶ build-ios (macOS, 태그 푸시만)
+
+backend-test (Ubuntu, 항상; analyze와 병렬)
+   └─ services: postgres:16-alpine
 ```
 
-`needs:` 의존성으로 직렬화되어 있어 analyze 실패 시 그 이후가 모두 스킵됩니다.
+`analyze → test → build-*` 체인은 직렬, `backend-test`는 Flutter 체인과 독립적으로 병렬 실행됩니다.
 
 ## 각 Job의 검증 항목
 
@@ -52,6 +55,13 @@ analyze (Ubuntu, 항상)
 - Android: `flutter build apk --release` → `app-release.apk` 아티팩트.
 - iOS: `flutter build ios --release --no-codesign` (CI에서는 코드 사인 안 함).
 
+### `backend-test` — Node + Prisma 통합 테스트
+
+- `services: postgres:16-alpine` 컨테이너를 띄우고 `DATABASE_URL`을 `localhost:5432`로 주입.
+- `npm ci` → `npx prisma generate` → `npx prisma migrate deploy` → `npm run test:coverage`.
+- 커버리지를 Codecov에 `backend` flag로 업로드 (Flutter는 `flutter` flag).
+- `JWT_SECRET`은 CI 전용 더미 값. `FORTYTWO_*`는 비워둠 — `Auth42Service`는 lazy init이고, OAuth를 직접 호출하는 테스트는 `jest.mock('axios')`로 분리되어 있어 외부 호출 없음.
+
 ## 커버리지 게이트 (`codecov.yml`)
 
 | 체크 | 기준 |
@@ -61,14 +71,13 @@ analyze (Ubuntu, 항상)
 
 baseline은 Codecov가 머지된 main 기준으로 자동 갱신합니다. 점진 상향은 PR 단위로 spec MVP 정의 (Backend/Flutter 80%)를 목표.
 
+**Flag 분리**: `lib/`은 `flutter`, `backend/src/`은 `backend` flag로 분리되어 측마다 독립적으로 추적됩니다. 한쪽 코드만 바뀐 PR이 반대편 baseline에 영향을 주지 않도록 `carryforward: true`.
+
 ## 알려진 한계 / TODO
 
-- **백엔드 테스트가 CI에서 돌지 않습니다**. `backend/tests/`의 100건 이상이 로컬에서만 검증되는 상태. 추가 job 필요 (TODO):
-  - `services` 블록으로 Postgres 16 띄우기
-  - `npm ci && npm run migrate && npm test` 실행
-  - lcov 업로드 (Flutter와 별도 flag로)
 - 모바일 빌드는 태그 푸시에만 실행 → PR에서 모바일 회귀 발견 불가. 로컬 `./scripts/local-verify.sh --mvp-mode`로 보완 (Constitution XVI).
 - iOS는 `--no-codesign` 빌드만 — 실제 .ipa는 별도 릴리스 파이프라인 필요 (App Store / TestFlight 결정 시).
+- 백엔드 테스트는 PR마다 약 30~60초 추가 — 현재 빠른 편이지만 통합 테스트가 늘어나면 cache 최적화 검토 필요.
 
 ## 로컬에서 CI와 동일한 검사 돌리기
 

--- a/specs/001-library-management/tasks.md
+++ b/specs/001-library-management/tasks.md
@@ -494,7 +494,7 @@
 - [ ] T236 Validate quickstart.md setup instructions
 - [X] T237 Create database backup and restore procedures — `docs/guides/database-backup-restore.md`
 - [X] T238 Document 42 OAuth setup instructions — `docs/guides/42-oauth-setup.md`
-- [X] T239 Create CI/CD pipeline configuration in .github/workflows/ci.yml — workflow는 v0.1 시절부터 존재. 이번 PR은 동작/규칙/한계 문서화 (`docs/guides/ci-cd-pipeline.md`). 백엔드 테스트 CI 미실행 갭은 TODO로 명시.
+- [X] T239 Create CI/CD pipeline configuration in .github/workflows/ci.yml — workflow + 동작/규칙 문서화 (`docs/guides/ci-cd-pipeline.md`). 백엔드 테스트 job 추가 + codecov flag 분리 (flutter / backend).
 
 ---
 


### PR DESCRIPTION
Closes #143

## Summary

T239 CI/CD 문서화에서 명시적으로 표면화한 갭 해결 — **백엔드 100+건 테스트가 로컬에서만 돌고 CI 회귀 차단이 안 되던 상태**.

## 변경

### `.github/workflows/ci.yml`
새 job `backend-test`:
- Ubuntu, Flutter 체인과 **병렬** 실행 (`needs:` 없음 — Flutter analyze/test와 독립)
- `services: postgres:16-alpine` 컨테이너 + `pg_isready` 헬스체크
- `npm ci` → `npx prisma generate` → `npx prisma migrate deploy` → `npm run test:coverage`
- Codecov 업로드 with `flag: backend`
- Flutter `test` job에도 `flag: flutter` 추가

### `codecov.yml`
- `flags.flutter` (paths: `lib/`) + `flags.backend` (paths: `backend/src/`)
- `carryforward: true` — 한쪽만 바뀐 PR이 반대편 baseline에 영향 안 주도록

### `docs/guides/ci-cd-pipeline.md`
- backend-test 섹션 신설 + 환경 변수 의도 설명 (lazy 42 OAuth init / 더미 JWT_SECRET)
- "백엔드 CI 미실행" TODO 제거
- Flag 분리 동작 설명

## 효과

| | Before | After |
|--|--|--|
| 백엔드 회귀 PR 단계 차단 | ❌ | ✅ |
| Flutter/백엔드 커버리지 독립 추적 | ❌ | ✅ |
| PR 시간 | ~3분 | ~3-4분 (병렬이라 +30-60초) |

## 위험 / 검증

- **마이그레이션 빈 DB 적용 가능성**: 기존 테스트는 모두 cleanup beforeAll/afterAll로 격리되어 있어 빈 DB → 마이그레이션 → 테스트 시퀀스가 안전할 것으로 예상.
- **YAML 문법 검증**: `python3 -c "import yaml; yaml.safe_load(open(...))"` 통과.
- **첫 실행이 진짜 검증** — 이 PR의 CI 결과로 확인.

## Test plan

- [ ] `backend-test` job이 green인지
- [ ] Codecov 코멘트에 두 flag (flutter/backend) 분리 표시되는지
- [ ] PR 전체 시간이 합리적인지 (4분 이내)

🤖 Generated with [Claude Code](https://claude.com/claude-code)