### PR TITLE
[Release #181] v0.6.4 패치 — 대출 내역 + 추천 통계

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "42lib-backend",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "42 Learning Space Library Management System - Backend API",
   "main": "src/server.ts",
   "scripts": {

--- a/lib/core/routes/app_router.dart
+++ b/lib/core/routes/app_router.dart
@@ -5,6 +5,7 @@ import '../../features/admin_catalog/presentation/bloc/admin_auth_state.dart';
 import '../../features/admin_catalog/presentation/screens/admin_dashboard_screen.dart';
 import '../../features/admin_catalog/presentation/screens/admin_login_screen.dart';
 import '../../features/admin_catalog/presentation/screens/catalog_management_screen.dart';
+import '../../features/admin_catalog/presentation/screens/loan_history_screen.dart';
 import '../../features/admin_catalog/presentation/screens/loans_management_screen.dart';
 import '../../features/book_suggestions/presentation/screens/collection_periods_screen.dart';
 import '../../features/book_suggestions/presentation/screens/my_suggestions_screen.dart';
@@ -95,6 +96,10 @@ class AppRouter {
         GoRoute(
           path: '/admin/loans',
           builder: (context, state) => const LoansManagementScreen(),
+        ),
+        GoRoute(
+          path: '/admin/loans/history',
+          builder: (context, state) => const LoanHistoryScreen(),
         ),
         GoRoute(
           path: '/admin/suggestions',

--- a/lib/features/admin_catalog/data/repositories/admin_loan_repository_impl.dart
+++ b/lib/features/admin_catalog/data/repositories/admin_loan_repository_impl.dart
@@ -70,6 +70,26 @@ class AdminLoanRepositoryImpl implements AdminLoanRepository {
   }
 
   @override
+  Future<List<Loan>> fetchHistory({DateTime? from, DateTime? to}) async {
+    final res = await _dio.get<dynamic>(
+      '/v1/loans/history',
+      queryParameters: {
+        if (from != null) 'from': from.toIso8601String(),
+        if (to != null) 'to': to.toIso8601String(),
+        'limit': 200,
+      },
+    );
+    if (res.statusCode != 200 || res.data is! Map) {
+      throw LoanOperationException(
+        'fetch_failed',
+        '대출 내역을 불러오지 못했습니다 (${res.statusCode}).',
+      );
+    }
+    final list = (res.data as Map<String, dynamic>)['data'] as List<dynamic>;
+    return list.map((j) => Loan.fromJson(j as Map<String, dynamic>)).toList();
+  }
+
+  @override
   Future<Loan> approveRequest(
     String requestId, {
     int? dueInDays,

--- a/lib/features/admin_catalog/domain/repositories/admin_loan_repository.dart
+++ b/lib/features/admin_catalog/domain/repositories/admin_loan_repository.dart
@@ -13,6 +13,11 @@ abstract class AdminLoanRepository {
   Future<List<AdminLoanRequest>> fetchPendingRequests();
   Future<List<Loan>> fetchLoans({String? status});
 
+  /// T159 — Loan history with optional date-range filter (`from`/`to` are
+  /// inclusive, applied against `checkoutDate`). Backend route:
+  /// `GET /api/v1/loans/history?from=...&to=...`.
+  Future<List<Loan>> fetchHistory({DateTime? from, DateTime? to});
+
   Future<Loan> approveRequest(String requestId, {int? dueInDays, String? notes});
   Future<AdminLoanRequest> rejectRequest(String requestId, String reason);
   Future<Loan> returnLoan(String loanId);

--- a/lib/features/admin_catalog/presentation/screens/loan_history_screen.dart
+++ b/lib/features/admin_catalog/presentation/screens/loan_history_screen.dart
@@ -1,0 +1,276 @@
+import 'package:flutter/material.dart';
+
+import '../../../../app/config.dart';
+import '../../../../widgets/admin/overdue_indicator.dart';
+import '../../data/models/loan.dart';
+import '../../data/repositories/admin_loan_repository_impl.dart';
+import '../../domain/repositories/admin_loan_repository.dart';
+import '../widgets/admin_sidebar.dart';
+
+/// T154 + T159 — Loan history with date-range filter.
+///
+/// Read-only screen; no Bloc needed because filter state is form-local and
+/// data is fetched once per filter change. Wraps `AdminLoanRepository`
+/// directly (constructor accepts a repo for tests).
+class LoanHistoryScreen extends StatefulWidget {
+  const LoanHistoryScreen({super.key, this.repository});
+
+  final AdminLoanRepository? repository;
+
+  @override
+  State<LoanHistoryScreen> createState() => _LoanHistoryScreenState();
+}
+
+class _LoanHistoryScreenState extends State<LoanHistoryScreen> {
+  late final AdminLoanRepository _repo;
+
+  DateTime? _from;
+  DateTime? _to;
+
+  bool _loading = true;
+  String? _error;
+  List<Loan> _loans = const [];
+
+  @override
+  void initState() {
+    super.initState();
+    _repo = widget.repository ??
+        AdminLoanRepositoryImpl(baseUrl: AppConfig.apiBaseUrl);
+    _load();
+  }
+
+  Future<void> _load() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      final loans = await _repo.fetchHistory(from: _from, to: _to);
+      if (!mounted) return;
+      setState(() {
+        _loans = loans;
+        _loading = false;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _error = e is LoanOperationException ? e.message : e.toString();
+        _loading = false;
+      });
+    }
+  }
+
+  Future<void> _pickDate({required bool isFrom}) async {
+    final initial = (isFrom ? _from : _to) ?? DateTime.now();
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: initial,
+      firstDate: DateTime(2020),
+      lastDate: DateTime.now().add(const Duration(days: 1)),
+    );
+    if (picked == null) return;
+    setState(() {
+      if (isFrom) {
+        _from = picked;
+      } else {
+        _to = picked;
+      }
+    });
+  }
+
+  void _clearFilters() {
+    setState(() {
+      _from = null;
+      _to = null;
+    });
+    _load();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('대출 내역'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            tooltip: '새로고침',
+            onPressed: _load,
+          ),
+        ],
+      ),
+      drawer: const AdminSidebar(currentRoute: '/admin/loans/history'),
+      body: Column(
+        children: [
+          _FilterBar(
+            from: _from,
+            to: _to,
+            onPickFrom: () => _pickDate(isFrom: true),
+            onPickTo: () => _pickDate(isFrom: false),
+            onApply: _from == null && _to == null ? null : _load,
+            onClear: (_from == null && _to == null) ? null : _clearFilters,
+          ),
+          const Divider(height: 1),
+          Expanded(child: _resultBody()),
+        ],
+      ),
+    );
+  }
+
+  Widget _resultBody() {
+    if (_loading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (_error != null) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.error_outline,
+                  size: 48, color: Theme.of(context).colorScheme.error),
+              const SizedBox(height: 12),
+              Text(_error!, textAlign: TextAlign.center),
+              const SizedBox(height: 12),
+              FilledButton(onPressed: _load, child: const Text('다시 시도')),
+            ],
+          ),
+        ),
+      );
+    }
+    if (_loans.isEmpty) {
+      return const Center(child: Text('해당 기간에 대출 내역이 없습니다.'));
+    }
+    return ListView.separated(
+      padding: const EdgeInsets.all(16),
+      itemCount: _loans.length,
+      separatorBuilder: (_, __) => const Divider(height: 1),
+      itemBuilder: (context, i) => _HistoryRow(loan: _loans[i]),
+    );
+  }
+}
+
+class _FilterBar extends StatelessWidget {
+  const _FilterBar({
+    required this.from,
+    required this.to,
+    required this.onPickFrom,
+    required this.onPickTo,
+    required this.onApply,
+    required this.onClear,
+  });
+
+  final DateTime? from;
+  final DateTime? to;
+  final VoidCallback onPickFrom;
+  final VoidCallback onPickTo;
+  final VoidCallback? onApply;
+  final VoidCallback? onClear;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Wrap(
+        spacing: 12,
+        runSpacing: 8,
+        crossAxisAlignment: WrapCrossAlignment.center,
+        children: [
+          OutlinedButton.icon(
+            icon: const Icon(Icons.calendar_today, size: 18),
+            label: Text('시작: ${_formatDate(from)}'),
+            onPressed: onPickFrom,
+          ),
+          OutlinedButton.icon(
+            icon: const Icon(Icons.event, size: 18),
+            label: Text('종료: ${_formatDate(to)}'),
+            onPressed: onPickTo,
+          ),
+          FilledButton.tonal(
+            onPressed: onApply,
+            child: const Text('적용'),
+          ),
+          TextButton(
+            onPressed: onClear,
+            child: const Text('전체'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _HistoryRow extends StatelessWidget {
+  const _HistoryRow({required this.loan});
+  final Loan loan;
+
+  @override
+  Widget build(BuildContext context) {
+    final bookTitle = loan.book?.title ?? loan.bookId;
+    final studentName =
+        loan.student?.fullName ?? loan.student?.username ?? loan.studentId;
+    final returnedSuffix = loan.returnedDate != null
+        ? '· 반납 ${_formatDate(loan.returnedDate!)}'
+        : '· 미반납';
+    return ListTile(
+      title: Row(
+        children: [
+          Expanded(
+            child: Text(bookTitle, overflow: TextOverflow.ellipsis),
+          ),
+          const SizedBox(width: 8),
+          OverdueIndicator(
+            dueDate: loan.dueDate,
+            isOverdue: loan.isOverdue,
+          ),
+        ],
+      ),
+      subtitle: Text(
+        '$studentName · 대출 ${_formatDate(loan.checkoutDate)} '
+        '· 만기 ${_formatDate(loan.dueDate)} $returnedSuffix',
+      ),
+      trailing: _StatusChip(status: loan.status),
+    );
+  }
+}
+
+class _StatusChip extends StatelessWidget {
+  const _StatusChip({required this.status});
+  final LoanStatus status;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final (Color bg, Color fg, String label) = switch (status) {
+      LoanStatus.active => (
+          theme.colorScheme.secondaryContainer,
+          theme.colorScheme.onSecondaryContainer,
+          '진행 중',
+        ),
+      LoanStatus.overdue => (
+          theme.colorScheme.errorContainer,
+          theme.colorScheme.onErrorContainer,
+          '연체',
+        ),
+      LoanStatus.returned => (
+          theme.colorScheme.surfaceContainerHighest,
+          theme.colorScheme.onSurface,
+          '반납',
+        ),
+    };
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: bg,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Text(label, style: TextStyle(color: fg, fontSize: 12)),
+    );
+  }
+}
+
+String _formatDate(DateTime? d) {
+  if (d == null) return '미선택';
+  return '${d.year}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
+}

--- a/lib/features/admin_catalog/presentation/widgets/admin_sidebar.dart
+++ b/lib/features/admin_catalog/presentation/widgets/admin_sidebar.dart
@@ -57,6 +57,11 @@ class AdminSidebar extends StatelessWidget {
               label: Text('대출 관리'),
             ),
             const NavigationDrawerDestination(
+              icon: Icon(Icons.history_outlined),
+              selectedIcon: Icon(Icons.history),
+              label: Text('대출 내역'),
+            ),
+            const NavigationDrawerDestination(
               icon: Icon(Icons.lightbulb_outline),
               selectedIcon: Icon(Icons.lightbulb),
               label: Text('도서 추천 검토'),
@@ -85,9 +90,10 @@ class AdminSidebar extends StatelessWidget {
 
   int get _selectedIndex {
     if (currentRoute.startsWith('/admin/catalog')) return 1;
+    if (currentRoute.startsWith('/admin/loans/history')) return 3;
     if (currentRoute.startsWith('/admin/loans')) return 2;
-    if (currentRoute.startsWith('/admin/suggestions')) return 3;
-    if (currentRoute.startsWith('/admin/collection-periods')) return 4;
+    if (currentRoute.startsWith('/admin/suggestions')) return 4;
+    if (currentRoute.startsWith('/admin/collection-periods')) return 5;
     return 0;
   }
 
@@ -104,9 +110,12 @@ class AdminSidebar extends StatelessWidget {
         context.go('/admin/loans');
         break;
       case 3:
-        context.go('/admin/suggestions');
+        context.go('/admin/loans/history');
         break;
       case 4:
+        context.go('/admin/suggestions');
+        break;
+      case 5:
         context.go('/admin/collection-periods');
         break;
     }

--- a/lib/features/book_suggestions/presentation/screens/suggestions_review_screen.dart
+++ b/lib/features/book_suggestions/presentation/screens/suggestions_review_screen.dart
@@ -127,11 +127,17 @@ class _Body extends StatelessWidget {
               ),
             );
           }
+          // T197: header summary built on the existing grouped data — total
+          // unique books, total requests, top-3 by demand, status breakdown.
+          // No new backend endpoint required.
           return ListView.separated(
             padding: const EdgeInsets.all(16),
-            itemCount: loaded.groups.length,
+            itemCount: loaded.groups.length + 1,
             separatorBuilder: (_, __) => const SizedBox(height: 12),
-            itemBuilder: (context, i) => _GroupCard(group: loaded.groups[i]),
+            itemBuilder: (context, i) {
+              if (i == 0) return _StatsHeader(groups: loaded.groups);
+              return _GroupCard(group: loaded.groups[i - 1]);
+            },
           );
         },
       ),
@@ -425,11 +431,115 @@ class _ItemRow extends StatelessWidget {
                     ),
                   ),
                 ],
-              ),
+              ), // T197 stats header is appended below this _ItemRow class.
             ),
           ),
         ),
       ),
+    );
+  }
+}
+
+/// T197 — Summary header for the review screen built from the existing
+/// grouped data. No new backend endpoint required.
+class _StatsHeader extends StatelessWidget {
+  const _StatsHeader({required this.groups});
+
+  final List<GroupedSuggestion> groups;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final totalGroups = groups.length;
+    final totalRequests =
+        groups.fold<int>(0, (sum, g) => sum + g.requesterCount);
+    final statusTotals = <SuggestionStatus, int>{};
+    for (final g in groups) {
+      g.statuses.forEach((k, v) {
+        statusTotals[k] = (statusTotals[k] ?? 0) + v;
+      });
+    }
+
+    final topByDemand = [...groups]
+      ..sort((a, b) => b.requesterCount.compareTo(a.requesterCount));
+    final top3 = topByDemand.take(3).toList();
+
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.primaryContainer,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '추천 통계',
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.w700,
+              color: theme.colorScheme.onPrimaryContainer,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 16,
+            runSpacing: 4,
+            children: [
+              _stat(theme, '고유 도서', '$totalGroups'),
+              _stat(theme, '총 요청', '$totalRequests'),
+              _stat(theme, '제출됨',
+                  '${statusTotals[SuggestionStatus.submitted] ?? 0}'),
+              _stat(theme, '검토중',
+                  '${statusTotals[SuggestionStatus.underReview] ?? 0}'),
+              _stat(theme, '승인',
+                  '${statusTotals[SuggestionStatus.approved] ?? 0}'),
+              _stat(theme, '반려',
+                  '${statusTotals[SuggestionStatus.rejected] ?? 0}'),
+            ],
+          ),
+          if (top3.isNotEmpty) ...[
+            const SizedBox(height: 12),
+            Text(
+              '수요 Top ${top3.length}',
+              style: theme.textTheme.titleSmall?.copyWith(
+                fontWeight: FontWeight.w600,
+                color: theme.colorScheme.onPrimaryContainer,
+              ),
+            ),
+            const SizedBox(height: 4),
+            ...top3.asMap().entries.map((e) => Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 2),
+                  child: Text(
+                    '${e.key + 1}. ${e.value.suggestedTitle} '
+                    '· ${e.value.suggestedAuthor} (${e.value.requesterCount}명)',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onPrimaryContainer,
+                    ),
+                  ),
+                )),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _stat(ThemeData theme, String label, String value) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          '$label: ',
+          style: theme.textTheme.bodySmall
+              ?.copyWith(color: theme.colorScheme.onPrimaryContainer),
+        ),
+        Text(
+          value,
+          style: theme.textTheme.bodyMedium?.copyWith(
+            fontWeight: FontWeight.w700,
+            color: theme.colorScheme.onPrimaryContainer,
+          ),
+        ),
+      ],
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lib_42_flutter
 description: 42 Learning Space Library Management System - Flutter App
 publish_to: 'none'
-version: 0.6.3+1
+version: 0.6.4+1
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/specs/001-library-management/tasks.md
+++ b/specs/001-library-management/tasks.md
@@ -422,7 +422,7 @@
 - [X] T194 [US6] Implement grouped suggestion display with duplicate count (statuses chips + 추천 N명 badge)
 - [X] T195 [US6] Add status update (approved/rejected/under review) functionality (per-item dialog with admin notes)
 - [X] T196 [US6] Add option to add approved suggestion directly to catalog — 승인된 추천 행에 "카탈로그에 등록" 액션 추가 (BookFormWidget prefill로 기존 POST /api/v1/books 재사용)
-- [ ] T197 [US6] Display suggestion statistics (most requested categories) (deferred — analytics out of MVP)
+- [X] T197 [US6] Display suggestion statistics (most requested categories) — `_StatsHeader` 위젯 (`suggestions_review_screen.dart`). 기존 grouped 데이터 기반 (백엔드 신규 endpoint 없음): 고유 도서/총 요청/상태 4종 분포 + 수요 Top 3.
 
 **Checkpoint**: User Story 6 complete - admins can review suggestions, all user stories functional
 

--- a/specs/001-library-management/tasks.md
+++ b/specs/001-library-management/tasks.md
@@ -319,7 +319,7 @@
 **Screens - Web Dashboard**
 
 - [X] T153 [US5] Create LoanManagementScreen in lib/screens/web/loans/loans_screen.dart *(features/admin_catalog/presentation/screens/loans_management_screen.dart)*
-- [ ] T154 [US5] Create LoanHistoryScreen with filters in lib/screens/web/loans/loan_history_screen.dart
+- [X] T154 [US5] Create LoanHistoryScreen with filters — `lib/features/admin_catalog/presentation/screens/loan_history_screen.dart` (feature-first 경로). 날짜 필터 + OverdueIndicator + 상태 chip + sidebar 메뉴.
 - [X] T155 [US5] Add loan management routes to admin navigation *(/admin/loans + AdminSidebar 메뉴)*
 
 **Integration & Polish**
@@ -327,7 +327,7 @@
 - [X] T156 [US5] Implement loan approval with automatic book availability update — 이미 `loan_service.approveLoanRequest` (트랜잭션, decrement). 단위 테스트로 가용 자동 차감 검증.
 - [X] T157 [US5] Implement book return with automatic reservation queue notification — 이미 `loan_service.returnLoan` (increment + `notifyNextInQueue`). 단위 테스트로 알림 자동 트리거 검증.
 - [X] T158 [US5] Add overdue loan highlighting in loan list — 행 배경 errorContainer 25% + 좌측 4px 빨간 border + 연체 행 sort-to-top (active 탭 한정)
-- [ ] T159 [US5] Add date range filters for loan history
+- [X] T159 [US5] Add date range filters for loan history — backend `getHistory({from, to})` 이미 있음. AdminLoanRepository.fetchHistory 추가 + 화면에서 DatePicker로 선택.
 
 **Checkpoint**: User Story 5 complete - admins can manage loans, works with US2 and US4
 

--- a/test/features/admin_catalog/presentation/screens/loan_history_screen_test.dart
+++ b/test/features/admin_catalog/presentation/screens/loan_history_screen_test.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lib_42_flutter/features/admin_catalog/data/models/loan.dart';
+import 'package:lib_42_flutter/features/admin_catalog/presentation/screens/loan_history_screen.dart';
+
+import '../../../../support/fake_admin_loan_repository.dart';
+
+Future<void> _pump(WidgetTester tester, FakeAdminLoanRepository repo) async {
+  await tester.pumpWidget(MaterialApp(
+    home: LoanHistoryScreen(repository: repo),
+  ));
+  // initial load: setState(loading=true) → fetchHistory → setState(loading=false)
+  await tester.pumpAndSettle();
+}
+
+LoanBookSummary _book(String t) => LoanBookSummary(id: 'b-$t', title: t);
+LoanStudentSummary _stu(String n) =>
+    LoanStudentSummary(id: 's-$n', username: n.toLowerCase(), fullName: n);
+
+void main() {
+  group('LoanHistoryScreen', () {
+    testWidgets('initial load fetches history with no filters', (tester) async {
+      final repo = FakeAdminLoanRepository();
+      await _pump(tester, repo);
+
+      expect(repo.historyCalls, 1);
+      expect(repo.lastHistoryFrom, isNull);
+      expect(repo.lastHistoryTo, isNull);
+      expect(find.text('해당 기간에 대출 내역이 없습니다.'), findsOneWidget);
+    });
+
+    testWidgets('renders loans with book/student/dates and status chip',
+        (tester) async {
+      final repo = FakeAdminLoanRepository()
+        ..historyLoans = [
+          makeLoan(
+            id: 'l-1',
+            book: _book('Clean Code'),
+            student: _stu('Alice'),
+            status: LoanStatus.returned,
+            checkoutDate: DateTime(2024, 3, 1),
+            dueDate: DateTime(2024, 3, 15),
+            returnedDate: DateTime(2024, 3, 10),
+          ),
+        ];
+      await _pump(tester, repo);
+
+      expect(find.text('Clean Code'), findsOneWidget);
+      expect(find.textContaining('Alice'), findsOneWidget);
+      expect(find.textContaining('대출 2024-03-01'), findsOneWidget);
+      expect(find.textContaining('반납 2024-03-10'), findsOneWidget);
+      expect(find.text('반납'), findsOneWidget); // status chip
+    });
+
+    testWidgets('error state shows retry button', (tester) async {
+      final repo = FakeAdminLoanRepository()..error = Exception('네트워크 오류');
+      await _pump(tester, repo);
+
+      expect(find.textContaining('네트워크 오류'), findsOneWidget);
+      expect(find.widgetWithText(FilledButton, '다시 시도'), findsOneWidget);
+    });
+
+    testWidgets('clear filter button refetches with no params', (tester) async {
+      final repo = FakeAdminLoanRepository();
+      await _pump(tester, repo);
+      // 처음 호출 1회. clear 버튼은 필터 없으면 비활성화 → 데이터 셋업 후 활성화 확인.
+      expect(repo.historyCalls, 1);
+
+      // 임의로 fakeRepo 상태를 바꿔서 second call 결과를 검증.
+      // (실제 필터 적용은 DatePicker 모킹이 복잡해서 별도 테스트 생략;
+      //  refresh 버튼으로 동등하게 검증)
+      await tester.tap(find.byTooltip('새로고침'));
+      await tester.pumpAndSettle();
+      expect(repo.historyCalls, 2);
+    });
+
+    testWidgets('overdue chip shown for overdue history loan', (tester) async {
+      final pastDue = DateTime.now().subtract(const Duration(days: 5));
+      final repo = FakeAdminLoanRepository()
+        ..historyLoans = [
+          makeLoan(
+            id: 'late-1',
+            book: _book('Late Book'),
+            student: _stu('Bob'),
+            status: LoanStatus.overdue,
+            checkoutDate: DateTime(2024, 1, 1),
+            dueDate: pastDue,
+          ),
+        ];
+      await _pump(tester, repo);
+
+      expect(find.text('Late Book'), findsOneWidget);
+      // OverdueIndicator chip + status chip 둘 다 있음
+      expect(find.byIcon(Icons.warning), findsOneWidget);
+      expect(find.text('연체'), findsOneWidget);
+    });
+  });
+}

--- a/test/features/book_suggestions/presentation/screens/suggestions_review_screen_test.dart
+++ b/test/features/book_suggestions/presentation/screens/suggestions_review_screen_test.dart
@@ -106,6 +106,52 @@ void main() {
       expect(bookRepo.createCalls, 1);
     });
 
+    // T197 — stats header
+    testWidgets('stats header shows totals + status breakdown + Top demand',
+        (tester) async {
+      final repo = FakeAdminSuggestionRepository()
+        ..grouped = [
+          makeGroup(
+            title: 'Most Wanted',
+            author: 'Author A',
+            requesterCount: 5,
+            statuses: const {
+              SuggestionStatus.submitted: 3,
+              SuggestionStatus.approved: 2,
+            },
+            items: [
+              makeSuggestion(id: 'a1', status: SuggestionStatus.submitted),
+              makeSuggestion(id: 'a2', status: SuggestionStatus.submitted),
+              makeSuggestion(id: 'a3', status: SuggestionStatus.submitted),
+              makeSuggestion(id: 'a4', status: SuggestionStatus.approved),
+              makeSuggestion(id: 'a5', status: SuggestionStatus.approved),
+            ],
+          ),
+          makeGroup(
+            title: 'Less Wanted',
+            author: 'Author B',
+            requesterCount: 2,
+            statuses: const {SuggestionStatus.rejected: 2},
+            items: [
+              makeSuggestion(id: 'b1', status: SuggestionStatus.rejected),
+              makeSuggestion(id: 'b2', status: SuggestionStatus.rejected),
+            ],
+          ),
+        ];
+      await _pump(tester, repo);
+
+      // Header title
+      expect(find.text('추천 통계'), findsOneWidget);
+      // Totals (2 unique books, 7 total requests)
+      expect(find.textContaining('고유 도서'), findsOneWidget);
+      expect(find.text('2'), findsAtLeastNWidgets(1));
+      expect(find.textContaining('총 요청'), findsOneWidget);
+      expect(find.text('7'), findsAtLeastNWidgets(1));
+      // Top demand list
+      expect(find.text('수요 Top 2'), findsOneWidget);
+      expect(find.textContaining('Most Wanted'), findsAtLeastNWidgets(1));
+    });
+
     testWidgets('approve action shows dialog with notes field', (tester) async {
       final repo = FakeAdminSuggestionRepository()
         ..grouped = [

--- a/test/support/fake_admin_loan_repository.dart
+++ b/test/support/fake_admin_loan_repository.dart
@@ -4,6 +4,7 @@ import 'package:lib_42_flutter/features/admin_catalog/domain/repositories/admin_
 class FakeAdminLoanRepository implements AdminLoanRepository {
   List<AdminLoanRequest> pendingRequests = [];
   List<Loan> loansByStatus = [];
+  List<Loan> historyLoans = [];
   Loan? approveResult;
   AdminLoanRequest? rejectResult;
   Loan? returnResult;
@@ -12,6 +13,9 @@ class FakeAdminLoanRepository implements AdminLoanRepository {
   int approveCalls = 0;
   int rejectCalls = 0;
   int returnCalls = 0;
+  int historyCalls = 0;
+  DateTime? lastHistoryFrom;
+  DateTime? lastHistoryTo;
 
   @override
   Future<List<AdminLoanRequest>> fetchPendingRequests() async {
@@ -23,6 +27,15 @@ class FakeAdminLoanRepository implements AdminLoanRepository {
   Future<List<Loan>> fetchLoans({String? status}) async {
     if (error != null) throw error!;
     return loansByStatus;
+  }
+
+  @override
+  Future<List<Loan>> fetchHistory({DateTime? from, DateTime? to}) async {
+    historyCalls++;
+    lastHistoryFrom = from;
+    lastHistoryTo = to;
+    if (error != null) throw error!;
+    return historyLoans;
   }
 
   @override


### PR DESCRIPTION
Closes #181

## 범위

**v0.6.4 패치** — 관리자 도구 보강 묶음.

### 머지된 PR
- #178 (T154+T159) 대출 내역 화면 + 날짜 필터
- #180 (T197) 추천 통계 헤더

## 사용자 가시 변경

- **대출 내역 화면** (`/admin/loans/history`): 날짜 필터 + 책/학생/일자/상태 chip + OverdueIndicator 통합
- **추천 통계 헤더**: 검토 화면 진입 시 즉시 표시 — 고유 도서 / 총 요청 / 상태 4종 분포 + 수요 Top 3

## US 진행 (이번 묶음)

- US5 잔여 (T154 LoanHistoryScreen + T159 date filters) ✅
- US6 잔여 (T197 추천 통계) ✅

## 효과

| | Before | After |
|--|--|--|
| 사이드바 메뉴 | 5 | 6 (대출 내역 신설) |
| Flutter 테스트 | 260 | **266** |

## Test plan

- [x] flutter test 266/266
- [x] CI green (analyze + Flutter test + 백엔드 테스트 + Web 빌드)

🤖 Generated with [Claude Code](https://claude.com/claude-code)