### PR TITLE
[Release #201] v0.6.8 패치 — Accessibility 1차 + secrets audit

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "42lib-backend",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "42 Learning Space Library Management System - Backend API",
   "main": "src/server.ts",
   "scripts": {

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -170,6 +170,7 @@ sudo systemctl status certbot.timer
 - [ ] 디스크 사용량 (DB volume + 로그) — `df -h`
 - [ ] JWT_SECRET 회전 정책 (운영 ADR에 따라)
 - [ ] 컨테이너 이미지 base 보안 업데이트 (`docker compose build --no-cache --pull` 후 재배포)
+- [ ] **월 1회 시크릿 audit** — `./scripts/audit-secrets.sh` (릴리스 직전에도 실행). `--history` 플래그로 전체 git 히스토리까지 스캔 가능.
 
 ## 7. 업그레이드 절차
 

--- a/lib/features/admin_catalog/presentation/screens/loan_history_screen.dart
+++ b/lib/features/admin_catalog/presentation/screens/loan_history_screen.dart
@@ -259,13 +259,18 @@ class _StatusChip extends StatelessWidget {
           '반납',
         ),
     };
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-      decoration: BoxDecoration(
-        color: bg,
-        borderRadius: BorderRadius.circular(8),
+    // T247: 색상으로만 구분되지 않도록 Semantics에 상태명 명시.
+    return Semantics(
+      label: '대출 상태: $label',
+      excludeSemantics: true,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        decoration: BoxDecoration(
+          color: bg,
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Text(label, style: TextStyle(color: fg, fontSize: 12)),
       ),
-      child: Text(label, style: TextStyle(color: fg, fontSize: 12)),
     );
   }
 }

--- a/lib/widgets/admin/overdue_indicator.dart
+++ b/lib/widgets/admin/overdue_indicator.dart
@@ -51,25 +51,38 @@ class OverdueIndicator extends StatelessWidget {
         ),
     };
 
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-      decoration: BoxDecoration(
-        color: bg,
-        borderRadius: BorderRadius.circular(12),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(icon, size: 14, color: fg),
-          const SizedBox(width: 4),
-          Text(
-            label,
-            style: theme.textTheme.bodySmall?.copyWith(
-              color: fg,
-              fontWeight: overdue ? FontWeight.w700 : FontWeight.w500,
+    // T247: 색상 기반 신호는 screen reader에 의미가 전달되지 않으므로
+    // Semantics 레이블로 상태를 명시.
+    final semanticLabel = switch (overdue) {
+      true => '연체된 대출, $label',
+      false when daysLeft <= dueSoonThresholdDays =>
+        '반납 임박 대출, $label',
+      false => '정상 대출, $label',
+    };
+    return Semantics(
+      label: semanticLabel,
+      // 시각 노드는 그대로 보여주되 자식의 텍스트/아이콘은 합쳐서 한 번만 읽힘.
+      excludeSemantics: true,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        decoration: BoxDecoration(
+          color: bg,
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: 14, color: fg),
+            const SizedBox(width: 4),
+            Text(
+              label,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: fg,
+                fontWeight: overdue ? FontWeight.w700 : FontWeight.w500,
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/widgets/book_cover_image.dart
+++ b/lib/widgets/book_cover_image.dart
@@ -59,15 +59,19 @@ class _Placeholder extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      width: width,
-      height: height,
-      color: Colors.grey.shade200,
-      alignment: Alignment.center,
-      child: Icon(
-        Icons.book,
-        size: width != null ? width! * 0.4 : 40,
-        color: Colors.grey,
+    // T247: placeholder가 책 표지를 대신하지만 정보 가치가 없는
+    // 장식이라 screen reader에서는 제외.
+    return ExcludeSemantics(
+      child: Container(
+        width: width,
+        height: height,
+        color: Colors.grey.shade200,
+        alignment: Alignment.center,
+        child: Icon(
+          Icons.book,
+          size: width != null ? width! * 0.4 : 40,
+          color: Colors.grey,
+        ),
       ),
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lib_42_flutter
 description: 42 Learning Space Library Management System - Flutter App
 publish_to: 'none'
-version: 0.6.7+1
+version: 0.6.8+1
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/scripts/audit-secrets.sh
+++ b/scripts/audit-secrets.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# T248: Security audit — scan committed history for accidentally exposed
+# secrets. Run periodically (recommended: monthly + before each release).
+#
+# Exit codes:
+#   0  no findings
+#   1  potential secret(s) found — review the output
+#   2  invocation error (missing tool, bad cwd)
+#
+# Usage:
+#   ./scripts/audit-secrets.sh            # scan tracked files in HEAD
+#   ./scripts/audit-secrets.sh --history  # also walk full git history (slow)
+#
+# Patterns intentionally narrow — false positives waste reviewer attention
+# more than they prevent leaks. Adjust as new secret types are introduced.
+
+set -uo pipefail
+
+cd "$(dirname "$0")/.." || { echo "cannot cd to repo root" >&2; exit 2; }
+
+if ! command -v git >/dev/null 2>&1; then
+  echo "git is required" >&2
+  exit 2
+fi
+
+SCAN_HISTORY=0
+if [[ "${1:-}" == "--history" ]]; then
+  SCAN_HISTORY=1
+fi
+
+found=0
+red() { printf "\033[31m%s\033[0m\n" "$*"; }
+green() { printf "\033[32m%s\033[0m\n" "$*"; }
+
+check() {
+  local label="$1" pattern="$2" exclude="$3"
+  printf "▸ %-32s " "$label"
+
+  local cmd
+  if [[ "$SCAN_HISTORY" -eq 1 ]]; then
+    cmd="git log --all -p -G '$pattern'"
+  else
+    cmd="git grep -nE '$pattern'"
+  fi
+
+  local output
+  output=$(eval "$cmd" 2>/dev/null | grep -vE "$exclude" || true)
+  if [[ -n "$output" ]]; then
+    red "FAIL"
+    echo "$output" | head -10
+    found=$((found + 1))
+  else
+    green "ok"
+  fi
+}
+
+# AWS access key
+check "AWS access key" \
+  'AKIA[0-9A-Z]{16}' \
+  '^$'
+
+# OpenAI / generic api keys with sk- prefix and length
+check "OpenAI / sk- prefixed key" \
+  'sk-[a-zA-Z0-9]{30,}' \
+  '^$'
+
+# Real-looking JWT secrets (filtered for placeholder values)
+check "JWT_SECRET literal value" \
+  'JWT_SECRET\s*[:=]\s*[\"\x27][A-Za-z0-9+/]{30,}' \
+  'change-me|your-secret|test|example|unused|ci-only'
+
+# 42 OAuth client/secret IDs (real format includes hex hash 40+ chars)
+check "42 OAuth real-looking ID" \
+  '(u|s)-s4t2ud-[a-f0-9]{40,}' \
+  '^$'
+
+# Generic Bearer tokens that look like real JWTs (≥3 base64 segments)
+check "Bearer token (live JWT shape)" \
+  'Bearer\s+[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}' \
+  'test|fake|stub|example'
+
+# Private key blocks
+check "Private key blocks" \
+  '-----BEGIN [A-Z ]*PRIVATE KEY-----' \
+  '^$'
+
+# Committed .env files (anything beyond .env.example is suspicious)
+printf "▸ %-32s " "Committed .env files"
+env_files=$(git ls-files | grep -E '\.env(\.[a-z]+)?$' | grep -v '\.example$' || true)
+if [[ -n "$env_files" ]]; then
+  red "FAIL"
+  echo "$env_files"
+  found=$((found + 1))
+else
+  green "ok"
+fi
+
+echo
+if [[ "$found" -eq 0 ]]; then
+  if [[ "$SCAN_HISTORY" -eq 1 ]]; then
+    green "✓ No secrets detected (scope: full git history)."
+  else
+    green "✓ No secrets detected (scope: tracked files in HEAD)."
+  fi
+  exit 0
+else
+  red "✗ $found pattern(s) flagged. Review above."
+  echo
+  echo "Next steps:"
+  echo "  1. If false positive: tighten the pattern or add to exclusion."
+  echo "  2. If real leak:"
+  echo "     a) Rotate the secret immediately at the source (42 intra, AWS, etc)"
+  echo "     b) Purge from history: git-filter-repo or BFG (see GitHub docs)"
+  echo "     c) Force-push (risky — coordinate with team)"
+  exit 1
+fi

--- a/specs/001-library-management/tasks.md
+++ b/specs/001-library-management/tasks.md
@@ -509,7 +509,7 @@
 - [ ] T244 Add loading animations with 42 brand identity
 - [ ] T245 Add error message translations (Korean)
 - [ ] T246 Implement app version checking
-- [ ] T247 Add accessibility features (screen reader support)
+- [X] T247 Add accessibility features (screen reader support) — 1차 audit: `OverdueIndicator` 3 상태 + `_StatusChip` (loan history) + `BookCoverImage` placeholder. 확장 후속 가능.
 - [ ] T248 Security audit - check for exposed secrets
 - [ ] T249 Review and optimize Docker container sizes
 - [ ] T250 Add Docker health checks for all services

--- a/specs/001-library-management/tasks.md
+++ b/specs/001-library-management/tasks.md
@@ -510,7 +510,7 @@
 - [ ] T245 Add error message translations (Korean)
 - [ ] T246 Implement app version checking
 - [X] T247 Add accessibility features (screen reader support) — 1차 audit: `OverdueIndicator` 3 상태 + `_StatusChip` (loan history) + `BookCoverImage` placeholder. 확장 후속 가능.
-- [ ] T248 Security audit - check for exposed secrets
+- [X] T248 Security audit - check for exposed secrets — `scripts/audit-secrets.sh` (AWS / OpenAI / JWT_SECRET 리터럴 / 42 OAuth 실 ID / Bearer JWT / private key / .env 파일 7가지 패턴). 현재 HEAD clean. 운영 정기 점검에 등록 (deployment.md §6).
 - [ ] T249 Review and optimize Docker container sizes
 - [ ] T250 Add Docker health checks for all services
 - [ ] T251 Test hot reload functionality in Docker environment

--- a/test/widget_test/widgets/admin/overdue_indicator_test.dart
+++ b/test/widget_test/widgets/admin/overdue_indicator_test.dart
@@ -80,6 +80,31 @@ void main() {
       expect(find.byIcon(Icons.schedule), findsOneWidget);
     });
 
+    // T247 — Screen reader semantics
+    testWidgets('overdue → "연체된 대출" semantic label', (tester) async {
+      await _pump(
+        tester,
+        OverdueIndicator(dueDate: DateTime(2024, 6, 10), now: now),
+      );
+      expect(find.bySemanticsLabel(RegExp('^연체된 대출')), findsOneWidget);
+    });
+
+    testWidgets('due-soon → "반납 임박 대출" semantic label', (tester) async {
+      await _pump(
+        tester,
+        OverdueIndicator(dueDate: DateTime(2024, 6, 17), now: now),
+      );
+      expect(find.bySemanticsLabel(RegExp('^반납 임박 대출')), findsOneWidget);
+    });
+
+    testWidgets('on-track → "정상 대출" semantic label', (tester) async {
+      await _pump(
+        tester,
+        OverdueIndicator(dueDate: DateTime(2024, 6, 25), now: now),
+      );
+      expect(find.bySemanticsLabel(RegExp('^정상 대출')), findsOneWidget);
+    });
+
     testWidgets('overdue label is bold; on-track label is medium-weight',
         (tester) async {
       // overdue


### PR DESCRIPTION
Closes #201

## 범위

**v0.6.8 패치** — Phase 13 polish 묶음.

### 머지된 PR
- #198 (T247) Accessibility 1차 — `OverdueIndicator` / `_StatusChip` / `BookCoverImage` Semantics
- #200 (T248) Secrets audit — `scripts/audit-secrets.sh` + 정기 점검 등록

## 효과

- **WCAG 1.4.1 부분 준수** — 색상에 의존하던 정보가 음성에서도 동일 전달
- **시크릿 누출 사후 감지** — 7가지 패턴 1초 검증
- 운영 정기 점검 체크리스트에 시크릿 audit 추가 (월 1회)

## Test plan

- [x] backend + Flutter 테스트 모두 green
- [x] CI 모든 단계 통과 (codecov patch/project 포함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)