### PR TITLE
[#197] ✨ feat(a11y): T247 — 색상 기반 신호의 screen reader 지원 (1차)

### DIFF
--- a/lib/features/admin_catalog/presentation/screens/loan_history_screen.dart
+++ b/lib/features/admin_catalog/presentation/screens/loan_history_screen.dart
@@ -259,13 +259,18 @@ class _StatusChip extends StatelessWidget {
           '반납',
         ),
     };
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-      decoration: BoxDecoration(
-        color: bg,
-        borderRadius: BorderRadius.circular(8),
+    // T247: 색상으로만 구분되지 않도록 Semantics에 상태명 명시.
+    return Semantics(
+      label: '대출 상태: $label',
+      excludeSemantics: true,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        decoration: BoxDecoration(
+          color: bg,
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Text(label, style: TextStyle(color: fg, fontSize: 12)),
       ),
-      child: Text(label, style: TextStyle(color: fg, fontSize: 12)),
     );
   }
 }

--- a/lib/widgets/admin/overdue_indicator.dart
+++ b/lib/widgets/admin/overdue_indicator.dart
@@ -51,25 +51,38 @@ class OverdueIndicator extends StatelessWidget {
         ),
     };
 
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-      decoration: BoxDecoration(
-        color: bg,
-        borderRadius: BorderRadius.circular(12),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(icon, size: 14, color: fg),
-          const SizedBox(width: 4),
-          Text(
-            label,
-            style: theme.textTheme.bodySmall?.copyWith(
-              color: fg,
-              fontWeight: overdue ? FontWeight.w700 : FontWeight.w500,
+    // T247: 색상 기반 신호는 screen reader에 의미가 전달되지 않으므로
+    // Semantics 레이블로 상태를 명시.
+    final semanticLabel = switch (overdue) {
+      true => '연체된 대출, $label',
+      false when daysLeft <= dueSoonThresholdDays =>
+        '반납 임박 대출, $label',
+      false => '정상 대출, $label',
+    };
+    return Semantics(
+      label: semanticLabel,
+      // 시각 노드는 그대로 보여주되 자식의 텍스트/아이콘은 합쳐서 한 번만 읽힘.
+      excludeSemantics: true,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        decoration: BoxDecoration(
+          color: bg,
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: 14, color: fg),
+            const SizedBox(width: 4),
+            Text(
+              label,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: fg,
+                fontWeight: overdue ? FontWeight.w700 : FontWeight.w500,
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/widgets/book_cover_image.dart
+++ b/lib/widgets/book_cover_image.dart
@@ -59,15 +59,19 @@ class _Placeholder extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      width: width,
-      height: height,
-      color: Colors.grey.shade200,
-      alignment: Alignment.center,
-      child: Icon(
-        Icons.book,
-        size: width != null ? width! * 0.4 : 40,
-        color: Colors.grey,
+    // T247: placeholder가 책 표지를 대신하지만 정보 가치가 없는
+    // 장식이라 screen reader에서는 제외.
+    return ExcludeSemantics(
+      child: Container(
+        width: width,
+        height: height,
+        color: Colors.grey.shade200,
+        alignment: Alignment.center,
+        child: Icon(
+          Icons.book,
+          size: width != null ? width! * 0.4 : 40,
+          color: Colors.grey,
+        ),
       ),
     );
   }

--- a/specs/001-library-management/tasks.md
+++ b/specs/001-library-management/tasks.md
@@ -509,7 +509,7 @@
 - [ ] T244 Add loading animations with 42 brand identity
 - [ ] T245 Add error message translations (Korean)
 - [ ] T246 Implement app version checking
-- [ ] T247 Add accessibility features (screen reader support)
+- [X] T247 Add accessibility features (screen reader support) — 1차 audit: `OverdueIndicator` 3 상태 + `_StatusChip` (loan history) + `BookCoverImage` placeholder. 확장 후속 가능.
 - [ ] T248 Security audit - check for exposed secrets
 - [ ] T249 Review and optimize Docker container sizes
 - [ ] T250 Add Docker health checks for all services

--- a/test/widget_test/widgets/admin/overdue_indicator_test.dart
+++ b/test/widget_test/widgets/admin/overdue_indicator_test.dart
@@ -80,6 +80,31 @@ void main() {
       expect(find.byIcon(Icons.schedule), findsOneWidget);
     });
 
+    // T247 — Screen reader semantics
+    testWidgets('overdue → "연체된 대출" semantic label', (tester) async {
+      await _pump(
+        tester,
+        OverdueIndicator(dueDate: DateTime(2024, 6, 10), now: now),
+      );
+      expect(find.bySemanticsLabel(RegExp('^연체된 대출')), findsOneWidget);
+    });
+
+    testWidgets('due-soon → "반납 임박 대출" semantic label', (tester) async {
+      await _pump(
+        tester,
+        OverdueIndicator(dueDate: DateTime(2024, 6, 17), now: now),
+      );
+      expect(find.bySemanticsLabel(RegExp('^반납 임박 대출')), findsOneWidget);
+    });
+
+    testWidgets('on-track → "정상 대출" semantic label', (tester) async {
+      await _pump(
+        tester,
+        OverdueIndicator(dueDate: DateTime(2024, 6, 25), now: now),
+      );
+      expect(find.bySemanticsLabel(RegExp('^정상 대출')), findsOneWidget);
+    });
+
     testWidgets('overdue label is bold; on-track label is medium-weight',
         (tester) async {
       // overdue


### PR DESCRIPTION
Closes #197

## Summary

T247 — 색상으로만 의미를 전달하던 시각 위젯에 `Semantics` 레이블 추가. 1차 audit 범위 (확장 후속 가능).

## 변경

### `OverdueIndicator` (3 상태)
- 연체 → "연체된 대출, 연체 N일"
- 임박 → "반납 임박 대출, D-N"
- 정상 → "정상 대출, D-N"

### `_StatusChip` (loan history)
- "대출 상태: 진행 중 / 연체 / 반납"

### `BookCoverImage` placeholder
- 장식 아이콘이라 `ExcludeSemantics`로 screen reader에서 무시

## 효과

- 시각 신호 (색상)에 의존하던 정보가 **음성에서도 동일하게 전달**
- WCAG 1.4.1 (정보를 색만으로 전달하지 않기) 충족

## 테스트 추가 3건

- 연체/임박/정상 각 상태의 `bySemanticsLabel` 매칭 검증

## Test plan

- [x] flutter test 280 → 283 (+3)
- [x] flutter analyze (info-only)

## 후속

- 카탈로그 화면 (`CatalogManagementScreen`) audit
- 추천 화면 (`SuggestionsReviewScreen`) `_StatsHeader` audit
- 메인 네비게이션 라이브 영역 (live regions) 검토

🤖 Generated with [Claude Code](https://claude.com/claude-code)