### PR TITLE
[#161] ✅ test(flutter): T133 + T162 — 대출 관리 + 추천 폼 widget 테스트

### DIFF
--- a/specs/001-library-management/tasks.md
+++ b/specs/001-library-management/tasks.md
@@ -281,7 +281,7 @@
 ### Tests for User Story 5
 
 - [X] T132 [P] [US5] Create unit test for Loan model in test/features/admin_catalog/data/models/loan_test.dart
-- [ ] T133 [P] [US5] Create widget test for loan management screen in test/widget_test/screens/web/loans/loans_screen_test.dart
+- [X] T133 [P] [US5] Create widget test for loan management screen — `test/features/admin_catalog/presentation/screens/loans_management_screen_test.dart` (8 tests, 88% line coverage)
 - [ ] T134 [P] [US5] Create integration test for loan approval flow in test/integration_test/admin_loan_management_test.dart
 - [X] T135 [P] [US5] Create backend unit test for PUT /loan-requests/:id/approve in backend/tests/unit/loan_requests.test.ts
 - [X] T136 [P] [US5] Create backend unit test for PUT /loans/:id/return in backend/tests/unit/loans.test.ts
@@ -343,7 +343,7 @@
 
 - [X] T160 [P] [US3] Create unit test for BookSuggestion model in test/unit_test/models/book_suggestion_test.dart
 - [X] T161 [P] [US3] Create unit test for CollectionPeriod model in test/unit_test/models/collection_period_test.dart
-- [ ] T162 [P] [US3] Create widget test for suggestion form in test/widget_test/screens/mobile/suggestions/suggestion_form_test.dart
+- [X] T162 [P] [US3] Create widget test for suggestion form — `test/features/book_suggestions/presentation/screens/suggestion_form_screen_test.dart` (7 tests, 100% line coverage)
 - [X] T163 [P] [US3] Create backend unit test for POST /suggestions in backend/tests/unit/suggestions.test.ts
 - [X] T164 [P] [US3] Create backend unit test for collection period validation in backend/tests/unit/collection_periods.test.ts
 

--- a/test/features/admin_catalog/presentation/screens/loans_management_screen_test.dart
+++ b/test/features/admin_catalog/presentation/screens/loans_management_screen_test.dart
@@ -1,0 +1,172 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lib_42_flutter/features/admin_catalog/data/models/loan.dart';
+import 'package:lib_42_flutter/features/admin_catalog/domain/repositories/admin_loan_repository.dart';
+import 'package:lib_42_flutter/features/admin_catalog/presentation/screens/loans_management_screen.dart';
+
+import '../../../../support/fake_admin_loan_repository.dart';
+
+Future<void> _pump(
+  WidgetTester tester,
+  FakeAdminLoanRepository repo,
+) async {
+  await tester.pumpWidget(MaterialApp(
+    home: LoansManagementScreen(repository: repo),
+  ));
+  // Initial AdminLoansRequested → Loading → Loaded
+  await tester.pump();
+  await tester.pump();
+}
+
+LoanBookSummary _book(String title) => LoanBookSummary(id: 'b-$title', title: title);
+LoanStudentSummary _stu(String name) => LoanStudentSummary(
+      id: 's-$name',
+      username: name.toLowerCase(),
+      fullName: name,
+    );
+
+void main() {
+  group('LoansManagementScreen', () {
+    testWidgets('shows two empty-state messages on initial load (no data)',
+        (tester) async {
+      final repo = FakeAdminLoanRepository();
+      await _pump(tester, repo);
+
+      // First tab is "대기 요청" (default selected) — empty
+      expect(find.text('대기 중인 대출 요청이 없습니다.'), findsOneWidget);
+      // Switch to "진행 중인 대출"
+      await tester.tap(find.text('진행 중인 대출'));
+      await tester.pumpAndSettle();
+      expect(find.text('진행 중인 대출이 없습니다.'), findsOneWidget);
+    });
+
+    testWidgets('renders pending requests with title + student + actions',
+        (tester) async {
+      final repo = FakeAdminLoanRepository()
+        ..pendingRequests = [
+          makeAdminLoanRequest(
+            id: 'req-1',
+            book: _book('클린 코드'),
+            student: _stu('Yoshin'),
+          ),
+        ];
+      await _pump(tester, repo);
+
+      expect(find.text('클린 코드'), findsOneWidget);
+      expect(find.textContaining('Yoshin'), findsOneWidget);
+      expect(find.byTooltip('승인'), findsOneWidget);
+      expect(find.byTooltip('반려'), findsOneWidget);
+    });
+
+    testWidgets('approve flow: confirm dialog → 승인 dispatches approveRequest',
+        (tester) async {
+      final repo = FakeAdminLoanRepository()
+        ..pendingRequests = [
+          makeAdminLoanRequest(id: 'req-1', book: _book('Approve Me')),
+        ];
+      await _pump(tester, repo);
+
+      await tester.tap(find.byTooltip('승인'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('대출 승인'), findsOneWidget);
+      expect(find.textContaining('Approve Me'), findsAtLeastNWidgets(1));
+
+      await tester.tap(find.widgetWithText(FilledButton, '승인'));
+      await tester.pumpAndSettle();
+
+      expect(repo.approveCalls, 1);
+    });
+
+    testWidgets('approve flow: 취소 closes without dispatching', (tester) async {
+      final repo = FakeAdminLoanRepository()
+        ..pendingRequests = [
+          makeAdminLoanRequest(id: 'req-1', book: _book('Skip Me')),
+        ];
+      await _pump(tester, repo);
+
+      await tester.tap(find.byTooltip('승인'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(TextButton, '취소'));
+      await tester.pumpAndSettle();
+
+      expect(repo.approveCalls, 0);
+    });
+
+    testWidgets('reject flow: opens dialog with reason field', (tester) async {
+      // Note: full reject flow (empty/with-reason dispatch) skipped in widget
+      // tests due to TextEditingController + unconstrained Column layout
+      // overflow in the 800×600 test viewport. Bloc-level dispatch is
+      // covered separately. We only verify the dialog opens with the
+      // expected fields.
+      final repo = FakeAdminLoanRepository()
+        ..pendingRequests = [
+          makeAdminLoanRequest(id: 'req-1', book: _book('Reject Test')),
+        ];
+      await _pump(tester, repo);
+
+      await tester.tap(find.byTooltip('반려'));
+      await tester.pump(); // single pump; no settle (overflow renders fine
+                            // for the visible part in one frame)
+
+      expect(find.text('대출 반려'), findsOneWidget);
+      expect(find.byType(TextField), findsOneWidget);
+    });
+
+    testWidgets('active loans tab: renders book + student + due date',
+        (tester) async {
+      final repo = FakeAdminLoanRepository()
+        ..loansByStatus = [
+          makeLoan(
+            id: 'loan-1',
+            book: _book('Active Book'),
+            student: _stu('Alice'),
+            checkoutDate: DateTime(2024, 1, 1),
+            dueDate: DateTime(2024, 1, 15),
+          ),
+        ];
+      await _pump(tester, repo);
+
+      await tester.tap(find.text('진행 중인 대출'));
+      await tester.pumpAndSettle();
+
+      // Tab transition can briefly leave both tab views in tree.
+      expect(find.text('Active Book'), findsAtLeastNWidgets(1));
+      expect(find.textContaining('Alice'), findsAtLeastNWidgets(1));
+      expect(find.byTooltip('반납 처리'), findsAtLeastNWidgets(1));
+    });
+
+    testWidgets('return flow: confirm dialog → 반납 dispatches returnLoan',
+        (tester) async {
+      final repo = FakeAdminLoanRepository()
+        ..loansByStatus = [
+          makeLoan(
+            id: 'loan-1',
+            book: _book('Return Me'),
+            checkoutDate: DateTime(2024, 1, 1),
+            dueDate: DateTime(2024, 1, 15),
+          ),
+        ];
+      await _pump(tester, repo);
+
+      await tester.tap(find.text('진행 중인 대출'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byTooltip('반납 처리').first);
+      await tester.pumpAndSettle();
+
+      expect(find.text('반납 처리'), findsAtLeastNWidgets(1));
+      await tester.tap(find.widgetWithText(FilledButton, '반납'));
+      await tester.pumpAndSettle();
+
+      expect(repo.returnCalls, 1);
+    });
+
+    testWidgets('error state shows retry button', (tester) async {
+      final repo = FakeAdminLoanRepository()..error = Exception('네트워크 오류');
+      await _pump(tester, repo);
+
+      expect(find.textContaining('네트워크 오류'), findsOneWidget);
+      expect(find.widgetWithText(FilledButton, '다시 시도'), findsOneWidget);
+    });
+  });
+}

--- a/test/features/book_suggestions/presentation/screens/suggestion_form_screen_test.dart
+++ b/test/features/book_suggestions/presentation/screens/suggestion_form_screen_test.dart
@@ -1,0 +1,156 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:lib_42_flutter/features/book_suggestions/presentation/bloc/suggestion_bloc.dart';
+import 'package:lib_42_flutter/features/book_suggestions/presentation/bloc/suggestion_state.dart';
+import 'package:lib_42_flutter/features/book_suggestions/presentation/screens/suggestion_form_screen.dart';
+
+import '../../../../support/fake_suggestion_repository.dart';
+
+SuggestionBloc _bloc({
+  FakeSuggestionRepository? repo,
+}) =>
+    SuggestionBloc(repository: repo ?? FakeSuggestionRepository());
+
+Future<void> _pump(
+  WidgetTester tester, {
+  required SuggestionBloc bloc,
+  SuggestionState? seed,
+}) async {
+  if (seed != null) bloc.emit(seed);
+  addTearDown(bloc.close);
+  // The screen calls `context.go('/suggestions/mine')` on success, so we need
+  // a GoRouter in the tree for routing-affected paths to work.
+  final router = GoRouter(
+    initialLocation: '/suggestions/new',
+    routes: [
+      GoRoute(
+        path: '/suggestions/new',
+        builder: (_, __) => SuggestionFormScreen(bloc: bloc),
+      ),
+      GoRoute(
+        path: '/suggestions/mine',
+        builder: (_, __) => const Scaffold(body: Text('mine-redirect')),
+      ),
+    ],
+  );
+  await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+  await tester.pump();
+}
+
+void main() {
+  group('SuggestionFormScreen', () {
+    testWidgets('renders form fields and submit button', (tester) async {
+      await _pump(tester, bloc: _bloc());
+
+      expect(find.text('도서 추천'), findsOneWidget);
+      expect(find.widgetWithText(TextFormField, ''),
+          findsAtLeastNWidgets(3)); // 제목/저자/사유
+      expect(find.widgetWithText(FilledButton, '제출'), findsOneWidget);
+    });
+
+    testWidgets('shows active period name when SuggestionLoaded has one',
+        (tester) async {
+      await _pump(
+        tester,
+        bloc: _bloc(),
+        seed: SuggestionLoaded(
+          activePeriod: makePeriod(name: '2024 Q3'),
+          mySuggestions: const [],
+        ),
+      );
+
+      expect(find.textContaining('2024 Q3'), findsOneWidget);
+    });
+
+    testWidgets('validation: empty title shows error message', (tester) async {
+      await _pump(tester, bloc: _bloc());
+
+      // Tap submit without entering anything
+      await tester.tap(find.widgetWithText(FilledButton, '제출'));
+      await tester.pump();
+
+      expect(find.text('제목을(를) 입력하세요'), findsOneWidget);
+      expect(find.text('저자을(를) 입력하세요'), findsOneWidget);
+    });
+
+    testWidgets('validation: title over 500 chars rejected', (tester) async {
+      await _pump(tester, bloc: _bloc());
+
+      final longText = 'a' * 501;
+      await tester.enterText(find.byType(TextFormField).at(0), longText);
+      await tester.enterText(find.byType(TextFormField).at(1), 'Author');
+      await tester.tap(find.widgetWithText(FilledButton, '제출'));
+      await tester.pump();
+
+      expect(find.text('제목은(는) 500자 이하여야 합니다'), findsOneWidget);
+    });
+
+    testWidgets('valid submit dispatches SuggestionSubmitted', (tester) async {
+      final repo = FakeSuggestionRepository()
+        ..submitResult = makeSuggestion(
+          id: 'new',
+          suggestedTitle: '새 도서',
+          suggestedAuthor: '새 저자',
+        );
+      final bloc = _bloc(repo: repo);
+      await _pump(
+        tester,
+        bloc: bloc,
+        seed: SuggestionLoaded(
+          activePeriod: makePeriod(),
+          mySuggestions: const [],
+        ),
+      );
+
+      await tester.enterText(find.byType(TextFormField).at(0), '새 도서');
+      await tester.enterText(find.byType(TextFormField).at(1), '새 저자');
+      await tester.enterText(find.byType(TextFormField).at(2), '학습용');
+      await tester.tap(find.widgetWithText(FilledButton, '제출'));
+      await tester.pump();
+
+      expect(repo.submitCalls, 1);
+    });
+
+    testWidgets('shows progress indicator while submission in progress',
+        (tester) async {
+      final bloc = _bloc();
+      await _pump(
+        tester,
+        bloc: bloc,
+        seed: SuggestionLoaded(
+          activePeriod: makePeriod(),
+          mySuggestions: const [],
+          actionStatus: SuggestionActionStatus.inProgress,
+        ),
+      );
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.text('제출'), findsNothing);
+    });
+
+    testWidgets('failure state surfaces snackbar with action message',
+        (tester) async {
+      final bloc = _bloc();
+      await _pump(
+        tester,
+        bloc: bloc,
+        seed: SuggestionLoaded(
+          activePeriod: makePeriod(),
+          mySuggestions: const [],
+        ),
+      );
+
+      bloc.emit(SuggestionLoaded(
+        activePeriod: makePeriod(),
+        mySuggestions: const [],
+        actionStatus: SuggestionActionStatus.failure,
+        actionMessage: '동일한 도서를 이미 추천했습니다.',
+      ));
+      // listener fires + SnackBar enqueues + animates in. Need a few frames.
+      await tester.pumpAndSettle();
+
+      expect(find.text('동일한 도서를 이미 추천했습니다.'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
Closes #161

## Summary

Phase 11 잔여 widget test 갭 — 두 화면이 0건 widget 테스트 상태였음. 한 PR로 묶어 커버.

| 파일 | Before | After |
|--|--|--|
| `loans_management_screen.dart` | 0 widget tests | **8 / 88%** |
| `suggestion_form_screen.dart` | 0 widget tests | **7 / 100%** |
| Flutter 테스트 | 228 | **243** |

## 테스트 추가 15건

### LoansManagementScreen (8)
- 빈 상태 (두 탭 각각)
- 대기 요청 렌더 (제목/학생명/액션 버튼)
- 승인 dialog 흐름 + 취소
- 반려 dialog 열림
- 진행 중 대출 렌더
- 반납 dialog 흐름
- 에러 상태 + retry 버튼

### SuggestionFormScreen (7)
- 폼 필드 렌더 + submit 버튼
- 활성 기간 이름 표시
- Empty title/author validation
- 제목 500자 초과 validation
- 정상 제출 → dispatch SuggestionSubmitted
- 진행 중 → CircularProgressIndicator
- 실패 → snackbar 메시지

## 알려진 제약

- **LoansManagement 반려 dispatch 흐름**: 다이얼로그의 `Column` + 무제한 `TextField`가 800×600 viewport에서 overflow + TextEditingController disposal 타이밍 이슈로 widget test에서 안정적 검증 어려움. **다이얼로그 열림만** 검증; dispatch는 bloc test에서 별도 커버.
- **SuggestionForm 정상 제출**: 화면이 `context.go('/suggestions/mine')` 호출 → 테스트는 `MaterialApp.router` + 더미 GoRouter 라우트로 wrap (실제 redirect 동작 자체는 검증 안 함).

## Test plan

- [x] `flutter test` 228 → 243 (+15, 회귀 없음)
- [x] 두 타깃 화면 0% → 88%/100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)