### PR TITLE
[#163] ✨ feat(suggestions): T178 + T180 — 추천 폼 활성 기간 가드 + 상태 banner

### DIFF
--- a/lib/features/book_suggestions/presentation/screens/suggestion_form_screen.dart
+++ b/lib/features/book_suggestions/presentation/screens/suggestion_form_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../data/models/collection_period.dart';
 import '../bloc/suggestion_bloc.dart';
 import '../bloc/suggestion_event.dart';
 import '../bloc/suggestion_state.dart';
@@ -56,7 +57,20 @@ class _SuggestionFormViewState extends State<_SuggestionFormView> {
     return null;
   }
 
-  void _submit() {
+  void _submit(BuildContext context) {
+    final loaded = context.read<SuggestionBloc>().state;
+    // T178: pre-flight guard — refuse to submit when there is no active
+    // collection period. Backend would 400 anyway, but inline message is
+    // gentler than a generic snackbar.
+    if (loaded is! SuggestionLoaded ||
+        !_isPeriodAcceptingSubmissions(loaded.activePeriod)) {
+      ScaffoldMessenger.of(context)
+        ..hideCurrentSnackBar()
+        ..showSnackBar(const SnackBar(
+          content: Text('현재 활성 수집 기간이 없어 추천을 제출할 수 없습니다.'),
+        ));
+      return;
+    }
     if (!_formKey.currentState!.validate()) return;
     context.read<SuggestionBloc>().add(SuggestionSubmitted(
           suggestedTitle: _title.text.trim(),
@@ -64,6 +78,9 @@ class _SuggestionFormViewState extends State<_SuggestionFormView> {
           reason: _reason.text.trim().isEmpty ? null : _reason.text.trim(),
         ));
   }
+
+  bool _isPeriodAcceptingSubmissions(CollectionPeriod? period) =>
+      period != null && period.status == PeriodStatus.active;
 
   @override
   Widget build(BuildContext context) {
@@ -88,6 +105,9 @@ class _SuggestionFormViewState extends State<_SuggestionFormView> {
         builder: (context, state) {
           final isInProgress = state is SuggestionLoaded &&
               state.actionStatus == SuggestionActionStatus.inProgress;
+          final period = state is SuggestionLoaded ? state.activePeriod : null;
+          final canSubmit =
+              !isInProgress && _isPeriodAcceptingSubmissions(period);
 
           return Padding(
             padding: const EdgeInsets.all(24),
@@ -97,16 +117,11 @@ class _SuggestionFormViewState extends State<_SuggestionFormView> {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
-                    if (state is SuggestionLoaded && state.activePeriod != null)
-                      Padding(
-                        padding: const EdgeInsets.only(bottom: 16),
-                        child: Text(
-                          '제출 대상 기간: ${state.activePeriod!.name}',
-                          style: Theme.of(context).textTheme.bodyMedium,
-                        ),
-                      ),
+                    _PeriodBanner(period: period),
+                    const SizedBox(height: 16),
                     TextFormField(
                       controller: _title,
+                      enabled: canSubmit,
                       decoration: const InputDecoration(
                         labelText: '제목 *',
                         helperText: '500자 이내',
@@ -117,6 +132,7 @@ class _SuggestionFormViewState extends State<_SuggestionFormView> {
                     const SizedBox(height: 12),
                     TextFormField(
                       controller: _author,
+                      enabled: canSubmit,
                       decoration: const InputDecoration(
                         labelText: '저자 *',
                         helperText: '200자 이내',
@@ -127,6 +143,7 @@ class _SuggestionFormViewState extends State<_SuggestionFormView> {
                     const SizedBox(height: 12),
                     TextFormField(
                       controller: _reason,
+                      enabled: canSubmit,
                       maxLines: 4,
                       decoration: const InputDecoration(
                         labelText: '추천 사유',
@@ -136,7 +153,7 @@ class _SuggestionFormViewState extends State<_SuggestionFormView> {
                     ),
                     const SizedBox(height: 24),
                     FilledButton(
-                      onPressed: isInProgress ? null : _submit,
+                      onPressed: canSubmit ? () => _submit(context) : null,
                       style: FilledButton.styleFrom(
                         minimumSize: const Size.fromHeight(48),
                       ),
@@ -157,4 +174,104 @@ class _SuggestionFormViewState extends State<_SuggestionFormView> {
       ),
     );
   }
+}
+
+/// Banner shown above the form. Three variants:
+///   • no period at all → 경고 (form 비활성)
+///   • upcoming/closed → 안내 (form 비활성)
+///   • active → 기간 이름 + 종료일 + 남은 일수
+class _PeriodBanner extends StatelessWidget {
+  const _PeriodBanner({required this.period});
+
+  final CollectionPeriod? period;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    if (period == null) {
+      return _banner(
+        context,
+        icon: Icons.warning_amber_outlined,
+        bg: theme.colorScheme.errorContainer,
+        fg: theme.colorScheme.onErrorContainer,
+        title: '활성 수집 기간이 없습니다',
+        body: '관리자가 새 기간을 활성화할 때까지 추천을 제출할 수 없습니다.',
+      );
+    }
+
+    if (period!.status != PeriodStatus.active) {
+      final label = period!.status == PeriodStatus.upcoming ? '예정' : '종료';
+      return _banner(
+        context,
+        icon: Icons.info_outline,
+        bg: theme.colorScheme.surfaceContainerHighest,
+        fg: theme.colorScheme.onSurface,
+        title: '"${period!.name}" — $label 상태',
+        body: '이 기간은 현재 추천을 받지 않습니다.',
+      );
+    }
+
+    final days = period!.daysRemaining(DateTime.now());
+    final endText = _formatDate(period!.endDate);
+    return _banner(
+      context,
+      icon: Icons.event_available,
+      bg: theme.colorScheme.primaryContainer,
+      fg: theme.colorScheme.onPrimaryContainer,
+      title: '제출 대상 기간: ${period!.name}',
+      body: days == 0
+          ? '오늘이 마지막 날입니다 (~$endText).'
+          : '종료까지 D-$days · ~$endText',
+    );
+  }
+
+  Widget _banner(
+    BuildContext context, {
+    required IconData icon,
+    required Color bg,
+    required Color fg,
+    required String title,
+    required String body,
+  }) {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: bg,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(icon, color: fg),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                        color: fg,
+                        fontWeight: FontWeight.w600,
+                      ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  body,
+                  style: Theme.of(context)
+                      .textTheme
+                      .bodySmall
+                      ?.copyWith(color: fg),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _formatDate(DateTime d) =>
+      '${d.year}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
 }

--- a/specs/001-library-management/tasks.md
+++ b/specs/001-library-management/tasks.md
@@ -376,9 +376,9 @@
 
 **Integration & Polish**
 
-- [ ] T178 [US3] Add validation for active collection period before submission
-- [ ] T179 [US3] Add confirmation message after successful suggestion submission
-- [ ] T180 [US3] Display collection period status (active/closed) in suggestion screen
+- [X] T178 [US3] Add validation for active collection period before submission — 폼 비활성 + 경고 banner + ScaffoldMessenger 가드
+- [X] T179 [US3] Add confirmation message after successful suggestion submission — 이미 구현됨 (SuggestionBloc actionMessage + screen snackbar)
+- [X] T180 [US3] Display collection period status (active/closed) in suggestion screen — `_PeriodBanner` 위젯 (active=primary container with D-day, upcoming/closed=info, none=warning)
 
 **Checkpoint**: User Story 3 complete - students can submit suggestions independently
 

--- a/test/features/book_suggestions/presentation/screens/suggestion_form_screen_test.dart
+++ b/test/features/book_suggestions/presentation/screens/suggestion_form_screen_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:lib_42_flutter/features/book_suggestions/data/models/collection_period.dart';
 import 'package:lib_42_flutter/features/book_suggestions/presentation/bloc/suggestion_bloc.dart';
 import 'package:lib_42_flutter/features/book_suggestions/presentation/bloc/suggestion_state.dart';
 import 'package:lib_42_flutter/features/book_suggestions/presentation/screens/suggestion_form_screen.dart';
@@ -44,29 +45,102 @@ void main() {
       await _pump(tester, bloc: _bloc());
 
       expect(find.text('도서 추천'), findsOneWidget);
-      expect(find.widgetWithText(TextFormField, ''),
-          findsAtLeastNWidgets(3)); // 제목/저자/사유
+      expect(find.byType(TextFormField), findsNWidgets(3)); // 제목/저자/사유
       expect(find.widgetWithText(FilledButton, '제출'), findsOneWidget);
     });
 
-    testWidgets('shows active period name when SuggestionLoaded has one',
+    testWidgets('active period banner shows name + end date + countdown',
         (tester) async {
       await _pump(
         tester,
         bloc: _bloc(),
         seed: SuggestionLoaded(
-          activePeriod: makePeriod(name: '2024 Q3'),
+          activePeriod: makePeriod(
+            name: '2024 Q3',
+            status: PeriodStatus.active,
+          ),
           mySuggestions: const [],
         ),
       );
 
       expect(find.textContaining('2024 Q3'), findsOneWidget);
+      // 시드의 endDate=2024-03-31 → 오늘 기준 D-? or 종료. 어쨌든 banner body 존재.
+      expect(find.byIcon(Icons.event_available), findsOneWidget);
+    });
+
+    testWidgets(
+        'closed period shows info banner and disables form (T180)',
+        (tester) async {
+      await _pump(
+        tester,
+        bloc: _bloc(),
+        seed: SuggestionLoaded(
+          activePeriod: makePeriod(
+            name: '2024 Q1',
+            status: PeriodStatus.closed,
+          ),
+          mySuggestions: const [],
+        ),
+      );
+
+      expect(find.textContaining('2024 Q1'), findsOneWidget);
+      expect(find.textContaining('종료'), findsOneWidget);
+      // 폼이 비활성화되어 submit 버튼 onPressed가 null
+      final submit =
+          tester.widget<FilledButton>(find.widgetWithText(FilledButton, '제출'));
+      expect(submit.onPressed, isNull);
+    });
+
+    testWidgets(
+        'upcoming period shows info banner and disables form (T180)',
+        (tester) async {
+      await _pump(
+        tester,
+        bloc: _bloc(),
+        seed: SuggestionLoaded(
+          activePeriod: makePeriod(
+            name: '2024 Q4',
+            status: PeriodStatus.upcoming,
+          ),
+          mySuggestions: const [],
+        ),
+      );
+
+      expect(find.textContaining('예정'), findsOneWidget);
+      final submit =
+          tester.widget<FilledButton>(find.widgetWithText(FilledButton, '제출'));
+      expect(submit.onPressed, isNull);
+    });
+
+    testWidgets(
+        'no active period shows error banner and disables form (T178)',
+        (tester) async {
+      await _pump(
+        tester,
+        bloc: _bloc(),
+        seed: const SuggestionLoaded(
+          activePeriod: null,
+          mySuggestions: [],
+        ),
+      );
+
+      expect(find.text('활성 수집 기간이 없습니다'), findsOneWidget);
+      expect(find.byIcon(Icons.warning_amber_outlined), findsOneWidget);
+      final submit =
+          tester.widget<FilledButton>(find.widgetWithText(FilledButton, '제출'));
+      expect(submit.onPressed, isNull);
     });
 
     testWidgets('validation: empty title shows error message', (tester) async {
-      await _pump(tester, bloc: _bloc());
+      await _pump(
+        tester,
+        bloc: _bloc(),
+        seed: SuggestionLoaded(
+          activePeriod: makePeriod(),
+          mySuggestions: const [],
+        ),
+      );
 
-      // Tap submit without entering anything
       await tester.tap(find.widgetWithText(FilledButton, '제출'));
       await tester.pump();
 
@@ -75,7 +149,14 @@ void main() {
     });
 
     testWidgets('validation: title over 500 chars rejected', (tester) async {
-      await _pump(tester, bloc: _bloc());
+      await _pump(
+        tester,
+        bloc: _bloc(),
+        seed: SuggestionLoaded(
+          activePeriod: makePeriod(),
+          mySuggestions: const [],
+        ),
+      );
 
       final longText = 'a' * 501;
       await tester.enterText(find.byType(TextFormField).at(0), longText);


### PR DESCRIPTION
Closes #163

## Summary

추천 폼 UX 다듬기. **T179는 이미 구현되어 있어** (snackbar 메시지) 이 PR에서는 T178 + T180만 처리.

## 변경

### T178 — 활성 기간 가드
- 폼 입력 (`title`/`author`/`reason`)이 active 기간일 때만 활성화
- 제출 버튼 onPressed가 `null`로 (시각적 차단)
- `_submit()`에 ScaffoldMessenger fallback — 혹시 우회 시도 시 명확 경고

### T180 — 상태 banner (`_PeriodBanner`)

3 가지 변형:

| 상태 | 색 | 아이콘 | 메시지 |
|--|--|--|--|
| active | primaryContainer | `event_available` | 기간명 + D-day + 종료일 |
| upcoming/closed | surfaceContainerHighest | `info_outline` | "이 기간은 추천 받지 않습니다" |
| 없음 | errorContainer | `warning_amber_outlined` | "활성 수집 기간이 없습니다" |

## 효과

- 학생이 backend 400 (`No active collection period`) 받기 전 인라인 차단
- 활성 기간 만료일이 즉시 보임 (마감 임박 시 D-day)
- 누락 / 비활성 / 활성 케이스가 시각적으로 구분

## 테스트 추가 3건 (전체 10건)

- active banner 렌더 + event_available 아이콘
- closed / upcoming → 폼 비활성 (`submit.onPressed == null`)
- 활성 기간 없음 → error banner + warning 아이콘

## Test plan

- [x] `flutter test` 243 → 246 (+3, 회귀 없음)
- [x] format + analyze (info-only, pre-existing trailing comma 외)

🤖 Generated with [Claude Code](https://claude.com/claude-code)