### PR TITLE
[Release #195] v0.6.7 패치 — Prisma 싱글톤 + 쿼리 로깅

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "42lib-backend",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "42 Learning Space Library Management System - Backend API",
   "main": "src/server.ts",
   "scripts": {

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -1,0 +1,59 @@
+// T210: Shared Prisma client + query logging.
+//
+// 모든 서비스/라우트가 이 모듈에서 `prisma`를 import하도록 통일.
+// 이전에는 각 서비스가 `new PrismaClient()`를 생성해 9개 connection
+// pool이 동시에 살아있었음 (Node.js 단일 프로세스에서 자원 낭비 +
+// 테스트에서 connection close 누락 위험).
+//
+// 로그 설정:
+//   - dev / test: query / warn / error / info — 느린 쿼리 추적 + 개발 디버깅
+//   - production: warn / error — 시끄러움 방지
+//
+// 느린 쿼리(>1s)는 별도 logger.warn으로 표면화 (observability rule §7).
+
+import { Prisma, PrismaClient } from '@prisma/client';
+import { logger } from './utils/logger';
+
+const isDev = process.env.NODE_ENV !== 'production';
+
+const logLevels: Prisma.LogLevel[] = isDev
+  ? ['query', 'warn', 'error', 'info']
+  : ['warn', 'error'];
+
+const logEvents: Prisma.LogDefinition[] = logLevels.map((level) => ({
+  emit: 'event',
+  level,
+}));
+
+export const prisma = new PrismaClient({ log: logEvents });
+
+// Forward Prisma events into our structured logger so logs follow the same
+// shape as the rest of the app (timestamp / level / service).
+prisma.$on('warn' as never, (e: Prisma.LogEvent) => {
+  logger.warn('prisma.warn', { message: e.message });
+});
+prisma.$on('error' as never, (e: Prisma.LogEvent) => {
+  logger.error('prisma.error', { message: e.message });
+});
+
+if (isDev) {
+  // Surface slow queries (≥1s) at WARN; quieter queries at DEBUG.
+  // observability rule §3: log at boundaries, include duration.
+  prisma.$on('query' as never, (e: Prisma.QueryEvent) => {
+    if (e.duration >= 1000) {
+      logger.warn('prisma.slow_query', {
+        durationMs: e.duration,
+        query: e.query,
+        params: e.params,
+      });
+    } else {
+      logger.debug('prisma.query', {
+        durationMs: e.duration,
+        query: e.query,
+      });
+    }
+  });
+  prisma.$on('info' as never, (e: Prisma.LogEvent) => {
+    logger.debug('prisma.info', { message: e.message });
+  });
+}

--- a/backend/src/routes/books.ts
+++ b/backend/src/routes/books.ts
@@ -1,10 +1,8 @@
 import { Router, Request, Response, NextFunction } from 'express';
-import { PrismaClient } from '@prisma/client';
+import { prisma } from '../db';
 import { bookService } from '../services/book_service';
 import { validateBookQuery, validateBookId } from '../middleware/validation/book_validation';
 import { authenticateAdmin } from '../middleware/auth';
-
-const prisma = new PrismaClient();
 
 const router = Router();
 

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -2,7 +2,7 @@ import express, { Express } from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
 import rateLimit from 'express-rate-limit';
-import { PrismaClient } from '@prisma/client';
+import { prisma } from './db';
 import { logger } from './utils/logger';
 import { errorHandler } from './middleware/error_handler';
 import bookRoutes from './routes/books';
@@ -15,7 +15,6 @@ import collectionPeriodRoutes from './routes/collection_periods';
 import { buildSwaggerRouter } from './swagger';
 
 const app: Express = express();
-const prisma = new PrismaClient();
 const PORT = process.env.PORT || 3000;
 
 // 미들웨어 설정

--- a/backend/src/services/admin_auth_service.ts
+++ b/backend/src/services/admin_auth_service.ts
@@ -1,8 +1,7 @@
-import { PrismaClient, Administrator } from '@prisma/client';
+import { Administrator } from '@prisma/client';
 import * as bcrypt from 'bcrypt';
+import { prisma } from '../db';
 import { generateAdminToken } from '../utils/jwt';
-
-const prisma = new PrismaClient();
 
 export interface AdminLoginResult {
   token: string;

--- a/backend/src/services/auth_42_service.ts
+++ b/backend/src/services/auth_42_service.ts
@@ -3,10 +3,8 @@
 // Reference: research.md Section 3 (42 API Integration)
 
 import axios from 'axios';
-import { PrismaClient } from '@prisma/client';
+import { prisma } from '../db';
 import { logger } from '../utils/logger';
-
-const prisma = new PrismaClient();
 
 interface FortyTwoUser {
   id: number;

--- a/backend/src/services/book_service.ts
+++ b/backend/src/services/book_service.ts
@@ -1,6 +1,5 @@
-import { PrismaClient, Book, Prisma } from '@prisma/client';
-
-const prisma = new PrismaClient();
+import { Book, Prisma } from '@prisma/client';
+import { prisma } from '../db';
 
 export interface BookFilters {
   title?: string;

--- a/backend/src/services/loan_request_service.ts
+++ b/backend/src/services/loan_request_service.ts
@@ -2,10 +2,9 @@
 // Handles loan request creation, validation, and reservation queue management
 // Reference: data-model.md Entity 3 (LoanRequest) and Entity 4 (Reservation)
 
-import { PrismaClient, LoanRequestStatus, ReservationStatus } from '@prisma/client';
+import { LoanRequestStatus, ReservationStatus } from '@prisma/client';
+import { prisma } from '../db';
 import { logger } from '../utils/logger';
-
-const prisma = new PrismaClient();
 
 export class LoanRequestService {
   /**

--- a/backend/src/services/loan_service.ts
+++ b/backend/src/services/loan_service.ts
@@ -2,15 +2,13 @@
 // Reference: data-model.md Entity 5 (Loan)
 
 import {
-  PrismaClient,
   LoanRequestStatus,
   LoanStatus,
   ReservationStatus,
 } from '@prisma/client';
+import { prisma } from '../db';
 import { logger } from '../utils/logger';
 import { reservationService } from './reservation_service';
-
-const prisma = new PrismaClient();
 
 export class LoanError extends Error {
   constructor(

--- a/backend/src/services/reservation_service.ts
+++ b/backend/src/services/reservation_service.ts
@@ -2,10 +2,9 @@
 // Manages FIFO reservation queue with notifications and expirations
 // Reference: data-model.md Entity 4 (Reservation)
 
-import { PrismaClient, ReservationStatus } from '@prisma/client';
+import { ReservationStatus } from '@prisma/client';
+import { prisma } from '../db';
 import { logger } from '../utils/logger';
-
-const prisma = new PrismaClient();
 
 export class ReservationService {
   /**

--- a/backend/src/services/suggestion_service.ts
+++ b/backend/src/services/suggestion_service.ts
@@ -2,14 +2,9 @@
 // scoped to an active collection period.
 // Reference: data-model.md Entity 6 (BookSuggestion), Entity 7 (CollectionPeriod)
 
-import {
-  PrismaClient,
-  PeriodStatus,
-  SuggestionStatus,
-} from '@prisma/client';
+import { PeriodStatus, SuggestionStatus } from '@prisma/client';
+import { prisma } from '../db';
 import { logger } from '../utils/logger';
-
-const prisma = new PrismaClient();
 
 export class SuggestionError extends Error {
   constructor(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lib_42_flutter
 description: 42 Learning Space Library Management System - Flutter App
 publish_to: 'none'
-version: 0.6.6+1
+version: 0.6.7+1
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/specs/001-library-management/tasks.md
+++ b/specs/001-library-management/tasks.md
@@ -451,7 +451,7 @@
 - [X] T207 [P] Add image caching for book covers with cached_network_image — `lib/widgets/book_cover_image.dart` 래퍼 + 3 호출 사이트 (legacy + feature-first BookCard + BookDetailScreen) 교체
 - [ ] T208 [P] Optimize sqflite queries with proper indexes
 - [ ] T209 [P] Implement virtual scrolling for 1000-book catalog
-- [ ] T210 [P] Add database query logging for performance monitoring
+- [X] T210 [P] Add database query logging for performance monitoring — `backend/src/db.ts` 싱글톤 + Prisma event → winston forwarding (slow query ≥1s WARN). 9개 파일 공유 인스턴스 사용.
 - [ ] T211 Profile app performance with Flutter DevTools
 - [ ] T212 Validate <30s book discovery time (SC-001)
 - [ ] T213 Validate <1s search response time (SC-002)


### PR DESCRIPTION
Closes #195

## 범위

**v0.6.7 패치** — backend Prisma 리팩터.

### 머지된 PR
- #194 (T210) Prisma 싱글톤 + 슬로우 쿼리 자동 로깅

## 효과

- **Connection pool 자원 9× 절감**: 이전 9개 파일이 각자 `new PrismaClient()` → 단일 싱글톤
- **슬로우 쿼리 자동 감지**: ≥1s 쿼리는 winston `WARN`, observability rule 준수
- dev/test 환경에서 쿼리 + 파라미터 DEBUG 가시성 (production은 warn/error만)

## Test plan

- [x] `npm run build` clean
- [x] `npm test` 145/145 (회귀 없음)
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)