### PR TITLE
[#199] 🔐 chore(security): T248 — 시크릿 audit 스크립트 + 정기 점검 등록

### DIFF
--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -170,6 +170,7 @@ sudo systemctl status certbot.timer
 - [ ] 디스크 사용량 (DB volume + 로그) — `df -h`
 - [ ] JWT_SECRET 회전 정책 (운영 ADR에 따라)
 - [ ] 컨테이너 이미지 base 보안 업데이트 (`docker compose build --no-cache --pull` 후 재배포)
+- [ ] **월 1회 시크릿 audit** — `./scripts/audit-secrets.sh` (릴리스 직전에도 실행). `--history` 플래그로 전체 git 히스토리까지 스캔 가능.
 
 ## 7. 업그레이드 절차
 

--- a/scripts/audit-secrets.sh
+++ b/scripts/audit-secrets.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# T248: Security audit — scan committed history for accidentally exposed
+# secrets. Run periodically (recommended: monthly + before each release).
+#
+# Exit codes:
+#   0  no findings
+#   1  potential secret(s) found — review the output
+#   2  invocation error (missing tool, bad cwd)
+#
+# Usage:
+#   ./scripts/audit-secrets.sh            # scan tracked files in HEAD
+#   ./scripts/audit-secrets.sh --history  # also walk full git history (slow)
+#
+# Patterns intentionally narrow — false positives waste reviewer attention
+# more than they prevent leaks. Adjust as new secret types are introduced.
+
+set -uo pipefail
+
+cd "$(dirname "$0")/.." || { echo "cannot cd to repo root" >&2; exit 2; }
+
+if ! command -v git >/dev/null 2>&1; then
+  echo "git is required" >&2
+  exit 2
+fi
+
+SCAN_HISTORY=0
+if [[ "${1:-}" == "--history" ]]; then
+  SCAN_HISTORY=1
+fi
+
+found=0
+red() { printf "\033[31m%s\033[0m\n" "$*"; }
+green() { printf "\033[32m%s\033[0m\n" "$*"; }
+
+check() {
+  local label="$1" pattern="$2" exclude="$3"
+  printf "▸ %-32s " "$label"
+
+  local cmd
+  if [[ "$SCAN_HISTORY" -eq 1 ]]; then
+    cmd="git log --all -p -G '$pattern'"
+  else
+    cmd="git grep -nE '$pattern'"
+  fi
+
+  local output
+  output=$(eval "$cmd" 2>/dev/null | grep -vE "$exclude" || true)
+  if [[ -n "$output" ]]; then
+    red "FAIL"
+    echo "$output" | head -10
+    found=$((found + 1))
+  else
+    green "ok"
+  fi
+}
+
+# AWS access key
+check "AWS access key" \
+  'AKIA[0-9A-Z]{16}' \
+  '^$'
+
+# OpenAI / generic api keys with sk- prefix and length
+check "OpenAI / sk- prefixed key" \
+  'sk-[a-zA-Z0-9]{30,}' \
+  '^$'
+
+# Real-looking JWT secrets (filtered for placeholder values)
+check "JWT_SECRET literal value" \
+  'JWT_SECRET\s*[:=]\s*[\"\x27][A-Za-z0-9+/]{30,}' \
+  'change-me|your-secret|test|example|unused|ci-only'
+
+# 42 OAuth client/secret IDs (real format includes hex hash 40+ chars)
+check "42 OAuth real-looking ID" \
+  '(u|s)-s4t2ud-[a-f0-9]{40,}' \
+  '^$'
+
+# Generic Bearer tokens that look like real JWTs (≥3 base64 segments)
+check "Bearer token (live JWT shape)" \
+  'Bearer\s+[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}' \
+  'test|fake|stub|example'
+
+# Private key blocks
+check "Private key blocks" \
+  '-----BEGIN [A-Z ]*PRIVATE KEY-----' \
+  '^$'
+
+# Committed .env files (anything beyond .env.example is suspicious)
+printf "▸ %-32s " "Committed .env files"
+env_files=$(git ls-files | grep -E '\.env(\.[a-z]+)?$' | grep -v '\.example$' || true)
+if [[ -n "$env_files" ]]; then
+  red "FAIL"
+  echo "$env_files"
+  found=$((found + 1))
+else
+  green "ok"
+fi
+
+echo
+if [[ "$found" -eq 0 ]]; then
+  if [[ "$SCAN_HISTORY" -eq 1 ]]; then
+    green "✓ No secrets detected (scope: full git history)."
+  else
+    green "✓ No secrets detected (scope: tracked files in HEAD)."
+  fi
+  exit 0
+else
+  red "✗ $found pattern(s) flagged. Review above."
+  echo
+  echo "Next steps:"
+  echo "  1. If false positive: tighten the pattern or add to exclusion."
+  echo "  2. If real leak:"
+  echo "     a) Rotate the secret immediately at the source (42 intra, AWS, etc)"
+  echo "     b) Purge from history: git-filter-repo or BFG (see GitHub docs)"
+  echo "     c) Force-push (risky — coordinate with team)"
+  exit 1
+fi

--- a/specs/001-library-management/tasks.md
+++ b/specs/001-library-management/tasks.md
@@ -510,7 +510,7 @@
 - [ ] T245 Add error message translations (Korean)
 - [ ] T246 Implement app version checking
 - [X] T247 Add accessibility features (screen reader support) — 1차 audit: `OverdueIndicator` 3 상태 + `_StatusChip` (loan history) + `BookCoverImage` placeholder. 확장 후속 가능.
-- [ ] T248 Security audit - check for exposed secrets
+- [X] T248 Security audit - check for exposed secrets — `scripts/audit-secrets.sh` (AWS / OpenAI / JWT_SECRET 리터럴 / 42 OAuth 실 ID / Bearer JWT / private key / .env 파일 7가지 패턴). 현재 HEAD clean. 운영 정기 점검에 등록 (deployment.md §6).
 - [ ] T249 Review and optimize Docker container sizes
 - [ ] T250 Add Docker health checks for all services
 - [ ] T251 Test hot reload functionality in Docker environment


### PR DESCRIPTION
Closes #199

## Summary

T248 — 노출된 시크릿 audit + 운영 정기 점검 절차 등록.

## 변경

### `scripts/audit-secrets.sh`
7가지 패턴 검사:
1. AWS access key (`AKIA...`)
2. OpenAI / `sk-` prefix key
3. `JWT_SECRET` 리터럴 (placeholder 제외)
4. 42 OAuth 실 ID (`u/s-s4t2ud-` + 40+ hex)
5. Bearer JWT 형태 (3-segment base64)
6. Private key 블록 (`-----BEGIN ... PRIVATE KEY-----`)
7. 커밋된 `.env` 파일 (`.env.example` 제외)

False positive 최소화: `placeholder|test|example|change-me|your-secret|unused|ci-only` 제외.

옵션:
- 기본: HEAD tracked files (즉시)
- `--history`: 전체 git 히스토리 (느림, 분기별 권장)

**현재 HEAD clean** — 모든 7 패턴 ok.

### `docs/guides/deployment.md` §6
"운영 중 정기 점검" 체크리스트에 **월 1회 시크릿 audit** 추가.

## 효과

- 신규 PR이 실수로 시크릿 커밋하지 않았는지 1초 검증
- 릴리스 직전 수동 게이트
- `--history` 옵션으로 과거 누출 사후 감지

## Test plan

- [x] `./scripts/audit-secrets.sh` 실행 → 7/7 패턴 ok
- [x] 출력 포매팅 (scope 라벨) 정확
- [x] CI green (코드 변경 없음, 스크립트만)

🤖 Generated with [Claude Code](https://claude.com/claude-code)