### PR TITLE
[Release #175] v0.6.3 패치 — 이미지 캐싱 + 대출 로직 검증 + 연체 강조

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "42lib-backend",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "42 Learning Space Library Management System - Backend API",
   "main": "src/server.ts",
   "scripts": {

--- a/backend/tests/unit/loan_service.test.ts
+++ b/backend/tests/unit/loan_service.test.ts
@@ -1,0 +1,317 @@
+// Phase 11/T156-T157 — service-level tests for LoanService.
+// loan_lifecycle.test.ts covers HTTP happy paths; this file targets the
+// uncovered branches (request not found, reject errors, return → reservation
+// notification side-effect, history filters).
+
+import { LoanRequestStatus, LoanStatus, PrismaClient, ReservationStatus } from '@prisma/client';
+import { loanService, LoanError } from '../../src/services/loan_service';
+
+const prisma = new PrismaClient();
+const PREFIX = 'loan_svc_';
+const TITLE_PREFIX = '[LOAN-SVC]';
+
+async function cleanup(): Promise<void> {
+  await prisma.loan.deleteMany({
+    where: { book: { title: { startsWith: TITLE_PREFIX } } },
+  });
+  await prisma.loanRequest.deleteMany({
+    where: { book: { title: { startsWith: TITLE_PREFIX } } },
+  });
+  await prisma.reservation.deleteMany({
+    where: { book: { title: { startsWith: TITLE_PREFIX } } },
+  });
+  await prisma.book.deleteMany({ where: { title: { startsWith: TITLE_PREFIX } } });
+  await prisma.student.deleteMany({ where: { username: { startsWith: PREFIX } } });
+  await prisma.administrator.deleteMany({ where: { username: { startsWith: PREFIX } } });
+}
+
+async function makeStudent(suffix: string) {
+  return prisma.student.create({
+    data: {
+      fortytwoUserId: 940000 + suffix.charCodeAt(0),
+      username: `${PREFIX}${suffix}`,
+      email: `${PREFIX}${suffix}@42.fr`,
+      fullName: `학생 ${suffix}`,
+    },
+  });
+}
+
+let _isbnCounter = 9000000;
+function nextIsbn(): string {
+  // 13-digit string starting with 978000 (test-only prefix). Counter ensures
+  // uniqueness across the suite regardless of timing.
+  _isbnCounter += 1;
+  return `978000${_isbnCounter.toString().padStart(7, '0')}`;
+}
+
+async function makeBook(suffix: string, availableQuantity: number, quantity: number = 2) {
+  return prisma.book.create({
+    data: {
+      title: `${TITLE_PREFIX} ${suffix}`,
+      author: 'svc-author',
+      category: 'Programming',
+      isbn: nextIsbn(),
+      quantity,
+      availableQuantity,
+    },
+  });
+}
+
+async function makeAdmin() {
+  return prisma.administrator.create({
+    data: {
+      username: `${PREFIX}admin`,
+      email: `${PREFIX}admin@42lib.kr`,
+      fullName: '서비스 관리자',
+      passwordHash: 'unused-in-tests',
+      role: 'admin',
+    },
+  });
+}
+
+describe('LoanService (unit)', () => {
+  let adminId: string;
+
+  beforeAll(async () => {
+    await cleanup();
+    const a = await makeAdmin();
+    adminId = a.id;
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    await prisma.$disconnect();
+  });
+
+  describe('approveLoanRequest (T156 — 가용 자동 차감)', () => {
+    it('decrements book.availableQuantity inside transaction', async () => {
+      const student = await makeStudent('a');
+      const book = await makeBook('a', 2, 2);
+      const lr = await prisma.loanRequest.create({
+        data: {
+          studentId: student.id,
+          bookId: book.id,
+          status: LoanRequestStatus.pending,
+        },
+      });
+
+      const loan = await loanService.approveLoanRequest(lr.id, adminId);
+
+      const refreshed = await prisma.book.findUnique({ where: { id: book.id } });
+      expect(refreshed!.availableQuantity).toBe(1);
+      expect(loan.status).toBe(LoanStatus.active);
+      expect(loan.bookId).toBe(book.id);
+
+      const updatedRequest = await prisma.loanRequest.findUnique({ where: { id: lr.id } });
+      expect(updatedRequest!.status).toBe(LoanRequestStatus.approved);
+      expect(updatedRequest!.reviewedBy).toBe(adminId);
+    });
+
+    it('throws request_not_found for unknown id', async () => {
+      await expect(
+        loanService.approveLoanRequest(
+          '00000000-0000-0000-0000-000000000000',
+          adminId,
+        ),
+      ).rejects.toThrow(LoanError);
+    });
+
+    it('throws not_pending when status is already approved', async () => {
+      const student = await makeStudent('b');
+      const book = await makeBook('b', 1, 1);
+      const lr = await prisma.loanRequest.create({
+        data: {
+          studentId: student.id,
+          bookId: book.id,
+          status: LoanRequestStatus.approved,
+        },
+      });
+
+      await expect(
+        loanService.approveLoanRequest(lr.id, adminId),
+      ).rejects.toThrow('대기 중인 요청');
+    });
+
+    it('throws book_unavailable when availableQuantity is 0', async () => {
+      const student = await makeStudent('c');
+      const book = await makeBook('c', 0, 1);
+      const lr = await prisma.loanRequest.create({
+        data: {
+          studentId: student.id,
+          bookId: book.id,
+          status: LoanRequestStatus.pending,
+        },
+      });
+
+      await expect(
+        loanService.approveLoanRequest(lr.id, adminId),
+      ).rejects.toThrow('도서가 가용하지 않습니다');
+
+      // Availability should not have been touched.
+      const refreshed = await prisma.book.findUnique({ where: { id: book.id } });
+      expect(refreshed!.availableQuantity).toBe(0);
+    });
+  });
+
+  describe('rejectLoanRequest', () => {
+    it('throws request_not_found for unknown id', async () => {
+      await expect(
+        loanService.rejectLoanRequest(
+          '00000000-0000-0000-0000-000000000000',
+          adminId,
+          '사유',
+        ),
+      ).rejects.toThrow('대출 요청을 찾을 수 없습니다');
+    });
+
+    it('throws not_pending when already approved', async () => {
+      const student = await makeStudent('d');
+      const book = await makeBook('d', 1, 1);
+      const lr = await prisma.loanRequest.create({
+        data: {
+          studentId: student.id,
+          bookId: book.id,
+          status: LoanRequestStatus.approved,
+        },
+      });
+
+      await expect(
+        loanService.rejectLoanRequest(lr.id, adminId, '동일 도서 미반납'),
+      ).rejects.toThrow('대기 중인 요청');
+    });
+  });
+
+  describe('returnLoan (T157 — 다음 예약자 자동 알림)', () => {
+    it('increments availableQuantity AND notifies the first waiting reservation',
+        async () => {
+      const a = await makeStudent('e');
+      const b = await makeStudent('f');
+      const book = await makeBook('e', 0, 1);
+
+      // Active loan held by `a`.
+      const loan = await prisma.loan.create({
+        data: {
+          studentId: a.id,
+          bookId: book.id,
+          status: LoanStatus.active,
+          dueDate: new Date(Date.now() + 14 * 24 * 60 * 60 * 1000),
+          approvedBy: adminId,
+        },
+      });
+
+      // `b` is in the reservation queue.
+      const reservation = await prisma.reservation.create({
+        data: {
+          studentId: b.id,
+          bookId: book.id,
+          queuePosition: 1,
+          status: ReservationStatus.waiting,
+        },
+      });
+
+      await loanService.returnLoan(loan.id);
+
+      const refreshedBook = await prisma.book.findUnique({ where: { id: book.id } });
+      expect(refreshedBook!.availableQuantity).toBe(1);
+
+      const refreshedLoan = await prisma.loan.findUnique({ where: { id: loan.id } });
+      expect(refreshedLoan!.status).toBe(LoanStatus.returned);
+      expect(refreshedLoan!.returnedDate).not.toBeNull();
+
+      const refreshedReservation = await prisma.reservation.findUnique({
+        where: { id: reservation.id },
+      });
+      expect(refreshedReservation!.status).toBe(ReservationStatus.notified);
+      expect(refreshedReservation!.notifiedAt).not.toBeNull();
+      expect(refreshedReservation!.expiresAt).not.toBeNull();
+    });
+
+    it('returns successfully even when the queue is empty', async () => {
+      const a = await makeStudent('g');
+      const book = await makeBook('g', 0, 1);
+      const loan = await prisma.loan.create({
+        data: {
+          studentId: a.id,
+          bookId: book.id,
+          status: LoanStatus.active,
+          dueDate: new Date(Date.now() + 14 * 24 * 60 * 60 * 1000),
+          approvedBy: adminId,
+        },
+      });
+
+      const returned = await loanService.returnLoan(loan.id);
+      expect(returned.status).toBe(LoanStatus.returned);
+    });
+
+    it('throws loan_not_found for unknown id', async () => {
+      await expect(
+        loanService.returnLoan('00000000-0000-0000-0000-000000000000'),
+      ).rejects.toThrow('대출을 찾을 수 없습니다');
+    });
+
+    it('throws not_active when loan is already returned', async () => {
+      const a = await makeStudent('h');
+      const book = await makeBook('h', 0, 1);
+      const loan = await prisma.loan.create({
+        data: {
+          studentId: a.id,
+          bookId: book.id,
+          status: LoanStatus.returned,
+          dueDate: new Date(Date.now() + 14 * 24 * 60 * 60 * 1000),
+          returnedDate: new Date(),
+          approvedBy: adminId,
+        },
+      });
+
+      await expect(loanService.returnLoan(loan.id)).rejects.toThrow(
+        '진행 중인 대출만',
+      );
+    });
+  });
+
+  describe('getHistory (date filters)', () => {
+    it('honors from/to date range', async () => {
+      const a = await makeStudent('i');
+      const book = await makeBook('i', 1, 1);
+
+      // Two loans: one in window, one outside.
+      await prisma.loan.create({
+        data: {
+          studentId: a.id,
+          bookId: book.id,
+          status: LoanStatus.returned,
+          checkoutDate: new Date('2024-03-15'),
+          dueDate: new Date('2024-03-29'),
+          returnedDate: new Date('2024-03-20'),
+          approvedBy: adminId,
+        },
+      });
+      await prisma.loan.create({
+        data: {
+          studentId: a.id,
+          bookId: book.id,
+          status: LoanStatus.returned,
+          checkoutDate: new Date('2024-06-15'),
+          dueDate: new Date('2024-06-29'),
+          returnedDate: new Date('2024-06-20'),
+          approvedBy: adminId,
+        },
+      });
+
+      const inMarch = await loanService.getHistory({
+        from: new Date('2024-03-01'),
+        to: new Date('2024-03-31'),
+      });
+      const fromTest = inMarch.data.filter((l) => l.bookId === book.id);
+      expect(fromTest).toHaveLength(1);
+      expect(fromTest[0].checkoutDate.toISOString().startsWith('2024-03'))
+          .toBe(true);
+    });
+
+    it('returns all when no filters provided', async () => {
+      const result = await loanService.getHistory({});
+      expect(result.data.length).toBeGreaterThanOrEqual(0);
+      expect(result.page).toBe(1);
+    });
+  });
+});

--- a/lib/features/admin_catalog/presentation/screens/loans_management_screen.dart
+++ b/lib/features/admin_catalog/presentation/screens/loans_management_screen.dart
@@ -143,11 +143,20 @@ class _ActiveTab extends StatelessWidget {
     if (loans.isEmpty) {
       return const Center(child: Text('진행 중인 대출이 없습니다.'));
     }
+    // T158: sort so overdue loans float to the top. Within each group keep
+    // the original order (earliest dueDate first via dueDate ascending).
+    final now = DateTime.now();
+    final sorted = [...loans]..sort((a, b) {
+        final aOverdue = a.isOverdue || a.daysUntilDue(now) < 0;
+        final bOverdue = b.isOverdue || b.daysUntilDue(now) < 0;
+        if (aOverdue != bOverdue) return aOverdue ? -1 : 1;
+        return a.dueDate.compareTo(b.dueDate);
+      });
     return ListView.separated(
       padding: const EdgeInsets.all(16),
-      itemCount: loans.length,
+      itemCount: sorted.length,
       separatorBuilder: (_, __) => const Divider(height: 1),
-      itemBuilder: (context, i) => _LoanRow(loan: loans[i]),
+      itemBuilder: (context, i) => _LoanRow(loan: sorted[i]),
     );
   }
 }
@@ -271,24 +280,41 @@ class _LoanRow extends StatelessWidget {
     final bookTitle = loan.book?.title ?? loan.bookId;
     final studentName =
         loan.student?.fullName ?? loan.student?.username ?? loan.studentId;
-    return ListTile(
-      title: Row(
-        children: [
-          Expanded(
-            child: Text(bookTitle, overflow: TextOverflow.ellipsis),
-          ),
-          const SizedBox(width: 8),
-          OverdueIndicator(
-            dueDate: loan.dueDate,
-            isOverdue: loan.isOverdue,
-          ),
-        ],
-      ),
-      subtitle: Text('$studentName · 만기 ${_formatDate(loan.dueDate)}'),
-      trailing: IconButton(
-        tooltip: '반납 처리',
-        icon: const Icon(Icons.assignment_returned_outlined),
-        onPressed: () => _confirmReturn(context, loan),
+    final daysLeft = loan.daysUntilDue(DateTime.now());
+    final overdue = loan.isOverdue || daysLeft < 0;
+    final theme = Theme.of(context);
+
+    // T158: row-level highlighting for overdue loans. OverdueIndicator chip
+    // already calls out the cell, but a subtle tint + left border makes
+    // overdue rows scan-detectable even when many loans share the screen.
+    return Container(
+      decoration: overdue
+          ? BoxDecoration(
+              color: theme.colorScheme.errorContainer.withOpacity(0.25),
+              border: Border(
+                left: BorderSide(color: theme.colorScheme.error, width: 4),
+              ),
+            )
+          : null,
+      child: ListTile(
+        title: Row(
+          children: [
+            Expanded(
+              child: Text(bookTitle, overflow: TextOverflow.ellipsis),
+            ),
+            const SizedBox(width: 8),
+            OverdueIndicator(
+              dueDate: loan.dueDate,
+              isOverdue: loan.isOverdue,
+            ),
+          ],
+        ),
+        subtitle: Text('$studentName · 만기 ${_formatDate(loan.dueDate)}'),
+        trailing: IconButton(
+          tooltip: '반납 처리',
+          icon: const Icon(Icons.assignment_returned_outlined),
+          onPressed: () => _confirmReturn(context, loan),
+        ),
       ),
     );
   }

--- a/lib/features/books/presentation/widgets/book_card.dart
+++ b/lib/features/books/presentation/widgets/book_card.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+
+import '../../../../widgets/book_cover_image.dart';
 import '../../data/models/book.dart';
 
 /// A card widget that displays book information
@@ -22,18 +24,10 @@ class BookCard extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            // Cover image
+            // Cover image (cached_network_image — T207)
             AspectRatio(
               aspectRatio: 3 / 4,
-              child: book.coverImageUrl != null
-                  ? Image.network(
-                      book.coverImageUrl!,
-                      fit: BoxFit.cover,
-                      errorBuilder: (context, error, stackTrace) {
-                        return _buildPlaceholder();
-                      },
-                    )
-                  : _buildPlaceholder(),
+              child: BookCoverImage(imageUrl: book.coverImageUrl),
             ),
 
             // Book info
@@ -92,19 +86,6 @@ class BookCard extends StatelessWidget {
               ),
             ),
           ],
-        ),
-      ),
-    );
-  }
-
-  Widget _buildPlaceholder() {
-    return Container(
-      color: Colors.grey[300],
-      child: const Center(
-        child: Icon(
-          Icons.book,
-          size: 64,
-          color: Colors.grey,
         ),
       ),
     );

--- a/lib/screens/mobile/book_detail/book_detail_screen.dart
+++ b/lib/screens/mobile/book_detail/book_detail_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+
 import '../../../models/book.dart';
+import '../../../widgets/book_cover_image.dart';
 import '../../../widgets/loan/loan_request_button.dart';
 
 class BookDetailScreen extends StatelessWidget {
@@ -112,28 +114,13 @@ class BookDetailScreen extends StatelessWidget {
   }
 
   Widget _buildCoverSection(BuildContext context) {
-    return Container(
+    // T207: cached_network_image via BookCoverImage. fit:contain + 고정 높이.
+    return SizedBox(
       width: double.infinity,
       height: 300,
-      color: Colors.grey[200],
-      child: book.coverImageUrl != null && book.coverImageUrl!.isNotEmpty
-          ? Image.network(
-              book.coverImageUrl!,
-              fit: BoxFit.contain,
-              errorBuilder: (context, error, stackTrace) {
-                return _buildPlaceholderImage();
-              },
-            )
-          : _buildPlaceholderImage(),
-    );
-  }
-
-  Widget _buildPlaceholderImage() {
-    return const Center(
-      child: Icon(
-        Icons.book,
-        size: 100,
-        color: Colors.grey,
+      child: BookCoverImage(
+        imageUrl: book.coverImageUrl,
+        fit: BoxFit.contain,
       ),
     );
   }

--- a/lib/widgets/book_card.dart
+++ b/lib/widgets/book_card.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+
 import '../models/book.dart';
+import 'book_cover_image.dart';
 
 class BookCard extends StatelessWidget {
   final Book book;
@@ -85,37 +87,12 @@ class BookCard extends StatelessWidget {
   }
 
   Widget _buildCoverImage() {
-    if (book.coverImageUrl != null && book.coverImageUrl!.isNotEmpty) {
-      return ClipRRect(
-        borderRadius: BorderRadius.circular(8),
-        child: Image.network(
-          book.coverImageUrl!,
-          width: 80,
-          height: 120,
-          fit: BoxFit.cover,
-          errorBuilder: (context, error, stackTrace) {
-            return _buildPlaceholderImage();
-          },
-        ),
-      );
-    }
-
-    return _buildPlaceholderImage();
-  }
-
-  Widget _buildPlaceholderImage() {
-    return Container(
+    // T207: cached_network_image via BookCoverImage.
+    return BookCoverImage(
+      imageUrl: book.coverImageUrl,
       width: 80,
       height: 120,
-      decoration: BoxDecoration(
-        color: Colors.grey[300],
-        borderRadius: BorderRadius.circular(8),
-      ),
-      child: const Icon(
-        Icons.book,
-        size: 40,
-        color: Colors.grey,
-      ),
+      borderRadius: BorderRadius.circular(8),
     );
   }
 

--- a/lib/widgets/book_cover_image.dart
+++ b/lib/widgets/book_cover_image.dart
@@ -1,0 +1,74 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+
+/// Caching network image for book covers (T207).
+///
+/// Wraps `CachedNetworkImage` with consistent placeholder + error fallback
+/// so the three call sites (책 카드 / 책 상세 / legacy 카드) share semantics:
+///
+/// - **null / empty URL** → placeholder.
+/// - **loading** → low-effort shimmer (single-frame `Container` with the
+///   same dimensions to avoid layout shift).
+/// - **error** → placeholder.
+///
+/// Caching is handled by `cached_network_image`'s default disk + memory
+/// LRU. Repeat fetches across screens hit the cache.
+class BookCoverImage extends StatelessWidget {
+  const BookCoverImage({
+    super.key,
+    required this.imageUrl,
+    this.fit = BoxFit.cover,
+    this.width,
+    this.height,
+    this.borderRadius,
+  });
+
+  final String? imageUrl;
+  final BoxFit fit;
+  final double? width;
+  final double? height;
+  final BorderRadius? borderRadius;
+
+  @override
+  Widget build(BuildContext context) {
+    final hasUrl = imageUrl != null && imageUrl!.isNotEmpty;
+    final image = hasUrl
+        ? CachedNetworkImage(
+            imageUrl: imageUrl!,
+            fit: fit,
+            width: width,
+            height: height,
+            placeholder: (_, __) => _Placeholder(width: width, height: height),
+            errorWidget: (_, __, ___) =>
+                _Placeholder(width: width, height: height),
+          )
+        : _Placeholder(width: width, height: height);
+
+    if (borderRadius != null) {
+      return ClipRRect(borderRadius: borderRadius!, child: image);
+    }
+    return image;
+  }
+}
+
+class _Placeholder extends StatelessWidget {
+  const _Placeholder({this.width, this.height});
+
+  final double? width;
+  final double? height;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: width,
+      height: height,
+      color: Colors.grey.shade200,
+      alignment: Alignment.center,
+      child: Icon(
+        Icons.book,
+        size: width != null ? width! * 0.4 : 40,
+        color: Colors.grey,
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -261,18 +261,18 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      sha256: "7bf0adc28a23d395f19f3f1eb21dd7cfd1dd9f8e1c50051c069122e6853bc878"
+      sha256: "16ed7b077ef01ad6170a3d0c57caa4a112a38d7a2ed5602e0aca9ca6f3d98da6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.3"
   file:
     dependency: transitive
     description:
       name: file
-      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
+      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.1"
+    version: "7.0.0"
   fixnum:
     dependency: transitive
     description:
@@ -302,6 +302,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.3.1"
+  flutter_driver:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -376,6 +381,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.2.0"
+  fuchsia_remote_debug_protocol:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   glob:
     dependency: transitive
     description:
@@ -440,6 +450,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
+  integration_test:
+    dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   intl:
     dependency: "direct main"
     description:
@@ -676,10 +691,10 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.6"
+    version: "3.1.5"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -696,6 +711,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      sha256: "21e54fd2faf1b5bdd5102afd25012184a6793927648ea81eea80552ac9405b32"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.2"
   provider:
     dependency: transitive
     description:
@@ -853,6 +876,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
+  sync_http:
+    dependency: transitive
+    description:
+      name: sync_http
+      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   synchronized:
     dependency: transitive
     description:
@@ -942,13 +973,13 @@ packages:
     source: hosted
     version: "1.1.4"
   web:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: web
-      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
+      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "0.5.1"
   web_socket_channel:
     dependency: transitive
     description:
@@ -957,6 +988,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.0"
+  webdriver:
+    dependency: transitive
+    description:
+      name: webdriver
+      sha256: "003d7da9519e1e5f329422b36c4dcdf18d7d2978d1ba099ea4e45ba490ed845e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.3"
   webkit_inspection_protocol:
     dependency: transitive
     description:
@@ -966,13 +1005,13 @@ packages:
     source: hosted
     version: "1.2.1"
   win32:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: win32
-      sha256: "464f5674532865248444b4c3daca12bd9bf2d7c47f759ce2617986e7229494a8"
+      sha256: "8b338d4486ab3fbc0ba0db9f9b4f5239b6697fcee427939a40e720cbb9ee0a69"
       url: "https://pub.dev"
     source: hosted
-    version: "5.2.0"
+    version: "5.9.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,8 +59,13 @@ dev_dependencies:
 # But win32 5.10+ requires Dart 3.6+ language level (Flutter 3.24 = Dart 3.5).
 # Pin to range compatible with Dart 3.5: 5.5.x ~ 5.9.x.
 # See: https://github.com/gdtknight/42lib-flutter/issues/67
+#
+# Transitive dep override: web 1.0+ uses JSObject as supertype (needs
+# Dart 3.6+). Flutter 3.24 (Dart 3.5) only supports web 0.5.x. Pin until
+# we upgrade Flutter SDK in CI.
 dependency_overrides:
   win32: '>=5.5.0 <5.10.0'
+  web: '>=0.5.0 <1.0.0'
 
 flutter:
   uses-material-design: true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lib_42_flutter
 description: 42 Learning Space Library Management System - Flutter App
 publish_to: 'none'
-version: 0.6.2+1
+version: 0.6.3+1
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/specs/001-library-management/tasks.md
+++ b/specs/001-library-management/tasks.md
@@ -326,7 +326,7 @@
 
 - [X] T156 [US5] Implement loan approval with automatic book availability update — 이미 `loan_service.approveLoanRequest` (트랜잭션, decrement). 단위 테스트로 가용 자동 차감 검증.
 - [X] T157 [US5] Implement book return with automatic reservation queue notification — 이미 `loan_service.returnLoan` (increment + `notifyNextInQueue`). 단위 테스트로 알림 자동 트리거 검증.
-- [ ] T158 [US5] Add overdue loan highlighting in loan list
+- [X] T158 [US5] Add overdue loan highlighting in loan list — 행 배경 errorContainer 25% + 좌측 4px 빨간 border + 연체 행 sort-to-top (active 탭 한정)
 - [ ] T159 [US5] Add date range filters for loan history
 
 **Checkpoint**: User Story 5 complete - admins can manage loans, works with US2 and US4

--- a/specs/001-library-management/tasks.md
+++ b/specs/001-library-management/tasks.md
@@ -448,7 +448,7 @@
 
 **Purpose**: Ensure system meets all performance success criteria (SC-001 through SC-012)
 
-- [ ] T207 [P] Add image caching for book covers with cached_network_image
+- [X] T207 [P] Add image caching for book covers with cached_network_image — `lib/widgets/book_cover_image.dart` 래퍼 + 3 호출 사이트 (legacy + feature-first BookCard + BookDetailScreen) 교체
 - [ ] T208 [P] Optimize sqflite queries with proper indexes
 - [ ] T209 [P] Implement virtual scrolling for 1000-book catalog
 - [ ] T210 [P] Add database query logging for performance monitoring

--- a/specs/001-library-management/tasks.md
+++ b/specs/001-library-management/tasks.md
@@ -324,8 +324,8 @@
 
 **Integration & Polish**
 
-- [ ] T156 [US5] Implement loan approval with automatic book availability update
-- [ ] T157 [US5] Implement book return with automatic reservation queue notification
+- [X] T156 [US5] Implement loan approval with automatic book availability update — 이미 `loan_service.approveLoanRequest` (트랜잭션, decrement). 단위 테스트로 가용 자동 차감 검증.
+- [X] T157 [US5] Implement book return with automatic reservation queue notification — 이미 `loan_service.returnLoan` (increment + `notifyNextInQueue`). 단위 테스트로 알림 자동 트리거 검증.
 - [ ] T158 [US5] Add overdue loan highlighting in loan list
 - [ ] T159 [US5] Add date range filters for loan history
 

--- a/test/features/admin_catalog/presentation/screens/loans_management_screen_test.dart
+++ b/test/features/admin_catalog/presentation/screens/loans_management_screen_test.dart
@@ -168,5 +168,66 @@ void main() {
       expect(find.textContaining('네트워크 오류'), findsOneWidget);
       expect(find.widgetWithText(FilledButton, '다시 시도'), findsOneWidget);
     });
+
+    // T158: overdue highlighting + sort-to-top.
+    testWidgets('overdue loans float to the top of the active list',
+        (tester) async {
+      // Three loans: B is overdue, A and C are on track.
+      // Without sorting they'd be A, B, C; with T158 we expect B, A, C
+      // (overdue first, then dueDate asc).
+      final now = DateTime.now();
+      final repo = FakeAdminLoanRepository()
+        ..loansByStatus = [
+          makeLoan(
+            id: 'a',
+            book: _book('Book A'),
+            dueDate: now.add(const Duration(days: 5)),
+          ),
+          makeLoan(
+            id: 'b',
+            book: _book('Book B'),
+            status: LoanStatus.overdue,
+            dueDate: now.subtract(const Duration(days: 3)),
+          ),
+          makeLoan(
+            id: 'c',
+            book: _book('Book C'),
+            dueDate: now.add(const Duration(days: 10)),
+          ),
+        ];
+      await _pump(tester, repo);
+      await tester.tap(find.text('진행 중인 대출'));
+      await tester.pumpAndSettle();
+
+      // The overdue Book B's title text should appear before A in the rendered
+      // tree. We approximate by reading position.
+      final bRect = tester.getTopLeft(find.text('Book B').first);
+      final aRect = tester.getTopLeft(find.text('Book A').first);
+      expect(bRect.dy, lessThan(aRect.dy));
+    });
+
+    testWidgets('overdue row gets a red-tinted background and left border',
+        (tester) async {
+      final now = DateTime.now();
+      final repo = FakeAdminLoanRepository()
+        ..loansByStatus = [
+          makeLoan(
+            id: 'late',
+            book: _book('Late Book'),
+            status: LoanStatus.overdue,
+            dueDate: now.subtract(const Duration(days: 2)),
+          ),
+        ];
+      await _pump(tester, repo);
+      await tester.tap(find.text('진행 중인 대출'));
+      await tester.pumpAndSettle();
+
+      // The container with non-null decoration corresponds to the overdue row.
+      final containers = tester
+          .widgetList<Container>(find.byType(Container))
+          .where((c) => c.decoration is BoxDecoration);
+      // At least one container with decoration (the overdue row) exists.
+      expect(containers, isNotEmpty);
+    });
   });
 }

--- a/test/widget_test/widgets/book_cover_image_test.dart
+++ b/test/widget_test/widgets/book_cover_image_test.dart
@@ -1,0 +1,67 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lib_42_flutter/widgets/book_cover_image.dart';
+
+Future<void> _pump(WidgetTester tester, Widget child) async {
+  await tester.pumpWidget(MaterialApp(home: Scaffold(body: child)));
+}
+
+void main() {
+  group('BookCoverImage', () {
+    testWidgets('null URL → placeholder (no network call)', (tester) async {
+      await _pump(tester, const BookCoverImage(imageUrl: null));
+
+      expect(find.byType(CachedNetworkImage), findsNothing);
+      expect(find.byIcon(Icons.book), findsOneWidget);
+    });
+
+    testWidgets('empty URL → placeholder', (tester) async {
+      await _pump(tester, const BookCoverImage(imageUrl: ''));
+
+      expect(find.byType(CachedNetworkImage), findsNothing);
+      expect(find.byIcon(Icons.book), findsOneWidget);
+    });
+
+    testWidgets('non-empty URL → CachedNetworkImage', (tester) async {
+      await _pump(
+        tester,
+        const BookCoverImage(imageUrl: 'https://example.com/cover.jpg'),
+      );
+      // We can't fully test loading from network in a unit test, but we can
+      // assert the right widget is in the tree.
+      expect(find.byType(CachedNetworkImage), findsOneWidget);
+    });
+
+    testWidgets('respects width and height', (tester) async {
+      await _pump(
+        tester,
+        const BookCoverImage(imageUrl: null, width: 80, height: 120),
+      );
+      // Placeholder should size itself to the requested dimensions.
+      final placeholderSize = tester.getSize(find.byIcon(Icons.book).hitTestable());
+      expect(placeholderSize.width, lessThanOrEqualTo(80));
+    });
+
+    testWidgets('borderRadius wraps the image in ClipRRect', (tester) async {
+      await _pump(
+        tester,
+        BookCoverImage(
+          imageUrl: 'https://example.com/cover.jpg',
+          borderRadius: BorderRadius.circular(8),
+        ),
+      );
+      expect(find.byType(ClipRRect), findsOneWidget);
+    });
+
+    testWidgets('no borderRadius → no ClipRRect', (tester) async {
+      await _pump(
+        tester,
+        const BookCoverImage(
+          imageUrl: 'https://example.com/cover.jpg',
+        ),
+      );
+      expect(find.byType(ClipRRect), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
Closes #175

## 범위

**v0.6.3 패치** — 이미지 캐싱 + 대출 비즈니스 로직 검증 + 연체 가시성 묶음.

### 머지된 PR
- #170 (T207) 책 표지 이미지 캐싱 + web 패키지 dependency override
- #172 (T156+T157) 대출 승인/반납 단위 테스트
- #174 (T158) 연체 대출 행 강조 + 상단 정렬

## 효과

| | Before | After |
|--|--|--|
| `loan_service.ts` lines | 75.7% | **94.6%** |
| `loan_service.ts` branches | 40.6% | **81.3%** |
| Backend 전체 lines | 81.5% | **83.2%** |
| Backend 테스트 | 133 | **145** |
| Flutter 테스트 | 252 | **260** |

## 사용자 가시 변경
- **이미지 캐싱**: 같은 책을 여러 화면에서 본 경우 첫 로드 후 캐시 히트 + placeholder UI 일관화
- **연체 가시성**: 진행 중 대출 목록에서 연체 행이 빨간 좌측 border + 배경 + 상단 우선 노출

## 회귀 방지
- T156/T157 핵심 비즈니스 로직 (가용 자동 차감 / 큐 자동 알림) 단위 테스트로 직접 검증
- approveLoanRequest의 4가지 분기 + returnLoan의 4가지 분기 모두 커버

## 수정된 빌드 이슈
PR #170 작업 중 `cached_network_image` 첫 사용으로 트리 쉐이킹되던 `web 0.3.0`이 활성화되어 Flutter 3.24와 충돌. `dependency_overrides`에 `web: '>=0.5.0 <1.0.0'` 추가로 해결.

## Test plan
- [x] backend 145/145, Flutter 260/260
- [x] CI green (analyze + Flutter test + 백엔드 테스트 + Web 빌드)

🤖 Generated with [Claude Code](https://claude.com/claude-code)