### PR TITLE
[#165] ✨ feat(admin): T152 — OverdueIndicator widget + 대출 화면 통합

### DIFF
--- a/lib/features/admin_catalog/presentation/screens/loans_management_screen.dart
+++ b/lib/features/admin_catalog/presentation/screens/loans_management_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../../../../app/config.dart';
+import '../../../../widgets/admin/overdue_indicator.dart';
 import '../../data/models/loan.dart';
 import '../../data/repositories/admin_loan_repository_impl.dart';
 import '../../domain/repositories/admin_loan_repository.dart';
@@ -270,18 +271,20 @@ class _LoanRow extends StatelessWidget {
     final bookTitle = loan.book?.title ?? loan.bookId;
     final studentName =
         loan.student?.fullName ?? loan.student?.username ?? loan.studentId;
-    final daysLeft = loan.daysUntilDue(DateTime.now());
-    final overdue = loan.isOverdue || daysLeft < 0;
     return ListTile(
-      title: Text(bookTitle),
-      subtitle: Text(
-        '$studentName · 만기 ${_formatDate(loan.dueDate)} '
-        '(${overdue ? '연체 ${-daysLeft}일' : 'D-$daysLeft'})',
-        style: TextStyle(
-          color: overdue ? Theme.of(context).colorScheme.error : null,
-          fontWeight: overdue ? FontWeight.bold : null,
-        ),
+      title: Row(
+        children: [
+          Expanded(
+            child: Text(bookTitle, overflow: TextOverflow.ellipsis),
+          ),
+          const SizedBox(width: 8),
+          OverdueIndicator(
+            dueDate: loan.dueDate,
+            isOverdue: loan.isOverdue,
+          ),
+        ],
       ),
+      subtitle: Text('$studentName · 만기 ${_formatDate(loan.dueDate)}'),
       trailing: IconButton(
         tooltip: '반납 처리',
         icon: const Icon(Icons.assignment_returned_outlined),

--- a/lib/widgets/admin/overdue_indicator.dart
+++ b/lib/widgets/admin/overdue_indicator.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+
+/// Visual indicator for a loan's due date.
+///
+/// Three variants based on `daysLeft` (`dueDate - now`):
+/// - **overdue** (`daysLeft < 0` or `isOverdue`): error chip + "연체 N일"
+/// - **due soon** (`0 ≤ daysLeft ≤ 2`): warning amber chip + "D-N"
+/// - **on track** (`daysLeft > 2`): muted chip + "D-N"
+///
+/// Used by admin loan management screens (T152) to draw attention to
+/// overdue loans without changing list semantics.
+class OverdueIndicator extends StatelessWidget {
+  const OverdueIndicator({
+    super.key,
+    required this.dueDate,
+    this.isOverdue = false,
+    this.now,
+    this.dueSoonThresholdDays = 2,
+  });
+
+  final DateTime dueDate;
+  final bool isOverdue;
+  final DateTime? now;
+  final int dueSoonThresholdDays;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final reference = now ?? DateTime.now();
+    final daysLeft = dueDate.difference(reference).inDays;
+    final overdue = isOverdue || daysLeft < 0;
+
+    final (Color bg, Color fg, IconData icon, String label) = switch (overdue) {
+      true => (
+          theme.colorScheme.errorContainer,
+          theme.colorScheme.onErrorContainer,
+          Icons.warning,
+          '연체 ${-daysLeft}일',
+        ),
+      false when daysLeft <= dueSoonThresholdDays => (
+          Colors.amber.shade100,
+          Colors.amber.shade900,
+          Icons.schedule,
+          'D-$daysLeft',
+        ),
+      false => (
+          theme.colorScheme.surfaceContainerHighest,
+          theme.colorScheme.onSurface,
+          Icons.event_outlined,
+          'D-$daysLeft',
+        ),
+    };
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: bg,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 14, color: fg),
+          const SizedBox(width: 4),
+          Text(
+            label,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: fg,
+              fontWeight: overdue ? FontWeight.w700 : FontWeight.w500,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/specs/001-library-management/tasks.md
+++ b/specs/001-library-management/tasks.md
@@ -314,7 +314,7 @@
 
 - [X] T150 [P] [US5] Create LoanRequestCard widget in lib/widgets/admin/loan_request_card.dart *(LoansManagementScreen 내 _LoanRequestRow)*
 - [X] T151 [P] [US5] Create ActiveLoanCard widget in lib/widgets/admin/active_loan_card.dart *(LoansManagementScreen 내 _LoanRow)*
-- [ ] T152 [P] [US5] Create OverdueIndicator widget in lib/widgets/admin/overdue_indicator.dart
+- [X] T152 [P] [US5] Create OverdueIndicator widget — `lib/widgets/admin/overdue_indicator.dart` (3 변형: 연체/임박/정상). LoansManagementScreen에 통합.
 
 **Screens - Web Dashboard**
 

--- a/test/widget_test/widgets/admin/overdue_indicator_test.dart
+++ b/test/widget_test/widgets/admin/overdue_indicator_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lib_42_flutter/widgets/admin/overdue_indicator.dart';
+
+Future<void> _pump(WidgetTester tester, Widget child) async {
+  await tester.pumpWidget(MaterialApp(home: Scaffold(body: child)));
+}
+
+void main() {
+  // Fixed reference time so tests are deterministic regardless of when run.
+  final now = DateTime(2024, 6, 15);
+
+  group('OverdueIndicator', () {
+    testWidgets('overdue: dueDate before now → "연체 N일" + warning icon',
+        (tester) async {
+      await _pump(
+        tester,
+        OverdueIndicator(
+          dueDate: DateTime(2024, 6, 10), // 5 days ago
+          now: now,
+        ),
+      );
+      expect(find.text('연체 5일'), findsOneWidget);
+      expect(find.byIcon(Icons.warning), findsOneWidget);
+    });
+
+    testWidgets('overdue: explicit isOverdue=true wins even when daysLeft >= 0',
+        (tester) async {
+      // dueDate today (daysLeft == 0) but server flagged it overdue.
+      await _pump(
+        tester,
+        OverdueIndicator(
+          dueDate: DateTime(2024, 6, 15),
+          isOverdue: true,
+          now: now,
+        ),
+      );
+      // -daysLeft when daysLeft==0 is 0 → "연체 0일" (still flags as overdue).
+      expect(find.textContaining('연체'), findsOneWidget);
+      expect(find.byIcon(Icons.warning), findsOneWidget);
+    });
+
+    testWidgets('due soon: 0 ≤ daysLeft ≤ 2 → amber "D-N" + schedule icon',
+        (tester) async {
+      await _pump(
+        tester,
+        OverdueIndicator(
+          dueDate: DateTime(2024, 6, 17), // 2 days
+          now: now,
+        ),
+      );
+      expect(find.text('D-2'), findsOneWidget);
+      expect(find.byIcon(Icons.schedule), findsOneWidget);
+    });
+
+    testWidgets('on track: daysLeft > threshold → muted "D-N" + event icon',
+        (tester) async {
+      await _pump(
+        tester,
+        OverdueIndicator(
+          dueDate: DateTime(2024, 6, 25), // 10 days
+          now: now,
+        ),
+      );
+      expect(find.text('D-10'), findsOneWidget);
+      expect(find.byIcon(Icons.event_outlined), findsOneWidget);
+    });
+
+    testWidgets('custom threshold flips due-soon vs on-track', (tester) async {
+      // 5 days left, threshold = 7 → should be "due soon" (amber).
+      await _pump(
+        tester,
+        OverdueIndicator(
+          dueDate: DateTime(2024, 6, 20),
+          now: now,
+          dueSoonThresholdDays: 7,
+        ),
+      );
+      expect(find.text('D-5'), findsOneWidget);
+      expect(find.byIcon(Icons.schedule), findsOneWidget);
+    });
+
+    testWidgets('overdue label is bold; on-track label is medium-weight',
+        (tester) async {
+      // overdue
+      await _pump(
+        tester,
+        OverdueIndicator(dueDate: DateTime(2024, 6, 10), now: now),
+      );
+      final overdueText = tester.widget<Text>(find.text('연체 5일'));
+      expect(overdueText.style?.fontWeight, FontWeight.w700);
+
+      // on-track
+      await _pump(
+        tester,
+        OverdueIndicator(dueDate: DateTime(2024, 7, 1), now: now),
+      );
+      final onTrackText = tester.widget<Text>(find.textContaining('D-'));
+      expect(onTrackText.style?.fontWeight, FontWeight.w500);
+    });
+  });
+}


### PR DESCRIPTION
Closes #165

## Summary

T152 — 재사용 가능한 연체/마감 임박 chip 위젯.

## 새 위젯 `lib/widgets/admin/overdue_indicator.dart`

3 변형:

| 상태 | 색 | 아이콘 | 라벨 |
|--|--|--|--|
| **연체** (`isOverdue` 또는 `daysLeft < 0`) | errorContainer | `warning` | 연체 N일 (bold) |
| **임박** (`0 ≤ daysLeft ≤ threshold`, default 2) | amber.100 | `schedule` | D-N |
| **정상** | surfaceContainerHighest | `event_outlined` | D-N |

API: `OverdueIndicator({dueDate, isOverdue, now?, dueSoonThresholdDays})`
- `now` 주입으로 테스트 결정성
- `dueSoonThresholdDays` 커스터마이즈

## LoansManagementScreen 통합

기존 인라인 텍스트 (red + bold subtitle):
```
$studentName · 만기 $date (연체 N일|D-N)
```

→ ListTile title row의 chip으로 분리:
```
[책 제목] [OverdueIndicator chip]
$studentName · 만기 $date  (subtitle, normal)
```

가독성 향상 + 다른 admin 화면 (loan history 등)에서 재사용 가능.

## 테스트 추가 6건

- 연체 (warning + bold + "연체 N일")
- `isOverdue=true` 우선 (daysLeft >= 0이라도)
- 임박 (D-2 + schedule + amber)
- 정상 (D-10 + event_outlined)
- 커스텀 threshold (5 days, threshold=7 → 임박)
- 폰트 weight (overdue=w700 / on-track=w500)

## Test plan

- [x] 6 새 위젯 테스트 통과
- [x] 기존 LoansManagementScreen 8건 테스트 회귀 없음
- [x] flutter analyze (info-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)