### PR TITLE
[#179] ✨ feat(suggestions): T197 — 추천 통계 헤더

### DIFF
--- a/lib/features/book_suggestions/presentation/screens/suggestions_review_screen.dart
+++ b/lib/features/book_suggestions/presentation/screens/suggestions_review_screen.dart
@@ -127,11 +127,17 @@ class _Body extends StatelessWidget {
               ),
             );
           }
+          // T197: header summary built on the existing grouped data — total
+          // unique books, total requests, top-3 by demand, status breakdown.
+          // No new backend endpoint required.
           return ListView.separated(
             padding: const EdgeInsets.all(16),
-            itemCount: loaded.groups.length,
+            itemCount: loaded.groups.length + 1,
             separatorBuilder: (_, __) => const SizedBox(height: 12),
-            itemBuilder: (context, i) => _GroupCard(group: loaded.groups[i]),
+            itemBuilder: (context, i) {
+              if (i == 0) return _StatsHeader(groups: loaded.groups);
+              return _GroupCard(group: loaded.groups[i - 1]);
+            },
           );
         },
       ),
@@ -425,11 +431,115 @@ class _ItemRow extends StatelessWidget {
                     ),
                   ),
                 ],
-              ),
+              ), // T197 stats header is appended below this _ItemRow class.
             ),
           ),
         ),
       ),
+    );
+  }
+}
+
+/// T197 — Summary header for the review screen built from the existing
+/// grouped data. No new backend endpoint required.
+class _StatsHeader extends StatelessWidget {
+  const _StatsHeader({required this.groups});
+
+  final List<GroupedSuggestion> groups;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final totalGroups = groups.length;
+    final totalRequests =
+        groups.fold<int>(0, (sum, g) => sum + g.requesterCount);
+    final statusTotals = <SuggestionStatus, int>{};
+    for (final g in groups) {
+      g.statuses.forEach((k, v) {
+        statusTotals[k] = (statusTotals[k] ?? 0) + v;
+      });
+    }
+
+    final topByDemand = [...groups]
+      ..sort((a, b) => b.requesterCount.compareTo(a.requesterCount));
+    final top3 = topByDemand.take(3).toList();
+
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.primaryContainer,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '추천 통계',
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.w700,
+              color: theme.colorScheme.onPrimaryContainer,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 16,
+            runSpacing: 4,
+            children: [
+              _stat(theme, '고유 도서', '$totalGroups'),
+              _stat(theme, '총 요청', '$totalRequests'),
+              _stat(theme, '제출됨',
+                  '${statusTotals[SuggestionStatus.submitted] ?? 0}'),
+              _stat(theme, '검토중',
+                  '${statusTotals[SuggestionStatus.underReview] ?? 0}'),
+              _stat(theme, '승인',
+                  '${statusTotals[SuggestionStatus.approved] ?? 0}'),
+              _stat(theme, '반려',
+                  '${statusTotals[SuggestionStatus.rejected] ?? 0}'),
+            ],
+          ),
+          if (top3.isNotEmpty) ...[
+            const SizedBox(height: 12),
+            Text(
+              '수요 Top ${top3.length}',
+              style: theme.textTheme.titleSmall?.copyWith(
+                fontWeight: FontWeight.w600,
+                color: theme.colorScheme.onPrimaryContainer,
+              ),
+            ),
+            const SizedBox(height: 4),
+            ...top3.asMap().entries.map((e) => Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 2),
+                  child: Text(
+                    '${e.key + 1}. ${e.value.suggestedTitle} '
+                    '· ${e.value.suggestedAuthor} (${e.value.requesterCount}명)',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onPrimaryContainer,
+                    ),
+                  ),
+                )),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _stat(ThemeData theme, String label, String value) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          '$label: ',
+          style: theme.textTheme.bodySmall
+              ?.copyWith(color: theme.colorScheme.onPrimaryContainer),
+        ),
+        Text(
+          value,
+          style: theme.textTheme.bodyMedium?.copyWith(
+            fontWeight: FontWeight.w700,
+            color: theme.colorScheme.onPrimaryContainer,
+          ),
+        ),
+      ],
     );
   }
 }

--- a/specs/001-library-management/tasks.md
+++ b/specs/001-library-management/tasks.md
@@ -422,7 +422,7 @@
 - [X] T194 [US6] Implement grouped suggestion display with duplicate count (statuses chips + 추천 N명 badge)
 - [X] T195 [US6] Add status update (approved/rejected/under review) functionality (per-item dialog with admin notes)
 - [X] T196 [US6] Add option to add approved suggestion directly to catalog — 승인된 추천 행에 "카탈로그에 등록" 액션 추가 (BookFormWidget prefill로 기존 POST /api/v1/books 재사용)
-- [ ] T197 [US6] Display suggestion statistics (most requested categories) (deferred — analytics out of MVP)
+- [X] T197 [US6] Display suggestion statistics (most requested categories) — `_StatsHeader` 위젯 (`suggestions_review_screen.dart`). 기존 grouped 데이터 기반 (백엔드 신규 endpoint 없음): 고유 도서/총 요청/상태 4종 분포 + 수요 Top 3.
 
 **Checkpoint**: User Story 6 complete - admins can review suggestions, all user stories functional
 

--- a/test/features/book_suggestions/presentation/screens/suggestions_review_screen_test.dart
+++ b/test/features/book_suggestions/presentation/screens/suggestions_review_screen_test.dart
@@ -106,6 +106,52 @@ void main() {
       expect(bookRepo.createCalls, 1);
     });
 
+    // T197 — stats header
+    testWidgets('stats header shows totals + status breakdown + Top demand',
+        (tester) async {
+      final repo = FakeAdminSuggestionRepository()
+        ..grouped = [
+          makeGroup(
+            title: 'Most Wanted',
+            author: 'Author A',
+            requesterCount: 5,
+            statuses: const {
+              SuggestionStatus.submitted: 3,
+              SuggestionStatus.approved: 2,
+            },
+            items: [
+              makeSuggestion(id: 'a1', status: SuggestionStatus.submitted),
+              makeSuggestion(id: 'a2', status: SuggestionStatus.submitted),
+              makeSuggestion(id: 'a3', status: SuggestionStatus.submitted),
+              makeSuggestion(id: 'a4', status: SuggestionStatus.approved),
+              makeSuggestion(id: 'a5', status: SuggestionStatus.approved),
+            ],
+          ),
+          makeGroup(
+            title: 'Less Wanted',
+            author: 'Author B',
+            requesterCount: 2,
+            statuses: const {SuggestionStatus.rejected: 2},
+            items: [
+              makeSuggestion(id: 'b1', status: SuggestionStatus.rejected),
+              makeSuggestion(id: 'b2', status: SuggestionStatus.rejected),
+            ],
+          ),
+        ];
+      await _pump(tester, repo);
+
+      // Header title
+      expect(find.text('추천 통계'), findsOneWidget);
+      // Totals (2 unique books, 7 total requests)
+      expect(find.textContaining('고유 도서'), findsOneWidget);
+      expect(find.text('2'), findsAtLeastNWidgets(1));
+      expect(find.textContaining('총 요청'), findsOneWidget);
+      expect(find.text('7'), findsAtLeastNWidgets(1));
+      // Top demand list
+      expect(find.text('수요 Top 2'), findsOneWidget);
+      expect(find.textContaining('Most Wanted'), findsAtLeastNWidgets(1));
+    });
+
     testWidgets('approve action shows dialog with notes field', (tester) async {
       final repo = FakeAdminSuggestionRepository()
         ..grouped = [


### PR DESCRIPTION
Closes #179

## Summary

T197 — 관리자 추천 검토 화면 상단에 통계 요약. 기존 `grouped` 응답으로 구성, 백엔드 신규 endpoint 없음.

## 변경

`SuggestionsReviewScreen`:
- ListView 0번 인덱스에 `_StatsHeader` 추가
- 표시 항목:
  - **고유 도서 수** / **총 요청 수**
  - 상태 4종 분포 (제출됨 / 검토중 / 승인 / 반려)
  - **수요 Top 3** (`requesterCount` desc)
- 디자인: primaryContainer 배경 + 12px 라운드

## 효과

관리자가 화면 진입 즉시:
- 어떤 책이 가장 많이 요청되었는지 (의사결정용)
- 검토 누락 (`제출됨` 카운트가 많이 쌓여있는지)
- 승인/반려 비율

## 테스트 추가 1건 (총 6건)

`stats header shows totals + status breakdown + Top demand`:
- 2개 그룹, 7개 요청, 다양한 상태 → 헤더 라벨 + 카운트 + Top 2 제목 검증

기존 데이터 모델 / repo / 백엔드 변경 없음. 순수 UI 추가.

## Test plan

- [x] `flutter test` 265 → 266 (+1, 회귀 없음)
- [x] flutter analyze (info-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)