### PR TITLE
[#173] ✨ feat(admin): T158 — 연체 대출 행 강조 + 상단 정렬

### DIFF
--- a/lib/features/admin_catalog/presentation/screens/loans_management_screen.dart
+++ b/lib/features/admin_catalog/presentation/screens/loans_management_screen.dart
@@ -143,11 +143,20 @@ class _ActiveTab extends StatelessWidget {
     if (loans.isEmpty) {
       return const Center(child: Text('진행 중인 대출이 없습니다.'));
     }
+    // T158: sort so overdue loans float to the top. Within each group keep
+    // the original order (earliest dueDate first via dueDate ascending).
+    final now = DateTime.now();
+    final sorted = [...loans]..sort((a, b) {
+        final aOverdue = a.isOverdue || a.daysUntilDue(now) < 0;
+        final bOverdue = b.isOverdue || b.daysUntilDue(now) < 0;
+        if (aOverdue != bOverdue) return aOverdue ? -1 : 1;
+        return a.dueDate.compareTo(b.dueDate);
+      });
     return ListView.separated(
       padding: const EdgeInsets.all(16),
-      itemCount: loans.length,
+      itemCount: sorted.length,
       separatorBuilder: (_, __) => const Divider(height: 1),
-      itemBuilder: (context, i) => _LoanRow(loan: loans[i]),
+      itemBuilder: (context, i) => _LoanRow(loan: sorted[i]),
     );
   }
 }
@@ -271,24 +280,41 @@ class _LoanRow extends StatelessWidget {
     final bookTitle = loan.book?.title ?? loan.bookId;
     final studentName =
         loan.student?.fullName ?? loan.student?.username ?? loan.studentId;
-    return ListTile(
-      title: Row(
-        children: [
-          Expanded(
-            child: Text(bookTitle, overflow: TextOverflow.ellipsis),
-          ),
-          const SizedBox(width: 8),
-          OverdueIndicator(
-            dueDate: loan.dueDate,
-            isOverdue: loan.isOverdue,
-          ),
-        ],
-      ),
-      subtitle: Text('$studentName · 만기 ${_formatDate(loan.dueDate)}'),
-      trailing: IconButton(
-        tooltip: '반납 처리',
-        icon: const Icon(Icons.assignment_returned_outlined),
-        onPressed: () => _confirmReturn(context, loan),
+    final daysLeft = loan.daysUntilDue(DateTime.now());
+    final overdue = loan.isOverdue || daysLeft < 0;
+    final theme = Theme.of(context);
+
+    // T158: row-level highlighting for overdue loans. OverdueIndicator chip
+    // already calls out the cell, but a subtle tint + left border makes
+    // overdue rows scan-detectable even when many loans share the screen.
+    return Container(
+      decoration: overdue
+          ? BoxDecoration(
+              color: theme.colorScheme.errorContainer.withOpacity(0.25),
+              border: Border(
+                left: BorderSide(color: theme.colorScheme.error, width: 4),
+              ),
+            )
+          : null,
+      child: ListTile(
+        title: Row(
+          children: [
+            Expanded(
+              child: Text(bookTitle, overflow: TextOverflow.ellipsis),
+            ),
+            const SizedBox(width: 8),
+            OverdueIndicator(
+              dueDate: loan.dueDate,
+              isOverdue: loan.isOverdue,
+            ),
+          ],
+        ),
+        subtitle: Text('$studentName · 만기 ${_formatDate(loan.dueDate)}'),
+        trailing: IconButton(
+          tooltip: '반납 처리',
+          icon: const Icon(Icons.assignment_returned_outlined),
+          onPressed: () => _confirmReturn(context, loan),
+        ),
       ),
     );
   }

--- a/specs/001-library-management/tasks.md
+++ b/specs/001-library-management/tasks.md
@@ -326,7 +326,7 @@
 
 - [X] T156 [US5] Implement loan approval with automatic book availability update — 이미 `loan_service.approveLoanRequest` (트랜잭션, decrement). 단위 테스트로 가용 자동 차감 검증.
 - [X] T157 [US5] Implement book return with automatic reservation queue notification — 이미 `loan_service.returnLoan` (increment + `notifyNextInQueue`). 단위 테스트로 알림 자동 트리거 검증.
-- [ ] T158 [US5] Add overdue loan highlighting in loan list
+- [X] T158 [US5] Add overdue loan highlighting in loan list — 행 배경 errorContainer 25% + 좌측 4px 빨간 border + 연체 행 sort-to-top (active 탭 한정)
 - [ ] T159 [US5] Add date range filters for loan history
 
 **Checkpoint**: User Story 5 complete - admins can manage loans, works with US2 and US4

--- a/test/features/admin_catalog/presentation/screens/loans_management_screen_test.dart
+++ b/test/features/admin_catalog/presentation/screens/loans_management_screen_test.dart
@@ -168,5 +168,66 @@ void main() {
       expect(find.textContaining('네트워크 오류'), findsOneWidget);
       expect(find.widgetWithText(FilledButton, '다시 시도'), findsOneWidget);
     });
+
+    // T158: overdue highlighting + sort-to-top.
+    testWidgets('overdue loans float to the top of the active list',
+        (tester) async {
+      // Three loans: B is overdue, A and C are on track.
+      // Without sorting they'd be A, B, C; with T158 we expect B, A, C
+      // (overdue first, then dueDate asc).
+      final now = DateTime.now();
+      final repo = FakeAdminLoanRepository()
+        ..loansByStatus = [
+          makeLoan(
+            id: 'a',
+            book: _book('Book A'),
+            dueDate: now.add(const Duration(days: 5)),
+          ),
+          makeLoan(
+            id: 'b',
+            book: _book('Book B'),
+            status: LoanStatus.overdue,
+            dueDate: now.subtract(const Duration(days: 3)),
+          ),
+          makeLoan(
+            id: 'c',
+            book: _book('Book C'),
+            dueDate: now.add(const Duration(days: 10)),
+          ),
+        ];
+      await _pump(tester, repo);
+      await tester.tap(find.text('진행 중인 대출'));
+      await tester.pumpAndSettle();
+
+      // The overdue Book B's title text should appear before A in the rendered
+      // tree. We approximate by reading position.
+      final bRect = tester.getTopLeft(find.text('Book B').first);
+      final aRect = tester.getTopLeft(find.text('Book A').first);
+      expect(bRect.dy, lessThan(aRect.dy));
+    });
+
+    testWidgets('overdue row gets a red-tinted background and left border',
+        (tester) async {
+      final now = DateTime.now();
+      final repo = FakeAdminLoanRepository()
+        ..loansByStatus = [
+          makeLoan(
+            id: 'late',
+            book: _book('Late Book'),
+            status: LoanStatus.overdue,
+            dueDate: now.subtract(const Duration(days: 2)),
+          ),
+        ];
+      await _pump(tester, repo);
+      await tester.tap(find.text('진행 중인 대출'));
+      await tester.pumpAndSettle();
+
+      // The container with non-null decoration corresponds to the overdue row.
+      final containers = tester
+          .widgetList<Container>(find.byType(Container))
+          .where((c) => c.decoration is BoxDecoration);
+      // At least one container with decoration (the overdue row) exists.
+      expect(containers, isNotEmpty);
+    });
   });
 }


### PR DESCRIPTION
Closes #173

## Summary

T158 — 진행 중인 대출 목록에서 연체 행을 시각적으로 강조 + 정렬 우선순위.

## 변경

### `_LoanRow` 행 강조
연체 행을 다음으로 감싸기:
- 배경: `errorContainer.withOpacity(0.25)`
- 좌측 4px 빨간 border (강한 시각 신호)

### `_ActiveTab` 정렬
표시 전 정렬: **연체 우선 → dueDate 오름차순**.

OverdueIndicator chip (PR #166)은 셀 단위 라벨, 이번 PR의 행 강조는 시야 단위. 둘이 같이 작동해서 한 화면에 많은 대출이 있어도 즉시 연체 식별 + 상단 우선 노출.

## 테스트 추가 2건

- **정렬 검증**: A(정상)/B(연체)/C(정상) 순으로 데이터 주입했을 때 B가 A보다 위에 렌더 (좌표 비교)
- **시각 강조 검증**: 연체 행 컨테이너에 `BoxDecoration` 적용

기존 8 LoansManagementScreen 테스트 회귀 없음.

## Test plan

- [x] `flutter test` 258 → 260 (+2, 회귀 없음)
- [x] flutter analyze (info-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)